### PR TITLE
Ungradlefy most of the codebase

### DIFF
--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/AbstractDomainObjectContainer.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/AbstractDomainObjectContainer.java
@@ -4,23 +4,21 @@ import dev.nokee.platform.base.KnownDomainObject;
 import groovy.lang.GroovyObjectSupport;
 import lombok.AccessLevel;
 import lombok.Getter;
-import org.codehaus.groovy.runtime.wrappers.GroovyObjectWrapper;
 import org.gradle.api.Action;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.specs.Spec;
 
-import javax.inject.Inject;
-
-public abstract class AbstractDomainObjectContainer<T> extends GroovyObjectSupport {
+public class AbstractDomainObjectContainer<T> extends GroovyObjectSupport {
 	private final Class<T> publicType;
 
-	protected AbstractDomainObjectContainer(Class<T> publicType, DomainObjectStore store) {
+	protected AbstractDomainObjectContainer(Class<T> publicType, DomainObjectStore store, ObjectFactory objects) {
 		this.publicType = publicType;
 		this.store = store;
+		this.objects = objects;
 	}
 
-	@Inject
-	protected abstract ObjectFactory getObjects();
+	@Getter(AccessLevel.PROTECTED)
+	private final ObjectFactory objects;
 
 	@Getter(AccessLevel.PROTECTED)
 	private final DomainObjectStore store;

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/AbstractView.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/AbstractView.java
@@ -2,18 +2,23 @@ package dev.nokee.platform.base.internal;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.gradle.api.Transformer;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.specs.Spec;
 
-import javax.inject.Inject;
 import java.util.List;
 import java.util.Set;
 
 public abstract class AbstractView<T> {
-	@Inject
-	protected abstract ProviderFactory getProviders();
+	@Getter(AccessLevel.PROTECTED)
+	private final ProviderFactory providers;
+
+	protected AbstractView(ProviderFactory providers) {
+		this.providers = providers;
+	}
 
 	protected abstract Set<? extends T> get();
 

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/BaseVariant.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/BaseVariant.java
@@ -1,30 +1,32 @@
 package dev.nokee.platform.base.internal;
 
-import dev.nokee.utils.Cast;
 import dev.nokee.platform.base.Binary;
 import dev.nokee.platform.base.BinaryView;
+import dev.nokee.utils.Cast;
+import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.Named;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 
-import javax.inject.Inject;
-
 // CAUTION: Never rely on the name of the variant, it isn't exposed on the public type!
-@RequiredArgsConstructor
-public abstract class BaseVariant implements Named {
-	@Getter private final DomainObjectSet<Binary> binaryCollection = getObjects().domainObjectSet(Binary.class);
+public class BaseVariant implements Named {
+	@Getter private final DomainObjectSet<Binary> binaryCollection;
 	@Getter private final String name;
 	@Getter private final BuildVariantInternal buildVariant;
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
+	@Getter private final Property<Binary> developmentBinary;
 
-	@Inject
-	protected abstract ObjectFactory getObjects();
+	protected BaseVariant(String name, BuildVariantInternal buildVariant, ObjectFactory objects) {
+		this.name = name;
+		this.buildVariant = buildVariant;
+		this.objects = objects;
+		this.binaryCollection = objects.domainObjectSet(Binary.class);
+		this.developmentBinary = objects.property(Binary.class);
+	}
 
 	public BinaryView<Binary> getBinaries() {
 		return Cast.uncheckedCastBecauseOfTypeErasure(getObjects().newInstance(DefaultBinaryView.class, Binary.class, binaryCollection, Realizable.IDENTITY));
 	}
-
-	public abstract Property<Binary> getDevelopmentBinary();
 }

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/DefaultBinaryView.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/DefaultBinaryView.java
@@ -5,24 +5,30 @@ import com.google.common.collect.ImmutableSet;
 import dev.nokee.utils.Cast;
 import dev.nokee.platform.base.Binary;
 import dev.nokee.platform.base.BinaryView;
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.gradle.api.Action;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.specs.Spec;
 
 import javax.inject.Inject;
 import java.util.Set;
 
-public abstract class DefaultBinaryView<T extends Binary> extends AbstractView<T> implements BinaryView<T> {
+public class DefaultBinaryView<T extends Binary> extends AbstractView<T> implements BinaryView<T> {
 	private final Class<T> elementType;
 	private final DomainObjectSet<T> delegate;
 	private final Realizable variants;
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
 
 	@Inject
-	public DefaultBinaryView(Class<T> elementType, DomainObjectSet<T> delegate, Realizable variants) {
+	public DefaultBinaryView(Class<T> elementType, DomainObjectSet<T> delegate, Realizable variants, ProviderFactory providers, ObjectFactory objects) {
+		super(providers);
 		this.elementType = elementType;
 		this.delegate = delegate;
 		this.variants = variants;
+		this.objects = objects;
 	}
 
 	@Override
@@ -63,9 +69,6 @@ public abstract class DefaultBinaryView<T extends Binary> extends AbstractView<T
 		variants.realize();
 		return ImmutableSet.copyOf(delegate);
 	}
-
-	@Inject
-	protected abstract ObjectFactory getObjects();
 
 	@Override
 	protected String getDisplayName() {

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/DefaultDomainObjectStore.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/DefaultDomainObjectStore.java
@@ -6,6 +6,8 @@ import dev.nokee.platform.base.DomainObjectElement;
 import dev.nokee.platform.base.DomainObjectProvider;
 import dev.nokee.platform.base.KnownDomainObject;
 import dev.nokee.utils.Cast;
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.model.ObjectFactory;
@@ -17,14 +19,17 @@ import javax.inject.Inject;
 import java.util.Collection;
 import java.util.List;
 
-public abstract class DefaultDomainObjectStore implements DomainObjectStore {
-	private final DomainObjectCollection<Object> store = new DefaultDomainObjectCollection<>(Object.class, getObjects(), getProviders());
+public class DefaultDomainObjectStore implements DomainObjectStore {
+	private final DomainObjectCollection<Object> store;
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
+	@Getter(AccessLevel.PROTECTED) private final ProviderFactory providers;
 
 	@Inject
-	protected abstract ObjectFactory getObjects();
-
-	@Inject
-	protected abstract ProviderFactory getProviders();
+	public DefaultDomainObjectStore(ObjectFactory objects, ProviderFactory providers) {
+		this.objects = objects;
+		this.providers = providers;
+		this.store = new DefaultDomainObjectCollection<>(Object.class, objects, providers);
+	}
 
 	@Override
 	public <U> DomainObjectProvider<U> register(DomainObjectFactory<U> factory) {

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/DefaultTaskView.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/DefaultTaskView.java
@@ -1,14 +1,16 @@
 package dev.nokee.platform.base.internal;
 
 import com.google.common.base.Preconditions;
-import dev.nokee.utils.Cast;
 import dev.nokee.platform.base.TaskView;
-import dev.nokee.platform.base.View;
+import dev.nokee.utils.Cast;
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.gradle.api.Action;
 import org.gradle.api.Task;
 import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.api.tasks.TaskProvider;
@@ -20,20 +22,20 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public abstract class DefaultTaskView<T extends Task> extends AbstractView<T> implements TaskView<T>, TaskDependency {
+public class DefaultTaskView<T extends Task> extends AbstractView<T> implements TaskView<T>, TaskDependency {
 	private final Class<T> elementType;
 	private final List<TaskProvider<? extends T>> delegate;
 	private final Realizable realizeTrigger;
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
 
 	@Inject
-	public DefaultTaskView(Class<T> elementType, List<TaskProvider<? extends T>> delegate, Realizable realizeTrigger) {
+	public DefaultTaskView(Class<T> elementType, List<TaskProvider<? extends T>> delegate, Realizable realizeTrigger, ProviderFactory providers, ObjectFactory objects) {
+		super(providers);
 		this.elementType = elementType;
 		this.delegate = delegate;
 		this.realizeTrigger = realizeTrigger;
+		this.objects = objects;
 	}
-
-	@Inject
-	protected abstract ObjectFactory getObjects();
 
 	@Override
 	public void configureEach(Action<? super T> action) {

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantAwareBinaryView.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantAwareBinaryView.java
@@ -4,18 +4,20 @@ import dev.nokee.platform.base.Binary;
 import dev.nokee.platform.base.BinaryView;
 import dev.nokee.platform.base.View;
 import dev.nokee.utils.Cast;
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.gradle.api.model.ObjectFactory;
 
 import javax.inject.Inject;
 
-public abstract class VariantAwareBinaryView<T extends Binary> extends BaseView<T> implements BinaryView<T> {
-	@Inject
-	public VariantAwareBinaryView(View<T> delegate) {
-		super(delegate);
-	}
+public class VariantAwareBinaryView<T extends Binary> extends BaseView<T> implements BinaryView<T> {
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
 
 	@Inject
-	protected abstract ObjectFactory getObjects();
+	public VariantAwareBinaryView(View<T> delegate, ObjectFactory objects) {
+		super(delegate);
+		this.objects = objects;
+	}
 
 	@Override
 	public <S extends T> BinaryView<S> withType(Class<S> type) {

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantCollection.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantCollection.java
@@ -7,6 +7,8 @@ import dev.nokee.platform.base.DomainObjectElement;
 import dev.nokee.platform.base.Variant;
 import dev.nokee.platform.base.VariantView;
 import dev.nokee.utils.Cast;
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.gradle.api.Action;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
@@ -17,21 +19,17 @@ import javax.inject.Inject;
 import java.util.List;
 import java.util.Set;
 
-public abstract class VariantCollection<T extends Variant> implements Realizable {
+public class VariantCollection<T extends Variant> implements Realizable {
 	private final DomainObjectCollection<T> delegate;
 	private final Class<T> elementType;
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
 	private boolean disallowChanges = false;
-
-	@Inject
-	protected abstract ObjectFactory getObjects();
-
-	@Inject
-	protected abstract ProviderFactory getProviders();
 
 	// TODO: Make the distinction between public and implementation type
 	@Inject
-	public VariantCollection(Class<T> elementType, ProviderFactory providers) {
+	public VariantCollection(Class<T> elementType, ProviderFactory providers, ObjectFactory objects) {
 		this.elementType = elementType;
+		this.objects = objects;
 		delegate = new DefaultDomainObjectCollection<>(elementType, getObjects(), providers);
 	}
 

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/DefaultComponentDependencies.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/DefaultComponentDependencies.java
@@ -2,6 +2,7 @@ package dev.nokee.platform.base.internal.dependencies;
 
 import dev.nokee.platform.base.DependencyBucket;
 import groovy.lang.Closure;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.val;
 import org.gradle.api.Action;
@@ -9,6 +10,7 @@ import org.gradle.api.DomainObjectSet;
 import org.gradle.api.UnknownDomainObjectException;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.internal.metaobject.*;
 import org.gradle.util.ConfigureUtil;
 
@@ -19,20 +21,20 @@ import java.util.Map;
 import java.util.Optional;
 
 // DO NOT EXTEND THIS CLASS, extends BaseComponentDependencies
-public abstract class DefaultComponentDependencies implements ComponentDependenciesInternal, MethodMixIn, PropertyMixIn {
+public class DefaultComponentDependencies implements ComponentDependenciesInternal, MethodMixIn, PropertyMixIn {
 	private final Map<String, DependencyBucket> bucketIndex = new HashMap<>();
 	private final ContainerElementsDynamicObject elementsDynamicObject = new ContainerElementsDynamicObject();
 	@Getter private final String componentDisplayName;
 	private final DependencyBucketFactory factory;
+	@Getter(AccessLevel.PROTECTED) private final DomainObjectSet<DependencyBucket> buckets;
 
 	@Inject
 	@Deprecated // use ObjectFactory
-	public DefaultComponentDependencies(String componentDisplayName, DependencyBucketFactory factory) {
+	public DefaultComponentDependencies(String componentDisplayName, DependencyBucketFactory factory, ObjectFactory objects) {
 		this.componentDisplayName = componentDisplayName;
 		this.factory = factory;
+		this.buckets = objects.domainObjectSet(DependencyBucket.class);
 	}
-
-	protected abstract DomainObjectSet<DependencyBucket> getBuckets();
 
 	@Override
 	public DependencyBucket create(String name) {

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/plugins/ProjectStorePlugin.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/plugins/ProjectStorePlugin.java
@@ -2,6 +2,8 @@ package dev.nokee.platform.base.internal.plugins;
 
 import dev.nokee.platform.base.internal.DefaultDomainObjectStore;
 import dev.nokee.platform.base.internal.DomainObjectStore;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.val;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -9,7 +11,14 @@ import org.gradle.api.model.ObjectFactory;
 
 import javax.inject.Inject;
 
-public abstract class ProjectStorePlugin implements Plugin<Project> {
+public class ProjectStorePlugin implements Plugin<Project> {
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
+
+	@Inject
+	public ProjectStorePlugin(ObjectFactory objects) {
+		this.objects = objects;
+	}
+
 	@Override
 	public void apply(Project project) {
 		val store = getObjects().newInstance(DefaultDomainObjectStore.class);
@@ -17,7 +26,4 @@ public abstract class ProjectStorePlugin implements Plugin<Project> {
 
 		project.afterEvaluate(proj -> store.disallowChanges());
 	}
-
-	@Inject
-	protected abstract ObjectFactory getObjects();
 }

--- a/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/VariantAwareBinaryViewTest.groovy
+++ b/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/VariantAwareBinaryViewTest.groovy
@@ -4,6 +4,7 @@ import dev.nokee.platform.base.Binary
 import dev.nokee.platform.base.Variant
 import dev.nokee.platform.base.VariantView
 import groovy.transform.ToString
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Provider
 import spock.lang.Ignore
 import spock.lang.Subject
@@ -66,10 +67,10 @@ class VariantAwareBinaryViewTest extends AbstractViewTest<Binary> {
 		variant.binaryCollection.addLater(v)
 	}
 
-	static abstract class TestVariant extends BaseVariant implements Variant {
+	static class TestVariant extends BaseVariant implements Variant {
 		@Inject
-		TestVariant() {
-			super('test', DefaultBuildVariant.of())
+		TestVariant(ObjectFactory objects) {
+            super('test', DefaultBuildVariant.of(), objects)
 		}
 	}
 

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/BaseIosExtension.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/BaseIosExtension.java
@@ -9,16 +9,20 @@ import dev.nokee.platform.nativebase.internal.BaseNativeComponent;
 import dev.nokee.platform.nativebase.internal.DefaultBinaryLinkage;
 import dev.nokee.runtime.nativebase.internal.DefaultMachineArchitecture;
 import dev.nokee.runtime.nativebase.internal.DefaultOperatingSystemFamily;
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ProviderFactory;
 
-import javax.inject.Inject;
-
-public abstract class BaseIosExtension<T extends BaseNativeComponent<?>> {
+public class BaseIosExtension<T extends BaseNativeComponent<?>> {
 	private final T component;
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
+	@Getter(AccessLevel.PROTECTED) private final ProviderFactory providers;
 
-	public BaseIosExtension(T component) {
+	public BaseIosExtension(T component, ObjectFactory objects, ProviderFactory providers) {
 		this.component = component;
+		this.objects = objects;
+		this.providers = providers;
 
 		component.getBuildVariants().convention(getProviders().provider(this::createBuildVariants));
 		component.getBuildVariants().finalizeValueOnRead();
@@ -26,12 +30,6 @@ public abstract class BaseIosExtension<T extends BaseNativeComponent<?>> {
 
 		component.getDimensions().disallowChanges(); // Let's disallow changing them for now.
 	}
-
-	@Inject
-	protected abstract ObjectFactory getObjects();
-
-	@Inject
-	protected abstract ProviderFactory getProviders();
 
 	protected Iterable<BuildVariantInternal> createBuildVariants() {
 		return ImmutableList.of(DefaultBuildVariant.of(DefaultOperatingSystemFamily.forName("ios"), DefaultMachineArchitecture.X86_64, DefaultBinaryLinkage.EXECUTABLE));

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationVariant.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationVariant.java
@@ -10,17 +10,20 @@ import dev.nokee.platform.nativebase.internal.BaseNativeVariant;
 import dev.nokee.platform.nativebase.internal.dependencies.DefaultNativeComponentDependencies;
 import dev.nokee.platform.nativebase.internal.dependencies.VariantComponentDependencies;
 import org.gradle.api.Action;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.tasks.TaskContainer;
 
 import javax.inject.Inject;
 import java.util.List;
 
-public abstract class DefaultIosApplicationVariant extends BaseNativeVariant implements IosApplication {
+public class DefaultIosApplicationVariant extends BaseNativeVariant implements IosApplication {
 	private final DefaultNativeComponentDependencies dependencies;
 
 	@Inject
-	public DefaultIosApplicationVariant(String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<DefaultNativeComponentDependencies> dependencies) {
-		super(name, names, buildVariant);
+	public DefaultIosApplicationVariant(String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<DefaultNativeComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
+		super(name, names, buildVariant, objects, tasks, providers);
 		this.dependencies = dependencies.getDependencies();
 	}
 

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultObjectiveCIosApplicationExtension.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultObjectiveCIosApplicationExtension.java
@@ -8,13 +8,15 @@ import dev.nokee.platform.ios.ObjectiveCIosApplicationExtension;
 import dev.nokee.platform.nativebase.NativeComponentDependencies;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
 
 import javax.inject.Inject;
 
-public abstract class DefaultObjectiveCIosApplicationExtension extends BaseIosExtension<DefaultIosApplicationComponent> implements ObjectiveCIosApplicationExtension {
+public class DefaultObjectiveCIosApplicationExtension extends BaseIosExtension<DefaultIosApplicationComponent> implements ObjectiveCIosApplicationExtension {
 	@Inject
-	public DefaultObjectiveCIosApplicationExtension(DefaultIosApplicationComponent component) {
-		super(component);
+	public DefaultObjectiveCIosApplicationExtension(DefaultIosApplicationComponent component, ObjectFactory objects, ProviderFactory providers) {
+		super(component, objects, providers);
 		getComponent().getSourceCollection().add(getObjects().newInstance(ObjectiveCSourceSet.class, "objc").srcDir("src/main/objc"));
 		getComponent().getSourceCollection().add(getObjects().newInstance(CHeaderSet.class, "headers").srcDir("src/main/headers"));
 	}

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultSwiftIosApplicationExtension.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultSwiftIosApplicationExtension.java
@@ -1,23 +1,21 @@
 package dev.nokee.platform.ios.internal;
 
-import dev.nokee.language.c.internal.CHeaderSet;
-import dev.nokee.language.objectivec.internal.ObjectiveCSourceSet;
 import dev.nokee.language.swift.internal.SwiftSourceSet;
 import dev.nokee.platform.base.VariantView;
-import dev.nokee.platform.base.internal.GroupId;
-import dev.nokee.platform.base.internal.NamingScheme;
 import dev.nokee.platform.ios.IosApplication;
 import dev.nokee.platform.ios.SwiftIosApplicationExtension;
 import dev.nokee.platform.nativebase.NativeComponentDependencies;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
 
 import javax.inject.Inject;
 
-public abstract class DefaultSwiftIosApplicationExtension extends BaseIosExtension<DefaultIosApplicationComponent> implements SwiftIosApplicationExtension {
+public class DefaultSwiftIosApplicationExtension extends BaseIosExtension<DefaultIosApplicationComponent> implements SwiftIosApplicationExtension {
 	@Inject
-	public DefaultSwiftIosApplicationExtension(DefaultIosApplicationComponent component) {
-		super(component);
+	public DefaultSwiftIosApplicationExtension(DefaultIosApplicationComponent component, ObjectFactory objects, ProviderFactory providers) {
+		super(component, objects, providers);
 		getComponent().getSourceCollection().add(getObjects().newInstance(SwiftSourceSet.class, "swift").srcDir("src/main/swift"));
 	}
 

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/IosApplicationBundleInternal.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/IosApplicationBundleInternal.java
@@ -7,6 +7,8 @@ import dev.nokee.platform.base.TaskView;
 import dev.nokee.platform.ios.tasks.internal.CreateIosApplicationBundleTask;
 import dev.nokee.platform.ios.tasks.internal.SignIosApplicationBundleTask;
 import dev.nokee.platform.nativebase.NativeBinary;
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.gradle.api.Buildable;
 import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.provider.Provider;
@@ -19,10 +21,13 @@ import javax.inject.Inject;
 // TODO: Not sure about implementing NativeBinary...
 //  BaseNativeVariant#getDevelopmentBinary() assume a NativeBinary...
 //  There should probably be something high level in Variant or BaseNativeVariant shouldn't be used for iOS variant.
-public abstract class IosApplicationBundleInternal implements Binary, Buildable {
+public class IosApplicationBundleInternal implements Binary, Buildable {
+	@Getter(AccessLevel.PROTECTED) private final TaskContainer tasks;
 
 	@Inject
-	protected abstract TaskContainer getTasks();
+	public IosApplicationBundleInternal(TaskContainer tasks) {
+		this.tasks = tasks;
+	}
 
 	public TaskProvider<CreateIosApplicationBundleTask> getBundleTask() {
 		return getTasks().named("createApplicationBundle", CreateIosApplicationBundleTask.class);

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/SignedIosApplicationBundleInternal.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/SignedIosApplicationBundleInternal.java
@@ -3,6 +3,8 @@ package dev.nokee.platform.ios.internal;
 import com.google.common.collect.ImmutableSet;
 import dev.nokee.platform.base.Binary;
 import dev.nokee.platform.ios.tasks.internal.SignIosApplicationBundleTask;
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.gradle.api.Buildable;
 import org.gradle.api.Task;
 import org.gradle.api.file.FileSystemLocation;
@@ -16,16 +18,15 @@ import javax.inject.Inject;
 // TODO: Not sure about implementing NativeBinary...
 //  BaseNativeVariant#getDevelopmentBinary() assume a NativeBinary...
 //  There should probably be something high level in Variant or BaseNativeVariant shouldn't be used for iOS variant.
-public abstract class SignedIosApplicationBundleInternal implements Binary, Buildable {
+public class SignedIosApplicationBundleInternal implements Binary, Buildable {
 	private final TaskProvider<SignIosApplicationBundleTask> bundleTask;
+	@Getter(AccessLevel.PROTECTED) private final TaskContainer tasks;
 
 	@Inject
-	public SignedIosApplicationBundleInternal(TaskProvider<SignIosApplicationBundleTask> bundleTask) {
+	public SignedIosApplicationBundleInternal(TaskProvider<SignIosApplicationBundleTask> bundleTask, TaskContainer tasks) {
 		this.bundleTask = bundleTask;
+		this.tasks = tasks;
 	}
-
-	@Inject
-	protected abstract TaskContainer getTasks();
 
 	public TaskProvider<? extends Task> getBundleTask() {
 		return bundleTask;

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/ObjectiveCIosApplicationPlugin.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/ObjectiveCIosApplicationPlugin.java
@@ -10,6 +10,8 @@ import dev.nokee.platform.ios.internal.DefaultObjectiveCIosApplicationExtension;
 import dev.nokee.runtime.darwin.internal.plugins.DarwinRuntimePlugin;
 import dev.nokee.runtime.nativebase.internal.DefaultMachineArchitecture;
 import dev.nokee.runtime.nativebase.internal.DefaultOperatingSystemFamily;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.val;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -30,20 +32,21 @@ import java.util.Arrays;
 import static dev.nokee.platform.ios.internal.plugins.IosApplicationRules.getSdkPath;
 import static dev.nokee.platform.nativebase.internal.NativePlatformFactory.platformNameFor;
 
-public abstract class ObjectiveCIosApplicationPlugin implements Plugin<Project> {
+public class ObjectiveCIosApplicationPlugin implements Plugin<Project> {
 	private static final String EXTENSION_NAME = "application";
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
+	@Getter(AccessLevel.PROTECTED) private final ProjectLayout layout;
+	@Getter(AccessLevel.PROTECTED) private final TaskContainer tasks;
+	@Getter(AccessLevel.PROTECTED) private final ProviderFactory providers;
 
 	@Inject
-	protected abstract ObjectFactory getObjects();
+	public ObjectiveCIosApplicationPlugin(ObjectFactory objects, ProjectLayout layout, TaskContainer tasks, ProviderFactory providers) {
 
-	@Inject
-	protected abstract ProjectLayout getLayout();
-
-	@Inject
-	protected abstract TaskContainer getTasks();
-
-	@Inject
-	protected abstract ProviderFactory getProviders();
+		this.objects = objects;
+		this.layout = layout;
+		this.tasks = tasks;
+		this.providers = providers;
+	}
 
 	@Override
 	public void apply(Project project) {

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/SwiftIosApplicationPlugin.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/SwiftIosApplicationPlugin.java
@@ -9,6 +9,8 @@ import dev.nokee.platform.ios.internal.DefaultIosApplicationComponent;
 import dev.nokee.platform.ios.internal.DefaultSwiftIosApplicationExtension;
 import dev.nokee.platform.ios.tasks.internal.CreateIosApplicationBundleTask;
 import dev.nokee.runtime.darwin.internal.plugins.DarwinRuntimePlugin;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.val;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -18,14 +20,16 @@ import org.gradle.nativeplatform.toolchain.plugins.SwiftCompilerPlugin;
 
 import javax.inject.Inject;
 
-public abstract class SwiftIosApplicationPlugin implements Plugin<Project> {
+public class SwiftIosApplicationPlugin implements Plugin<Project> {
 	private static final String EXTENSION_NAME = "application";
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
+	@Getter(AccessLevel.PROTECTED) private final TaskContainer tasks;
 
 	@Inject
-	protected abstract ObjectFactory getObjects();
-
-	@Inject
-	protected abstract TaskContainer getTasks();
+	public SwiftIosApplicationPlugin(ObjectFactory objects, TaskContainer tasks) {
+		this.objects = objects;
+		this.tasks = tasks;
+	}
 
 	@Override
 	public void apply(Project project) {

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/tasks/internal/AssetCatalogCompileTask.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/tasks/internal/AssetCatalogCompileTask.java
@@ -2,6 +2,8 @@ package dev.nokee.platform.ios.tasks.internal;
 
 import dev.nokee.core.exec.CommandLineTool;
 import dev.nokee.core.exec.GradleWorkerExecutorEngine;
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
@@ -12,22 +14,42 @@ import org.gradle.api.tasks.*;
 import javax.inject.Inject;
 import java.io.File;
 
-public abstract class AssetCatalogCompileTask extends DefaultTask {
+public class AssetCatalogCompileTask extends DefaultTask {
+	private final DirectoryProperty destinationDirectory;
+	private final RegularFileProperty source;
+	private final Property<String> identifier;
+	private final Property<CommandLineTool> assetCompilerTool;
+	@Getter(value=AccessLevel.PROTECTED, onMethod_={@Inject}) private final ObjectFactory objects;
+
 	@OutputDirectory
-	public abstract DirectoryProperty getDestinationDirectory();
+	public DirectoryProperty getDestinationDirectory() {
+		return destinationDirectory;
+	}
 
 	@SkipWhenEmpty
 	@InputDirectory
-	public abstract RegularFileProperty getSource();
+	public RegularFileProperty getSource() {
+		return source;
+	}
 
 	@Input
-	public abstract Property<String> getIdentifier();
+	public Property<String> getIdentifier() {
+		return identifier;
+	}
 
 	@Nested
-	public abstract Property<CommandLineTool> getAssetCompilerTool();
+	public Property<CommandLineTool> getAssetCompilerTool() {
+		return assetCompilerTool;
+	}
 
 	@Inject
-	protected abstract ObjectFactory getObjects();
+	public AssetCatalogCompileTask(ObjectFactory objects) {
+		this.destinationDirectory = objects.directoryProperty();
+		this.source = objects.fileProperty();
+		this.identifier = objects.property(String.class);
+		this.assetCompilerTool = objects.property(CommandLineTool.class);
+		this.objects = objects;
+	}
 
 	@TaskAction
 	private void compile() {

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/tasks/internal/ProcessPropertyListTask.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/tasks/internal/ProcessPropertyListTask.java
@@ -1,10 +1,13 @@
 package dev.nokee.platform.ios.tasks.internal;
 
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.*;
 import org.gradle.process.ExecOperations;
@@ -13,24 +16,44 @@ import javax.inject.Inject;
 import java.io.*;
 import java.nio.charset.Charset;
 
-public abstract class ProcessPropertyListTask extends DefaultTask {
+public class ProcessPropertyListTask extends DefaultTask {
+	private final ConfigurableFileCollection sources;
+	private final Property<String> module;
+	private final Property<String> identifier;
+	private final RegularFileProperty outputFile;
+	@Getter(value=AccessLevel.PROTECTED, onMethod_={@Inject}) private final ExecOperations execOperations;
+
 	@Optional
 	@SkipWhenEmpty // TODO: Test no source
 	@InputFiles
-	public abstract ConfigurableFileCollection getSources();
+	public ConfigurableFileCollection getSources() {
+		return sources;
+	}
 
 	@Input
-	public abstract Property<String> getModule();
+	public Property<String> getModule() {
+		return module;
+	}
 
 	@Input
-	public abstract Property<String> getIdentifier();
+	public Property<String> getIdentifier() {
+		return identifier;
+	}
 
 	// TODO: Find a better name
 	@OutputFile
-	public abstract RegularFileProperty getOutputFile();
+	public RegularFileProperty getOutputFile() {
+		return outputFile;
+	}
 
 	@Inject
-	protected abstract ExecOperations getExecOperations();
+	public ProcessPropertyListTask(ObjectFactory objects, ExecOperations execOperations) {
+		this.sources = objects.fileCollection();
+		this.module = objects.property(String.class);
+		this.identifier = objects.property(String.class);
+		this.outputFile = objects.fileProperty();
+		this.execOperations = execOperations;
+	}
 
 	@TaskAction
 	private void process() throws IOException {

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/tasks/internal/SignIosApplicationBundleTask.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/tasks/internal/SignIosApplicationBundleTask.java
@@ -2,6 +2,8 @@ package dev.nokee.platform.ios.tasks.internal;
 
 import dev.nokee.core.exec.CommandLineTool;
 import dev.nokee.core.exec.GradleWorkerExecutorEngine;
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.file.FileSystemOperations;
@@ -12,22 +14,37 @@ import org.gradle.api.tasks.*;
 import javax.inject.Inject;
 import java.io.File;
 
-public abstract class SignIosApplicationBundleTask extends DefaultTask {
+public class SignIosApplicationBundleTask extends DefaultTask {
+	private final Property<FileSystemLocation> unsignedApplicationBundle;
+	private final Property<FileSystemLocation> signedApplicationBundle;
+	private final Property<CommandLineTool> codeSignatureTool;
+	@Getter(value=AccessLevel.PROTECTED, onMethod_={@Inject}) private final FileSystemOperations fileOperations;
+	@Getter(value=AccessLevel.PROTECTED, onMethod_={@Inject}) private final ObjectFactory objects;
+
 	@SkipWhenEmpty
 	@InputDirectory
-	public abstract Property<FileSystemLocation> getUnsignedApplicationBundle();
+	public Property<FileSystemLocation> getUnsignedApplicationBundle() {
+		return unsignedApplicationBundle;
+	}
 
 	@OutputDirectory
-	public abstract Property<FileSystemLocation> getSignedApplicationBundle();
+	public Property<FileSystemLocation> getSignedApplicationBundle() {
+		return signedApplicationBundle;
+	}
 
 	@Nested
-	public abstract Property<CommandLineTool> getCodeSignatureTool();
+	public Property<CommandLineTool> getCodeSignatureTool() {
+		return codeSignatureTool;
+	}
 
 	@Inject
-	protected abstract FileSystemOperations getFileOperations();
-
-	@Inject
-	protected abstract ObjectFactory getObjects();
+	public SignIosApplicationBundleTask(ObjectFactory objects, FileSystemOperations fileOperations) {
+		this.unsignedApplicationBundle = objects.property(FileSystemLocation.class);
+		this.signedApplicationBundle = objects.property(FileSystemLocation.class);
+		this.codeSignatureTool = objects.property(CommandLineTool.class);
+		this.fileOperations = fileOperations;
+		this.objects = objects;
+	}
 
 	@TaskAction
 	private void sign() {

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/tasks/internal/StoryboardCompileTask.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/tasks/internal/StoryboardCompileTask.java
@@ -2,6 +2,8 @@ package dev.nokee.platform.ios.tasks.internal;
 
 import dev.nokee.core.exec.CommandLineTool;
 import dev.nokee.core.exec.GradleWorkerExecutorEngine;
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.gradle.api.DefaultTask;
@@ -22,24 +24,44 @@ import java.io.File;
 import java.io.IOException;
 
 @CacheableTask
-public abstract class StoryboardCompileTask extends DefaultTask {
+public class StoryboardCompileTask extends DefaultTask {
+	private final DirectoryProperty destinationDirectory;
+	private final Property<String> module;
+	private final ConfigurableFileCollection sources;
+	private final Property<CommandLineTool> interfaceBuilderTool;
+	@Getter(value=AccessLevel.PROTECTED, onMethod_={@Inject}) private final ObjectFactory objects;
+
 	@OutputDirectory
-	public abstract DirectoryProperty getDestinationDirectory();
+	public DirectoryProperty getDestinationDirectory() {
+		return destinationDirectory;
+	}
 
 	@Input
-	public abstract Property<String> getModule();
+	public Property<String> getModule() {
+		return module;
+	}
 
 	// TODO: This may need to be richer so we keep the context path
 	@Incremental
 	@InputFiles
 	@PathSensitive(PathSensitivity.RELATIVE)
-	public abstract ConfigurableFileCollection getSources();
+	public ConfigurableFileCollection getSources() {
+		return sources;
+	}
 
 	@Nested
-	public abstract Property<CommandLineTool> getInterfaceBuilderTool();
+	public Property<CommandLineTool> getInterfaceBuilderTool() {
+		return interfaceBuilderTool;
+	}
 
 	@Inject
-	protected abstract ObjectFactory getObjects();
+	public StoryboardCompileTask(ObjectFactory objects) {
+		this.destinationDirectory = objects.directoryProperty();
+		this.module = objects.property(String.class);
+		this.sources = objects.fileCollection();
+		this.interfaceBuilderTool = objects.property(CommandLineTool.class);
+		this.objects = objects;
+	}
 
 	@TaskAction
 	private void compile(InputChanges inputChanges) throws IOException {

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/tasks/internal/StoryboardLinkTask.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/tasks/internal/StoryboardLinkTask.java
@@ -2,6 +2,8 @@ package dev.nokee.platform.ios.tasks.internal;
 
 import dev.nokee.core.exec.CommandLineTool;
 import dev.nokee.core.exec.GradleWorkerExecutorEngine;
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
@@ -16,12 +18,22 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public abstract class StoryboardLinkTask extends DefaultTask {
+public class StoryboardLinkTask extends DefaultTask {
+	private final DirectoryProperty destinationDirectory;
+	private final Property<String> module;
+	private final ConfigurableFileCollection sources;
+	private final Property<CommandLineTool> interfaceBuilderTool;
+	@Getter(value=AccessLevel.PROTECTED, onMethod_={@Inject}) private final ObjectFactory objects;
+
 	@OutputDirectory
-	public abstract DirectoryProperty getDestinationDirectory();
+	public DirectoryProperty getDestinationDirectory() {
+		return destinationDirectory;
+	}
 
 	@Input
-	public abstract Property<String> getModule();
+	public Property<String> getModule() {
+		return module;
+	}
 
 	// TODO: This may need to be richer so we keep the context path
 	@SkipWhenEmpty
@@ -37,17 +49,24 @@ public abstract class StoryboardLinkTask extends DefaultTask {
 	}
 
 	@Internal
-	public abstract ConfigurableFileCollection getSources();
+	public ConfigurableFileCollection getSources() {
+		return sources;
+	}
 
 	@Nested
-	public abstract Property<CommandLineTool> getInterfaceBuilderTool();
-
-	public StoryboardLinkTask() {
-		dependsOn(getSources()); // TODO: Test dependencies are followed via the source
+	public Property<CommandLineTool> getInterfaceBuilderTool() {
+		return interfaceBuilderTool;
 	}
 
 	@Inject
-	protected abstract ObjectFactory getObjects();
+	public StoryboardLinkTask(ObjectFactory objects) {
+		this.destinationDirectory = objects.directoryProperty();
+		this.module = objects.property(String.class);
+		this.sources = objects.fileCollection();
+		this.interfaceBuilderTool = objects.property(CommandLineTool.class);
+		this.objects = objects;
+		dependsOn(getSources()); // TODO: Test dependencies are followed via the source
+	}
 
 	@TaskAction
 	private void doLink() {

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/DefaultJniJarBinary.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/DefaultJniJarBinary.java
@@ -6,7 +6,7 @@ import org.gradle.jvm.tasks.Jar;
 
 import javax.inject.Inject;
 
-public abstract class DefaultJniJarBinary extends AbstractJarBinary implements JniJarBinary {
+public class DefaultJniJarBinary extends AbstractJarBinary implements JniJarBinary {
 	@Inject
 	public DefaultJniJarBinary(TaskProvider<Jar> jarTask) {
 		super(jarTask);

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/DefaultJvmJarBinary.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/DefaultJvmJarBinary.java
@@ -6,7 +6,7 @@ import org.gradle.jvm.tasks.Jar;
 
 import javax.inject.Inject;
 
-public abstract class DefaultJvmJarBinary extends AbstractJarBinary implements JvmJarBinary {
+public class DefaultJvmJarBinary extends AbstractJarBinary implements JvmJarBinary {
 	@Inject
 	public DefaultJvmJarBinary(TaskProvider<Jar> jarTask) {
 		super(jarTask);

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryComponentInternal.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryComponentInternal.java
@@ -21,12 +21,15 @@ import dev.nokee.runtime.nativebase.TargetMachine;
 import dev.nokee.runtime.nativebase.internal.DefaultMachineArchitecture;
 import dev.nokee.runtime.nativebase.internal.DefaultOperatingSystemFamily;
 import dev.nokee.runtime.nativebase.internal.DefaultTargetMachine;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.val;
 import org.gradle.api.Action;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.provider.SetProperty;
@@ -38,18 +41,26 @@ import java.util.stream.Collectors;
 
 import static dev.nokee.platform.nativebase.internal.BaseNativeComponent.one;
 
-public abstract class JniLibraryComponentInternal extends BaseComponent<JniLibraryInternal> implements DependencyAwareComponent<JavaNativeInterfaceLibraryComponentDependencies>, BinaryAwareComponent {
+public class JniLibraryComponentInternal extends BaseComponent<JniLibraryInternal> implements DependencyAwareComponent<JavaNativeInterfaceLibraryComponentDependencies>, BinaryAwareComponent {
 	private final DefaultJavaNativeInterfaceLibraryComponentDependencies dependencies;
 	private final GroupId groupId;
 	private final DomainObjectSet<LanguageSourceSetInternal> sources;
+	@Getter(AccessLevel.PROTECTED) private final ConfigurationContainer configurations;
+	@Getter(AccessLevel.PROTECTED) private final DependencyHandler dependencyHandler;
+	@Getter(AccessLevel.PROTECTED) private final ProviderFactory providers;
+	@Getter private final SetProperty<TargetMachine> targetMachines;
 
 	@Inject
-	public JniLibraryComponentInternal(NamingScheme names, GroupId groupId) {
-		super(names, JniLibraryInternal.class);
-		val dependencyContainer = getObjects().newInstance(DefaultComponentDependencies.class, names.getComponentDisplayName(), new FrameworkAwareDependencyBucketFactory(new DefaultDependencyBucketFactory(new ConfigurationFactories.Prefixing(new ConfigurationFactories.MaybeCreating(getConfigurations()), names::getConfigurationName), new DefaultDependencyFactory(getDependencyHandler()))));
-		this.dependencies = getObjects().newInstance(DefaultJavaNativeInterfaceLibraryComponentDependencies.class, dependencyContainer);
+	public JniLibraryComponentInternal(NamingScheme names, GroupId groupId, ObjectFactory objects, ConfigurationContainer configurations, DependencyHandler dependencyHandler, ProviderFactory providers) {
+		super(names, JniLibraryInternal.class, objects);
+		this.configurations = configurations;
+		this.dependencyHandler = dependencyHandler;
+		this.providers = providers;
+		val dependencyContainer = objects.newInstance(DefaultComponentDependencies.class, names.getComponentDisplayName(), new FrameworkAwareDependencyBucketFactory(new DefaultDependencyBucketFactory(new ConfigurationFactories.Prefixing(new ConfigurationFactories.MaybeCreating(getConfigurations()), names::getConfigurationName), new DefaultDependencyFactory(getDependencyHandler()))));
+		this.dependencies = objects.newInstance(DefaultJavaNativeInterfaceLibraryComponentDependencies.class, dependencyContainer);
 		this.groupId = groupId;
-		this.sources = getObjects().domainObjectSet(LanguageSourceSetInternal.class);
+		this.sources = objects.domainObjectSet(LanguageSourceSetInternal.class);
+		this.targetMachines = objects.setProperty(TargetMachine.class);
 
 		getDimensions().convention(ImmutableSet.of(DefaultOperatingSystemFamily.DIMENSION_TYPE, DefaultMachineArchitecture.DIMENSION_TYPE, BaseTargetBuildType.DIMENSION_TYPE));
 		getDimensions().disallowChanges(); // Let's disallow changing them for now.
@@ -61,15 +72,6 @@ public abstract class JniLibraryComponentInternal extends BaseComponent<JniLibra
 		getDevelopmentVariant().convention(getDefaultVariant());
 		getDevelopmentVariant().disallowChanges();
 	}
-
-	@Inject
-	protected abstract ConfigurationContainer getConfigurations();
-
-	@Inject
-	protected abstract DependencyHandler getDependencyHandler();
-
-	@Inject
-	protected abstract ProviderFactory getProviders();
 
 	@Override
 	public DefaultJavaNativeInterfaceLibraryComponentDependencies getDependencies() {
@@ -127,6 +129,4 @@ public abstract class JniLibraryComponentInternal extends BaseComponent<JniLibra
 	public DomainObjectSet<LanguageSourceSetInternal> getSources() {
 		return sources;
 	}
-
-	public abstract SetProperty<TargetMachine> getTargetMachines();
 }

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryExtensionInternal.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryExtensionInternal.java
@@ -15,6 +15,7 @@ import dev.nokee.platform.nativebase.TargetMachineFactory;
 import dev.nokee.platform.nativebase.internal.DefaultTargetMachineFactory;
 import dev.nokee.runtime.base.internal.DimensionType;
 import dev.nokee.runtime.nativebase.TargetMachine;
+import lombok.AccessLevel;
 import lombok.Getter;
 import org.gradle.api.Action;
 import org.gradle.api.DomainObjectSet;
@@ -26,22 +27,19 @@ import org.gradle.api.provider.SetProperty;
 
 import javax.inject.Inject;
 
-public abstract class JniLibraryExtensionInternal implements JniLibraryExtension {
+public class JniLibraryExtensionInternal implements JniLibraryExtension {
 	@Getter private final JniLibraryComponentInternal component;
+	@Getter(AccessLevel.PROTECTED) private final ConfigurationContainer configurations;
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
+	@Getter(AccessLevel.PROTECTED) private final ProviderFactory providers;
 
 	@Inject
-	public JniLibraryExtensionInternal(GroupId groupId, NamingScheme names) {
-		this.component = getObjects().newInstance(JniLibraryComponentInternal.class, names, groupId);
+	public JniLibraryExtensionInternal(GroupId groupId, NamingScheme names, ConfigurationContainer configurations, ObjectFactory objects, ProviderFactory providers) {
+		this.configurations = configurations;
+		this.objects = objects;
+		this.providers = providers;
+		this.component = objects.newInstance(JniLibraryComponentInternal.class, names, groupId);
 	}
-
-	@Inject
-	protected abstract ConfigurationContainer getConfigurations();
-
-	@Inject
-	protected abstract ObjectFactory getObjects();
-
-	@Inject
-	protected abstract ProviderFactory getProviders();
 
 	//region Variant-awareness
 	public VariantCollection<JniLibraryInternal> getVariantCollection() {

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/DefaultCApplicationExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/DefaultCApplicationExtension.java
@@ -8,15 +8,32 @@ import dev.nokee.platform.nativebase.NativeApplication;
 import dev.nokee.platform.nativebase.NativeApplicationComponentDependencies;
 import dev.nokee.platform.nativebase.internal.BaseNativeExtension;
 import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
+import dev.nokee.runtime.nativebase.TargetBuildType;
+import dev.nokee.runtime.nativebase.TargetMachine;
+import lombok.Getter;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.provider.SetProperty;
 
 import javax.inject.Inject;
 
-public abstract class DefaultCApplicationExtension extends BaseNativeExtension<DefaultNativeApplicationComponent> implements CApplicationExtension {
+public class DefaultCApplicationExtension extends BaseNativeExtension<DefaultNativeApplicationComponent> implements CApplicationExtension {
+	@Getter private final ConfigurableFileCollection sources;
+	@Getter private final ConfigurableFileCollection privateHeaders;
+	@Getter private final SetProperty<TargetMachine> targetMachines;
+	@Getter private final SetProperty<TargetBuildType> targetBuildTypes;
+
 	@Inject
-	public DefaultCApplicationExtension(DefaultNativeApplicationComponent component) {
-		super(component);
+	public DefaultCApplicationExtension(DefaultNativeApplicationComponent component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
+		super(component, objects, providers, layout);
+		this.sources = objects.fileCollection();
+		this.privateHeaders = objects.fileCollection();
+		this.targetMachines = objects.setProperty(TargetMachine.class);
+		this.targetBuildTypes = objects.setProperty(TargetBuildType.class);
 		getComponent().getSourceCollection().add(getObjects().newInstance(CSourceSet.class, "c").from(getSources().getElements().map(toIfEmpty("src/main/c"))));
 		getComponent().getSourceCollection().add(getObjects().newInstance(CHeaderSet.class, "headers").srcDir(getPrivateHeaders().getElements().map(toIfEmpty("src/main/headers"))));
 	}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/DefaultCLibraryExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/DefaultCLibraryExtension.java
@@ -8,15 +8,38 @@ import dev.nokee.platform.nativebase.NativeLibrary;
 import dev.nokee.platform.nativebase.NativeLibraryComponentDependencies;
 import dev.nokee.platform.nativebase.internal.BaseNativeExtension;
 import dev.nokee.platform.nativebase.internal.DefaultNativeLibraryComponent;
+import dev.nokee.runtime.nativebase.TargetBuildType;
+import dev.nokee.runtime.nativebase.TargetLinkage;
+import dev.nokee.runtime.nativebase.TargetMachine;
+import lombok.Getter;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.provider.SetProperty;
 
 import javax.inject.Inject;
 
-public abstract class DefaultCLibraryExtension extends BaseNativeExtension<DefaultNativeLibraryComponent> implements CLibraryExtension {
+public class DefaultCLibraryExtension extends BaseNativeExtension<DefaultNativeLibraryComponent> implements CLibraryExtension {
+	@Getter private final ConfigurableFileCollection sources;
+	@Getter private final ConfigurableFileCollection privateHeaders;
+	@Getter private final ConfigurableFileCollection publicHeaders;
+	@Getter private final SetProperty<TargetLinkage> targetLinkages;
+	@Getter private final SetProperty<TargetMachine> targetMachines;
+	@Getter private final SetProperty<TargetBuildType> targetBuildTypes;
+
 	@Inject
-	public DefaultCLibraryExtension(DefaultNativeLibraryComponent component) {
-		super(component);
+	public DefaultCLibraryExtension(DefaultNativeLibraryComponent component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
+		super(component, objects, providers, layout);
+		this.sources = objects.fileCollection();
+		this.privateHeaders = objects.fileCollection();
+		this.publicHeaders = objects.fileCollection();
+		this.targetLinkages = objects.setProperty(TargetLinkage.class);
+		this.targetMachines = objects.setProperty(TargetMachine.class);
+		this.targetBuildTypes = objects.setProperty(TargetBuildType.class);
+
 		getComponent().getSourceCollection().add(getObjects().newInstance(CSourceSet.class, "c").from(getSources().getElements().map(toIfEmpty("src/main/c"))));
 		getComponent().getSourceCollection().add(getObjects().newInstance(CHeaderSet.class, "headers").srcDir(getPrivateHeaders().getElements().map(toIfEmpty("src/main/headers"))));
 		getComponent().getSourceCollection().add(getObjects().newInstance(CHeaderSet.class, "public").srcDir(getPublicHeaders().getElements().map(toIfEmpty("src/main/public"))));

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/plugins/CApplicationPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/plugins/CApplicationPlugin.java
@@ -8,6 +8,8 @@ import dev.nokee.platform.c.internal.DefaultCApplicationExtension;
 import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
 import dev.nokee.platform.nativebase.internal.TargetBuildTypeRule;
 import dev.nokee.platform.nativebase.internal.TargetMachineRule;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.val;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -16,11 +18,14 @@ import org.gradle.nativeplatform.toolchain.internal.plugins.StandardToolChainsPl
 
 import javax.inject.Inject;
 
-public abstract class CApplicationPlugin implements Plugin<Project> {
+public class CApplicationPlugin implements Plugin<Project> {
 	private static final String EXTENSION_NAME = "application";
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
 
 	@Inject
-	protected abstract ObjectFactory getObjects();
+	public CApplicationPlugin(ObjectFactory objects) {
+		this.objects = objects;
+	}
 
 	@Override
 	public void apply(Project project) {

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/plugins/CLibraryPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/plugins/CLibraryPlugin.java
@@ -9,6 +9,8 @@ import dev.nokee.platform.nativebase.internal.DefaultNativeLibraryComponent;
 import dev.nokee.platform.nativebase.internal.TargetBuildTypeRule;
 import dev.nokee.platform.nativebase.internal.TargetLinkageRule;
 import dev.nokee.platform.nativebase.internal.TargetMachineRule;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.val;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -17,11 +19,14 @@ import org.gradle.nativeplatform.toolchain.internal.plugins.StandardToolChainsPl
 
 import javax.inject.Inject;
 
-public abstract class CLibraryPlugin implements Plugin<Project> {
+public class CLibraryPlugin implements Plugin<Project> {
 	private static final String EXTENSION_NAME = "library";
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
 
 	@Inject
-	protected abstract ObjectFactory getObjects();
+	public CLibraryPlugin(ObjectFactory objects) {
+		this.objects = objects;
+	}
 
 	@Override
 	public void apply(Project project) {

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/DefaultCppApplicationExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/DefaultCppApplicationExtension.java
@@ -8,15 +8,33 @@ import dev.nokee.platform.nativebase.NativeApplication;
 import dev.nokee.platform.nativebase.NativeApplicationComponentDependencies;
 import dev.nokee.platform.nativebase.internal.BaseNativeExtension;
 import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
+import dev.nokee.runtime.nativebase.TargetBuildType;
+import dev.nokee.runtime.nativebase.TargetMachine;
+import lombok.Getter;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.provider.SetProperty;
 
 import javax.inject.Inject;
 
-public abstract class DefaultCppApplicationExtension extends BaseNativeExtension<DefaultNativeApplicationComponent> implements CppApplicationExtension {
+public class DefaultCppApplicationExtension extends BaseNativeExtension<DefaultNativeApplicationComponent> implements CppApplicationExtension {
+	@Getter private final ConfigurableFileCollection sources;
+	@Getter private final ConfigurableFileCollection privateHeaders;
+	@Getter private final SetProperty<TargetMachine> targetMachines;
+	@Getter private final SetProperty<TargetBuildType> targetBuildTypes;
+
 	@Inject
-	public DefaultCppApplicationExtension(DefaultNativeApplicationComponent component) {
-		super(component);
+	public DefaultCppApplicationExtension(DefaultNativeApplicationComponent component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
+		super(component, objects, providers, layout);
+		this.sources = objects.fileCollection();
+		this.privateHeaders = objects.fileCollection();
+		this.targetMachines = objects.setProperty(TargetMachine.class);
+		this.targetBuildTypes = objects.setProperty(TargetBuildType.class);
+
 		getComponent().getSourceCollection().add(getObjects().newInstance(CppSourceSet.class, "cpp").from(getSources().getElements().map(toIfEmpty("src/main/cpp"))));
 		getComponent().getSourceCollection().add(getObjects().newInstance(CppHeaderSet.class, "headers").srcDir(getPrivateHeaders().getElements().map(toIfEmpty("src/main/headers"))));
 	}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/DefaultCppLibraryExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/DefaultCppLibraryExtension.java
@@ -8,15 +8,38 @@ import dev.nokee.platform.nativebase.NativeLibrary;
 import dev.nokee.platform.nativebase.NativeLibraryComponentDependencies;
 import dev.nokee.platform.nativebase.internal.BaseNativeExtension;
 import dev.nokee.platform.nativebase.internal.DefaultNativeLibraryComponent;
+import dev.nokee.runtime.nativebase.TargetBuildType;
+import dev.nokee.runtime.nativebase.TargetLinkage;
+import dev.nokee.runtime.nativebase.TargetMachine;
+import lombok.Getter;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.provider.SetProperty;
 
 import javax.inject.Inject;
 
-public abstract class DefaultCppLibraryExtension extends BaseNativeExtension<DefaultNativeLibraryComponent> implements CppLibraryExtension {
+public class DefaultCppLibraryExtension extends BaseNativeExtension<DefaultNativeLibraryComponent> implements CppLibraryExtension {
+	@Getter private final ConfigurableFileCollection sources;
+	@Getter private final ConfigurableFileCollection privateHeaders;
+	@Getter private final ConfigurableFileCollection publicHeaders;
+	@Getter private final SetProperty<TargetLinkage> targetLinkages;
+	@Getter private final SetProperty<TargetMachine> targetMachines;
+	@Getter private final SetProperty<TargetBuildType> targetBuildTypes;
+
 	@Inject
-	public DefaultCppLibraryExtension(DefaultNativeLibraryComponent component) {
-		super(component);
+	public DefaultCppLibraryExtension(DefaultNativeLibraryComponent component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
+		super(component, objects, providers, layout);
+		this.sources = objects.fileCollection();
+		this.privateHeaders = objects.fileCollection();
+		this.publicHeaders = objects.fileCollection();
+		this.targetLinkages = objects.setProperty(TargetLinkage.class);
+		this.targetMachines = objects.setProperty(TargetMachine.class);
+		this.targetBuildTypes = objects.setProperty(TargetBuildType.class);
+
 		getComponent().getSourceCollection().add(getObjects().newInstance(CppSourceSet.class, "cpp").from(getSources().getElements().map(toIfEmpty("src/main/cpp"))));
 		getComponent().getSourceCollection().add(getObjects().newInstance(CppHeaderSet.class, "headers").srcDir(getPrivateHeaders().getElements().map(toIfEmpty("src/main/headers"))));
 		getComponent().getSourceCollection().add(getObjects().newInstance(CppHeaderSet.class, "public").srcDir(getPublicHeaders().getElements().map(toIfEmpty("src/main/public"))));

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppApplicationPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppApplicationPlugin.java
@@ -8,6 +8,8 @@ import dev.nokee.platform.cpp.internal.DefaultCppApplicationExtension;
 import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
 import dev.nokee.platform.nativebase.internal.TargetBuildTypeRule;
 import dev.nokee.platform.nativebase.internal.TargetMachineRule;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.val;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -16,11 +18,14 @@ import org.gradle.nativeplatform.toolchain.internal.plugins.StandardToolChainsPl
 
 import javax.inject.Inject;
 
-public abstract class CppApplicationPlugin implements Plugin<Project> {
+public class CppApplicationPlugin implements Plugin<Project> {
 	private static final String EXTENSION_NAME = "application";
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
 
 	@Inject
-	protected abstract ObjectFactory getObjects();
+	public CppApplicationPlugin(ObjectFactory objects) {
+		this.objects = objects;
+	}
 
 	@Override
 	public void apply(Project project) {

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppLibraryPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppLibraryPlugin.java
@@ -9,6 +9,8 @@ import dev.nokee.platform.nativebase.internal.DefaultNativeLibraryComponent;
 import dev.nokee.platform.nativebase.internal.TargetBuildTypeRule;
 import dev.nokee.platform.nativebase.internal.TargetLinkageRule;
 import dev.nokee.platform.nativebase.internal.TargetMachineRule;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.val;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -17,11 +19,14 @@ import org.gradle.nativeplatform.toolchain.internal.plugins.StandardToolChainsPl
 
 import javax.inject.Inject;
 
-public abstract class CppLibraryPlugin implements Plugin<Project> {
+public class CppLibraryPlugin implements Plugin<Project> {
 	private static final String EXTENSION_NAME = "library";
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
 
 	@Inject
-	protected abstract ObjectFactory getObjects();
+	public CppLibraryPlugin(ObjectFactory objects) {
+		this.objects = objects;
+	}
 
 	@Override
 	public void apply(Project project) {

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeComponent.java
@@ -23,12 +23,15 @@ import dev.nokee.platform.nativebase.tasks.internal.LinkSharedLibraryTask;
 import dev.nokee.runtime.nativebase.internal.DefaultMachineArchitecture;
 import dev.nokee.runtime.nativebase.internal.DefaultOperatingSystemFamily;
 import dev.nokee.runtime.nativebase.internal.DefaultTargetMachine;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.val;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFile;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.TaskContainer;
@@ -36,7 +39,6 @@ import org.gradle.api.tasks.TaskProvider;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.language.nativeplatform.tasks.AbstractNativeCompileTask;
 
-import javax.inject.Inject;
 import java.io.File;
 import java.util.Iterator;
 import java.util.List;
@@ -46,21 +48,17 @@ import static java.util.Collections.emptyList;
 
 public abstract class BaseNativeComponent<T extends Variant> extends BaseComponent<T> {
 	private final Class<T> variantType;
+	@Getter(AccessLevel.PROTECTED) private final ProviderFactory providers;
+	@Getter(AccessLevel.PROTECTED) private final TaskContainer tasks;
+	@Getter(AccessLevel.PROTECTED) private final ProjectLayout layout;
+	@Getter(AccessLevel.PROTECTED) private final ConfigurationContainer configurations;
 
-	@Inject
-	protected abstract ProviderFactory getProviders();
-
-	@Inject
-	protected abstract TaskContainer getTasks();
-
-	@Inject
-	protected abstract ProjectLayout getLayout();
-
-	@Inject
-	protected abstract ConfigurationContainer getConfigurations();
-
-	public BaseNativeComponent(NamingScheme names, Class<T> variantType) {
-		super(names, variantType);
+	public BaseNativeComponent(NamingScheme names, Class<T> variantType, ObjectFactory objects, ProviderFactory providers, TaskContainer tasks, ProjectLayout layout, ConfigurationContainer configurations) {
+		super(names, variantType, objects);
+		this.providers = providers;
+		this.tasks = tasks;
+		this.layout = layout;
+		this.configurations = configurations;
 		Preconditions.checkArgument(BaseNativeVariant.class.isAssignableFrom(variantType));
 		this.variantType = variantType;
 		getDevelopmentVariant().convention(getDefaultVariant());

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeExtension.java
@@ -13,33 +13,34 @@ import dev.nokee.platform.nativebase.TargetMachineAwareComponent;
 import dev.nokee.runtime.base.internal.DefaultDimensionType;
 import dev.nokee.runtime.base.internal.Dimension;
 import dev.nokee.runtime.base.internal.DimensionType;
-import dev.nokee.runtime.nativebase.MachineArchitecture;
 import dev.nokee.runtime.nativebase.TargetBuildType;
 import dev.nokee.runtime.nativebase.TargetLinkage;
-import dev.nokee.runtime.nativebase.TargetMachine;
-import dev.nokee.runtime.nativebase.internal.DefaultMachineArchitecture;
-import dev.nokee.runtime.nativebase.internal.DefaultOperatingSystemFamily;
 import dev.nokee.runtime.nativebase.internal.DefaultTargetMachine;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
-import org.gradle.api.GradleException;
 import org.gradle.api.Transformer;
 import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ProviderFactory;
 
-import javax.inject.Inject;
 import java.util.Collection;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public abstract class BaseNativeExtension<T extends BaseNativeComponent<?>> {
+public class BaseNativeExtension<T extends BaseNativeComponent<?>> {
 	@Getter private final T component;
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
+	@Getter(AccessLevel.PROTECTED) private final ProviderFactory providers;
+	@Getter(AccessLevel.PROTECTED) private final ProjectLayout layout;
 
-	public BaseNativeExtension(T component) {
+	public BaseNativeExtension(T component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
 		this.component = component;
+		this.objects = objects;
+		this.providers = providers;
+		this.layout = layout;
 
 		component.getBuildVariants().convention(getProviders().provider(this::createBuildVariants));
 		component.getBuildVariants().finalizeValueOnRead();
@@ -47,15 +48,6 @@ public abstract class BaseNativeExtension<T extends BaseNativeComponent<?>> {
 
 		component.getDimensions().disallowChanges(); // Let's disallow changing them for now.
 	}
-
-	@Inject
-	protected abstract ObjectFactory getObjects();
-
-	@Inject
-	protected abstract ProviderFactory getProviders();
-
-	@Inject
-	protected abstract ProjectLayout getLayout();
 
 	protected Transformer<Iterable<FileSystemLocation>, Set<FileSystemLocation>> toIfEmpty(String path) {
 		return sources -> {

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeVariant.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeVariant.java
@@ -5,31 +5,30 @@ import dev.nokee.platform.base.Binary;
 import dev.nokee.platform.base.internal.BaseVariant;
 import dev.nokee.platform.base.internal.BuildVariantInternal;
 import dev.nokee.platform.base.internal.NamingScheme;
+import lombok.AccessLevel;
 import lombok.Getter;
 import org.gradle.api.Task;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 
-import javax.inject.Inject;
 import java.util.Iterator;
 
-public abstract class BaseNativeVariant extends BaseVariant {
+public class BaseNativeVariant extends BaseVariant {
 	@Getter private final NamingScheme names;
+	@Getter(AccessLevel.PROTECTED) private final TaskContainer tasks;
+	@Getter(AccessLevel.PROTECTED) private final ProviderFactory providers;
 
-	public BaseNativeVariant(String name, NamingScheme names, BuildVariantInternal buildVariant) {
-		super(name, buildVariant);
+	public BaseNativeVariant(String name, NamingScheme names, BuildVariantInternal buildVariant, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
+		super(name, buildVariant, objects);
 		this.names = names;
+		this.tasks = tasks;
+		this.providers = providers;
 
 		getDevelopmentBinary().convention(getDefaultBinary());
 	}
-
-	@Inject
-	protected abstract TaskContainer getTasks();
-
-	@Inject
-	protected abstract ProviderFactory getProviders();
 
 	public TaskProvider<Task> getAssembleTask() {
 		return getTasks().named(names.getTaskName("assemble"));

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BundleBinaryInternal.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BundleBinaryInternal.java
@@ -10,30 +10,35 @@ import dev.nokee.platform.nativebase.tasks.internal.LinkBundleTask;
 import dev.nokee.platform.nativebase.tasks.internal.ObjectFilesToBinaryTask;
 import dev.nokee.runtime.nativebase.OperatingSystemFamily;
 import dev.nokee.runtime.nativebase.internal.DefaultTargetMachine;
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.gradle.api.Buildable;
 import org.gradle.api.DomainObjectSet;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFile;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.api.tasks.TaskProvider;
 
 import javax.inject.Inject;
 
-public abstract class BundleBinaryInternal extends BaseNativeBinary implements BundleBinary, Buildable {
+public class BundleBinaryInternal extends BaseNativeBinary implements BundleBinary, Buildable {
 	private final TaskProvider<LinkBundleTask> linkTask;
+	@Getter(AccessLevel.PROTECTED) private final TaskContainer tasks;
 
 	@Inject
-	public BundleBinaryInternal(NamingScheme names, DefaultTargetMachine targetMachine, DomainObjectSet<GeneratedSourceSet> objectSourceSets, TaskProvider<LinkBundleTask> linkTask, NativeIncomingDependencies dependencies) {
-		super(names, objectSourceSets, targetMachine, dependencies);
+	public BundleBinaryInternal(NamingScheme names, DefaultTargetMachine targetMachine, DomainObjectSet<GeneratedSourceSet> objectSourceSets, TaskProvider<LinkBundleTask> linkTask, NativeIncomingDependencies dependencies, ObjectFactory objects, ProjectLayout layout, ProviderFactory providers, ConfigurationContainer configurations, TaskContainer tasks) {
+		super(names, objectSourceSets, targetMachine, dependencies, objects, layout, providers, configurations);
 
 		this.linkTask = linkTask;
+		this.tasks = tasks;
 
 		linkTask.configure(this::configureBundleTask);
 	}
-
-	@Inject
-	protected abstract TaskContainer getTasks();
 
 	private void configureBundleTask(LinkBundleTask task) {
 		task.setDescription("Links the bundle.");

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/ConfigurationUtils.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/ConfigurationUtils.java
@@ -4,9 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import dev.nokee.platform.base.internal.BuildVariantInternal;
 import dev.nokee.runtime.nativebase.internal.*;
-import lombok.Value;
-import lombok.With;
-import lombok.val;
+import lombok.*;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.attributes.Attribute;
@@ -28,7 +26,14 @@ import static dev.nokee.platform.nativebase.internal.ConfigurationUtils.Configur
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 
-public abstract class ConfigurationUtils {
+public class ConfigurationUtils {
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
+
+	@Inject
+	public ConfigurationUtils(ObjectFactory objects) {
+		this.objects = objects;
+	}
+
 	//region Bucket
 	public DescribableConfigurationAction asBucket() {
 		return new DescribableConfigurationAction(ConfigurationSpec.asBucket());
@@ -118,9 +123,6 @@ public abstract class ConfigurationUtils {
 		configuration.setCanBeResolved(false);
 	}
 
-	@Inject
-	protected abstract ObjectFactory getObjects();
-
 	public static class DescribableConfigurationAction implements Action<Configuration> {
 		protected final ConfigurationSpec spec;
 
@@ -138,14 +140,14 @@ public abstract class ConfigurationUtils {
 		}
 	}
 
-	public static abstract class IncomingConfigurationAction extends DescribableConfigurationAction {
-		@Inject
-		public IncomingConfigurationAction(ConfigurationSpec spec) {
-			super(spec);
-		}
+	public static class IncomingConfigurationAction extends DescribableConfigurationAction {
+		@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
 
 		@Inject
-		protected abstract ObjectFactory getObjects();
+		public IncomingConfigurationAction(ConfigurationSpec spec, ObjectFactory objects) {
+			super(spec);
+			this.objects = objects;
+		}
 
 		public IncomingConfigurationAction asDebug() {
 			return getObjects().newInstance(IncomingConfigurationAction.class,
@@ -180,15 +182,14 @@ public abstract class ConfigurationUtils {
 		}
 	}
 
-	public static abstract class VariantAwareOutgoingConfigurationAction extends DescribableConfigurationAction {
+	public static class VariantAwareOutgoingConfigurationAction extends DescribableConfigurationAction {
+		@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
 
 		@Inject
-		public VariantAwareOutgoingConfigurationAction(ConfigurationSpec spec) {
+		public VariantAwareOutgoingConfigurationAction(ConfigurationSpec spec, ObjectFactory objects) {
 			super(spec);
+			this.objects = objects;
 		}
-
-		@Inject
-		protected abstract ObjectFactory getObjects();
 
 		public VariantAwareOutgoingConfigurationAction withVariant(BuildVariantInternal variant) {
 			val attributes = ImmutableMap.<Attribute<?>, Object>builder().putAll(spec.attributes);

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationComponent.java
@@ -37,7 +37,7 @@ public class DefaultNativeApplicationComponent extends BaseNativeComponent<Defau
 		this.dependencyHandler = dependencyHandler;
 		val dependencyContainer = objects.newInstance(DefaultComponentDependencies.class, names.getComponentDisplayName(), new FrameworkAwareDependencyBucketFactory(new DefaultDependencyBucketFactory(new ConfigurationFactories.Prefixing(new ConfigurationFactories.Creating(getConfigurations()), names::getConfigurationName), new DefaultDependencyFactory(getDependencyHandler()))));
 		this.dependencies = objects.newInstance(DefaultNativeApplicationComponentDependencies.class, dependencyContainer);
-		getDimensions().convention(ImmutableSet.of(DefaultBinaryLinkage.DIMENSION_TYPE, DefaultOperatingSystemFamily.DIMENSION_TYPE, DefaultMachineArchitecture.DIMENSION_TYPE));
+		getDimensions().convention(ImmutableSet.of(DefaultBinaryLinkage.DIMENSION_TYPE, BaseTargetBuildType.DIMENSION_TYPE, DefaultOperatingSystemFamily.DIMENSION_TYPE, DefaultMachineArchitecture.DIMENSION_TYPE));
 	}
 
 	@Override

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationComponent.java
@@ -13,27 +13,32 @@ import dev.nokee.platform.nativebase.NativeApplicationComponentDependencies;
 import dev.nokee.platform.nativebase.internal.dependencies.*;
 import dev.nokee.runtime.nativebase.internal.DefaultMachineArchitecture;
 import dev.nokee.runtime.nativebase.internal.DefaultOperatingSystemFamily;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.val;
 import lombok.var;
 import org.gradle.api.Action;
+import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.tasks.TaskContainer;
 
 import javax.inject.Inject;
 
-public abstract class DefaultNativeApplicationComponent extends BaseNativeComponent<DefaultNativeApplicationVariant> implements DependencyAwareComponent<NativeApplicationComponentDependencies>, BinaryAwareComponent, Component {
+public class DefaultNativeApplicationComponent extends BaseNativeComponent<DefaultNativeApplicationVariant> implements DependencyAwareComponent<NativeApplicationComponentDependencies>, BinaryAwareComponent, Component {
 	private final DefaultNativeApplicationComponentDependencies dependencies;
+	@Getter(AccessLevel.PROTECTED) private final DependencyHandler dependencyHandler;
 
 	@Inject
-	public DefaultNativeApplicationComponent(NamingScheme names) {
-		super(names, DefaultNativeApplicationVariant.class);
-		val dependencyContainer = getObjects().newInstance(DefaultComponentDependencies.class, names.getComponentDisplayName(), new FrameworkAwareDependencyBucketFactory(new DefaultDependencyBucketFactory(new ConfigurationFactories.Prefixing(new ConfigurationFactories.Creating(getConfigurations()), names::getConfigurationName), new DefaultDependencyFactory(getDependencyHandler()))));
-		this.dependencies = getObjects().newInstance(DefaultNativeApplicationComponentDependencies.class, dependencyContainer);
-		getDimensions().convention(ImmutableSet.of(DefaultBinaryLinkage.DIMENSION_TYPE, DefaultOperatingSystemFamily.DIMENSION_TYPE, DefaultMachineArchitecture.DIMENSION_TYPE, BaseTargetBuildType.DIMENSION_TYPE));
+	public DefaultNativeApplicationComponent(NamingScheme names, ObjectFactory objects, ProviderFactory providers, TaskContainer tasks, ProjectLayout layout, ConfigurationContainer configurations, DependencyHandler dependencyHandler) {
+		super(names, DefaultNativeApplicationVariant.class, objects, providers, tasks, layout, configurations);
+		this.dependencyHandler = dependencyHandler;
+		val dependencyContainer = objects.newInstance(DefaultComponentDependencies.class, names.getComponentDisplayName(), new FrameworkAwareDependencyBucketFactory(new DefaultDependencyBucketFactory(new ConfigurationFactories.Prefixing(new ConfigurationFactories.Creating(getConfigurations()), names::getConfigurationName), new DefaultDependencyFactory(getDependencyHandler()))));
+		this.dependencies = objects.newInstance(DefaultNativeApplicationComponentDependencies.class, dependencyContainer);
+		getDimensions().convention(ImmutableSet.of(DefaultBinaryLinkage.DIMENSION_TYPE, DefaultOperatingSystemFamily.DIMENSION_TYPE, DefaultMachineArchitecture.DIMENSION_TYPE));
 	}
-
-	@Inject
-	protected abstract DependencyHandler getDependencyHandler();
 
 	@Override
 	public DefaultNativeApplicationComponentDependencies getDependencies() {

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationVariant.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationVariant.java
@@ -8,15 +8,18 @@ import dev.nokee.platform.nativebase.internal.dependencies.DefaultNativeApplicat
 import dev.nokee.platform.nativebase.internal.dependencies.VariantComponentDependencies;
 import lombok.Getter;
 import org.gradle.api.Action;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.tasks.TaskContainer;
 
 import javax.inject.Inject;
 
-public abstract class DefaultNativeApplicationVariant extends BaseNativeVariant implements NativeApplication {
+public class DefaultNativeApplicationVariant extends BaseNativeVariant implements NativeApplication {
 	@Getter private final DefaultNativeApplicationComponentDependencies dependencies;
 
 	@Inject
-	public DefaultNativeApplicationVariant(String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<DefaultNativeApplicationComponentDependencies> dependencies) {
-		super(name, names, buildVariant);
+	public DefaultNativeApplicationVariant(String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<DefaultNativeApplicationComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
+		super(name, names, buildVariant, objects, tasks, providers);
 		this.dependencies = dependencies.getDependencies();
 	}
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryComponent.java
@@ -37,7 +37,7 @@ public class DefaultNativeLibraryComponent extends BaseNativeComponent<DefaultNa
 		this.dependencyHandler = dependencyHandler;
 		val dependencyContainer = objects.newInstance(DefaultComponentDependencies.class, names.getComponentDisplayName(), new FrameworkAwareDependencyBucketFactory(new DefaultDependencyBucketFactory(new ConfigurationFactories.Prefixing(new ConfigurationFactories.Creating(getConfigurations()), names::getConfigurationName), new DefaultDependencyFactory(getDependencyHandler()))));
 		this.dependencies = objects.newInstance(DefaultNativeLibraryComponentDependencies.class, dependencyContainer);
-		getDimensions().convention(ImmutableSet.of(DefaultBinaryLinkage.DIMENSION_TYPE, DefaultOperatingSystemFamily.DIMENSION_TYPE, DefaultMachineArchitecture.DIMENSION_TYPE));
+		getDimensions().convention(ImmutableSet.of(DefaultBinaryLinkage.DIMENSION_TYPE, BaseTargetBuildType.DIMENSION_TYPE, DefaultOperatingSystemFamily.DIMENSION_TYPE, DefaultMachineArchitecture.DIMENSION_TYPE));
 	}
 
 	@Override

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryComponent.java
@@ -13,27 +13,32 @@ import dev.nokee.platform.nativebase.NativeLibraryComponentDependencies;
 import dev.nokee.platform.nativebase.internal.dependencies.*;
 import dev.nokee.runtime.nativebase.internal.DefaultMachineArchitecture;
 import dev.nokee.runtime.nativebase.internal.DefaultOperatingSystemFamily;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.val;
 import lombok.var;
 import org.gradle.api.Action;
+import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.tasks.TaskContainer;
 
 import javax.inject.Inject;
 
-public abstract class DefaultNativeLibraryComponent extends BaseNativeComponent<DefaultNativeLibraryVariant> implements DependencyAwareComponent<NativeLibraryComponentDependencies>, BinaryAwareComponent, Component {
+public class DefaultNativeLibraryComponent extends BaseNativeComponent<DefaultNativeLibraryVariant> implements DependencyAwareComponent<NativeLibraryComponentDependencies>, BinaryAwareComponent, Component {
 	private final DefaultNativeLibraryComponentDependencies dependencies;
+	@Getter(AccessLevel.PROTECTED) private final DependencyHandler dependencyHandler;
 
 	@Inject
-	public DefaultNativeLibraryComponent(NamingScheme names) {
-		super(names, DefaultNativeLibraryVariant.class);
-		val dependencyContainer = getObjects().newInstance(DefaultComponentDependencies.class, names.getComponentDisplayName(), new FrameworkAwareDependencyBucketFactory(new DefaultDependencyBucketFactory(new ConfigurationFactories.Prefixing(new ConfigurationFactories.Creating(getConfigurations()), names::getConfigurationName), new DefaultDependencyFactory(getDependencyHandler()))));
-		this.dependencies = getObjects().newInstance(DefaultNativeLibraryComponentDependencies.class, dependencyContainer);
-		getDimensions().convention(ImmutableSet.of(DefaultBinaryLinkage.DIMENSION_TYPE, DefaultOperatingSystemFamily.DIMENSION_TYPE, DefaultMachineArchitecture.DIMENSION_TYPE, BaseTargetBuildType.DIMENSION_TYPE));
+	public DefaultNativeLibraryComponent(NamingScheme names, ObjectFactory objects, ProviderFactory providers, TaskContainer tasks, ProjectLayout layout, ConfigurationContainer configurations, DependencyHandler dependencyHandler) {
+		super(names, DefaultNativeLibraryVariant.class, objects, providers, tasks, layout, configurations);
+		this.dependencyHandler = dependencyHandler;
+		val dependencyContainer = objects.newInstance(DefaultComponentDependencies.class, names.getComponentDisplayName(), new FrameworkAwareDependencyBucketFactory(new DefaultDependencyBucketFactory(new ConfigurationFactories.Prefixing(new ConfigurationFactories.Creating(getConfigurations()), names::getConfigurationName), new DefaultDependencyFactory(getDependencyHandler()))));
+		this.dependencies = objects.newInstance(DefaultNativeLibraryComponentDependencies.class, dependencyContainer);
+		getDimensions().convention(ImmutableSet.of(DefaultBinaryLinkage.DIMENSION_TYPE, DefaultOperatingSystemFamily.DIMENSION_TYPE, DefaultMachineArchitecture.DIMENSION_TYPE));
 	}
-
-	@Inject
-	protected abstract DependencyHandler getDependencyHandler();
 
 	@Override
 	public DefaultNativeLibraryComponentDependencies getDependencies() {

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryVariant.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryVariant.java
@@ -6,23 +6,26 @@ import dev.nokee.platform.nativebase.NativeLibrary;
 import dev.nokee.platform.nativebase.NativeLibraryComponentDependencies;
 import dev.nokee.platform.nativebase.internal.dependencies.DefaultNativeLibraryComponentDependencies;
 import dev.nokee.platform.nativebase.internal.dependencies.VariantComponentDependencies;
+import lombok.AccessLevel;
 import lombok.Getter;
 import org.gradle.api.Action;
 import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.tasks.TaskContainer;
 
 import javax.inject.Inject;
 
-public abstract class DefaultNativeLibraryVariant extends BaseNativeVariant implements NativeLibrary {
+public class DefaultNativeLibraryVariant extends BaseNativeVariant implements NativeLibrary {
 	@Getter private final DefaultNativeLibraryComponentDependencies dependencies;
+	@Getter(AccessLevel.PROTECTED) private final ProjectLayout layout;
 
 	@Inject
-	public DefaultNativeLibraryVariant(String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<DefaultNativeLibraryComponentDependencies> dependencies) {
-		super(name, names, buildVariant);
+	public DefaultNativeLibraryVariant(String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<DefaultNativeLibraryComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers, ProjectLayout layout) {
+		super(name, names, buildVariant, objects, tasks, providers);
 		this.dependencies = dependencies.getDependencies();
+		this.layout = layout;
 	}
-
-	@Inject
-	protected abstract ProjectLayout getLayout();
 
 	@Override
 	public void dependencies(Action<? super NativeLibraryComponentDependencies> action) {

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/ExecutableBinaryInternal.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/ExecutableBinaryInternal.java
@@ -13,11 +13,17 @@ import dev.nokee.platform.nativebase.tasks.internal.LinkExecutableTask;
 import dev.nokee.platform.nativebase.tasks.internal.ObjectFilesToBinaryTask;
 import dev.nokee.runtime.nativebase.OperatingSystemFamily;
 import dev.nokee.runtime.nativebase.internal.DefaultTargetMachine;
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.apache.commons.io.FilenameUtils;
 import org.gradle.api.Buildable;
 import org.gradle.api.DomainObjectSet;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFile;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.api.tasks.TaskProvider;
@@ -28,13 +34,15 @@ import java.io.File;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public abstract class ExecutableBinaryInternal extends BaseNativeBinary implements ExecutableBinary, Buildable {
+public class ExecutableBinaryInternal extends BaseNativeBinary implements ExecutableBinary, Buildable {
 	private final TaskProvider<LinkExecutableTask> linkTask;
+	@Getter(AccessLevel.PROTECTED) private final TaskContainer tasks;
 
 	@Inject
-	public ExecutableBinaryInternal(NamingScheme names, DomainObjectSet<GeneratedSourceSet> objectSourceSets, DefaultTargetMachine targetMachine, TaskProvider<LinkExecutableTask> linkTask, NativeIncomingDependencies dependencies) {
-		super(names, objectSourceSets, targetMachine, dependencies);
+	public ExecutableBinaryInternal(NamingScheme names, DomainObjectSet<GeneratedSourceSet> objectSourceSets, DefaultTargetMachine targetMachine, TaskProvider<LinkExecutableTask> linkTask, NativeIncomingDependencies dependencies, ObjectFactory objects, ProjectLayout layout, ProviderFactory providers, ConfigurationContainer configurations, TaskContainer tasks) {
+		super(names, objectSourceSets, targetMachine, dependencies, objects, layout, providers, configurations);
 		this.linkTask = linkTask;
+		this.tasks = tasks;
 
 		linkTask.configure(this::configureExecutableTask);
 		linkTask.configure(task -> {
@@ -81,9 +89,6 @@ public abstract class ExecutableBinaryInternal extends BaseNativeBinary implemen
 			return osOperations.getExecutableName(getNames().getOutputDirectoryBase("exes") + "/" + it);
 		}));
 	}
-
-	@Inject
-	protected abstract TaskContainer getTasks();
 
 	@Override
 	public TaskProvider<LinkExecutable> getLinkTask() {

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/NativeLanguageRules.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/NativeLanguageRules.java
@@ -14,6 +14,7 @@ import dev.nokee.language.objectivecpp.internal.tasks.ObjectiveCppCompileTask;
 import dev.nokee.language.swift.internal.SwiftSourceSet;
 import dev.nokee.language.swift.tasks.internal.SwiftCompileTask;
 import dev.nokee.platform.base.internal.NamingScheme;
+import lombok.AccessLevel;
 import lombok.Getter;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.model.ObjectFactory;
@@ -24,19 +25,17 @@ import org.gradle.language.nativeplatform.tasks.AbstractNativeCompileTask;
 import javax.inject.Inject;
 import java.util.function.Function;
 
-public abstract class NativeLanguageRules {
+public class NativeLanguageRules {
 	@Getter private final NamingScheme names;
+	@Getter(AccessLevel.PROTECTED) private final TaskContainer tasks;
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
 
 	@Inject
-	public NativeLanguageRules(NamingScheme names) {
+	public NativeLanguageRules(NamingScheme names, TaskContainer tasks, ObjectFactory objects) {
 		this.names = names;
+		this.tasks = tasks;
+		this.objects = objects;
 	}
-
-	@Inject
-	protected abstract TaskContainer getTasks();
-
-	@Inject
-	protected abstract ObjectFactory getObjects();
 
 	public DomainObjectSet<GeneratedSourceSet> apply(DomainObjectSet<SourceSet> sourceSets) {
 		DomainObjectSet<GeneratedSourceSet> objectSourceSets = getObjects().domainObjectSet(GeneratedSourceSet.class);

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/StaticLibraryBinaryInternal.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/StaticLibraryBinaryInternal.java
@@ -10,11 +10,17 @@ import dev.nokee.platform.nativebase.tasks.internal.CreateStaticLibraryTask;
 import dev.nokee.platform.nativebase.tasks.internal.ObjectFilesToBinaryTask;
 import dev.nokee.runtime.nativebase.OperatingSystemFamily;
 import dev.nokee.runtime.nativebase.internal.DefaultTargetMachine;
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.gradle.api.Buildable;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.Task;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFile;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.api.tasks.TaskProvider;
@@ -23,19 +29,18 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.util.Set;
 
-public abstract class StaticLibraryBinaryInternal extends BaseNativeBinary implements StaticLibraryBinary, Buildable {
+public class StaticLibraryBinaryInternal extends BaseNativeBinary implements StaticLibraryBinary, Buildable {
 	private final TaskProvider<CreateStaticLibraryTask> createTask;
+	@Getter(AccessLevel.PROTECTED) private final TaskContainer tasks;
 
 	@Inject
-	public StaticLibraryBinaryInternal(NamingScheme names, DomainObjectSet<GeneratedSourceSet> objectSourceSets, DefaultTargetMachine targetMachine, TaskProvider<CreateStaticLibraryTask> createTask, NativeIncomingDependencies dependencies) {
-		super(names, objectSourceSets, targetMachine, dependencies);
+	public StaticLibraryBinaryInternal(NamingScheme names, DomainObjectSet<GeneratedSourceSet> objectSourceSets, DefaultTargetMachine targetMachine, TaskProvider<CreateStaticLibraryTask> createTask, NativeIncomingDependencies dependencies, ObjectFactory objects, ProjectLayout layout, ProviderFactory providers, ConfigurationContainer configurations, TaskContainer tasks) {
+		super(names, objectSourceSets, targetMachine, dependencies, objects, layout, providers, configurations);
 		this.createTask = createTask;
+		this.tasks = tasks;
 
 		createTask.configure(this::configureStaticLibraryTask);
 	}
-
-	@Inject
-	protected abstract TaskContainer getTasks();
 
 	private void configureStaticLibraryTask(CreateStaticLibraryTask task) {
 		task.setDescription("Creates the static library.");

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/TargetLinkageRule.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/TargetLinkageRule.java
@@ -2,7 +2,10 @@ package dev.nokee.platform.nativebase.internal;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import dev.nokee.platform.base.DependencyBucket;
 import dev.nokee.runtime.nativebase.TargetLinkage;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.val;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
@@ -19,24 +22,22 @@ import java.util.Set;
 
 import static java.util.stream.Collectors.joining;
 
-public abstract class TargetLinkageRule implements Action<Project> {
+public class TargetLinkageRule implements Action<Project> {
 	private final SetProperty<TargetLinkage> targetLinkages;
 	private final String componentName;
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
+	@Getter(AccessLevel.PROTECTED) private final DependencyHandler dependencies;
 
 	@Inject
-	public TargetLinkageRule(SetProperty<TargetLinkage> targetLinkages, String componentName) {
+	public TargetLinkageRule(SetProperty<TargetLinkage> targetLinkages, String componentName, ObjectFactory objects, DependencyHandler dependencies) {
 		this.targetLinkages = targetLinkages;
 		this.componentName = componentName;
+		this.objects = objects;
+		this.dependencies = dependencies;
 		targetLinkages.convention(ImmutableList.of(DefaultBinaryLinkage.SHARED));
 
 		getDependencies().getAttributesSchema().attribute(DefaultBinaryLinkage.LINKAGE_ATTRIBUTE).getDisambiguationRules().add(LinkageSelectionRule.class);
 	}
-
-	@Inject
-	protected abstract ObjectFactory getObjects();
-
-	@Inject
-	protected abstract DependencyHandler getDependencies();
 
 	static class LinkageSelectionRule implements AttributeDisambiguationRule<String> {
 		@Override

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/TargetMachineRule.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/TargetMachineRule.java
@@ -4,6 +4,8 @@ import com.google.common.collect.ImmutableList;
 import dev.nokee.runtime.nativebase.TargetMachine;
 import dev.nokee.runtime.nativebase.internal.DefaultMachineArchitecture;
 import dev.nokee.runtime.nativebase.internal.DefaultOperatingSystemFamily;
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.model.ObjectFactory;
@@ -17,20 +19,20 @@ import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.joining;
 
-public abstract class TargetMachineRule implements Action<Project> {
-	private final ToolChainSelectorInternal toolChainSelector = getObjects().newInstance(ToolChainSelectorInternal.class);
+public class TargetMachineRule implements Action<Project> {
+	private final ToolChainSelectorInternal toolChainSelector;
 	private final SetProperty<TargetMachine> targetMachines;
 	private final String componentName;
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
 
 	@Inject
-	public TargetMachineRule(SetProperty<TargetMachine> targetMachines, String componentName) {
+	public TargetMachineRule(SetProperty<TargetMachine> targetMachines, String componentName, ObjectFactory objects) {
 		this.targetMachines = targetMachines;
 		this.componentName = componentName;
+		this.objects = objects;
+		this.toolChainSelector = objects.newInstance(ToolChainSelectorInternal.class);
 		targetMachines.convention(ImmutableList.of(DefaultTargetMachineFactory.host()));
 	}
-
-	@Inject
-	protected abstract ObjectFactory getObjects();
 
 	@Override
 	public void execute(Project project) {

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/dependencies/NativeApplicationOutgoingDependencies.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/dependencies/NativeApplicationOutgoingDependencies.java
@@ -6,6 +6,8 @@ import dev.nokee.platform.base.internal.NamingScheme;
 import dev.nokee.platform.nativebase.internal.ConfigurationUtils;
 import dev.nokee.platform.nativebase.internal.ExecutableBinaryInternal;
 import dev.nokee.platform.nativebase.tasks.LinkExecutable;
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.file.DirectoryProperty;
@@ -17,20 +19,25 @@ import org.gradle.api.provider.Provider;
 
 import javax.inject.Inject;
 
-public abstract class NativeApplicationOutgoingDependencies implements NativeOutgoingDependencies {
+public class NativeApplicationOutgoingDependencies implements NativeOutgoingDependencies {
+	@Getter private final DirectoryProperty exportedHeaders;
+	@Getter private final RegularFileProperty exportedSwiftModule;
+	@Getter private final Property<Binary> exportedBinary;
+	@Getter(AccessLevel.PROTECTED) private final ConfigurationContainer configurations;
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
+
 	@Inject
-	public NativeApplicationOutgoingDependencies(NamingScheme names, BuildVariantInternal buildVariant, DefaultNativeComponentDependencies dependencies) {
-		ConfigurationUtils builder = getObjects().newInstance(ConfigurationUtils.class);
+	public NativeApplicationOutgoingDependencies(NamingScheme names, BuildVariantInternal buildVariant, DefaultNativeComponentDependencies dependencies, ConfigurationContainer configurations, ObjectFactory objects) {
+		this.configurations = configurations;
+		this.objects = objects;
+		this.exportedHeaders = objects.directoryProperty();
+		this.exportedSwiftModule = objects.fileProperty();
+		this.exportedBinary = objects.property(Binary.class);
+		ConfigurationUtils builder = objects.newInstance(ConfigurationUtils.class);
 		Configuration runtimeElements = getConfigurations().create(names.getConfigurationName("runtimeElements"), builder.asOutgoingRuntimeLibrariesFrom(dependencies.getImplementation().getAsConfiguration(), dependencies.getRuntimeOnly().getAsConfiguration()).withVariant(buildVariant).withDescription(names.getConfigurationDescription("Runtime elements for %s.")));
 
 		runtimeElements.getOutgoing().artifact(getExportedBinary().flatMap(this::getOutgoingRuntimeLibrary));
 	}
-
-	@Inject
-	protected abstract ConfigurationContainer getConfigurations();
-
-	@Inject
-	protected abstract ObjectFactory getObjects();
 
 	private Provider<RegularFile> getOutgoingRuntimeLibrary(Binary binary) {
 		if (binary instanceof ExecutableBinaryInternal) {
@@ -38,8 +45,4 @@ public abstract class NativeApplicationOutgoingDependencies implements NativeOut
 		}
 		throw new IllegalArgumentException("Unsupported binary to export");
 	}
-
-	public abstract DirectoryProperty getExportedHeaders();
-	public abstract RegularFileProperty getExportedSwiftModule();
-	public abstract Property<Binary> getExportedBinary();
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/dependencies/NativeLibraryOutgoingDependencies.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/dependencies/NativeLibraryOutgoingDependencies.java
@@ -4,15 +4,18 @@ import dev.nokee.platform.base.internal.BuildVariantInternal;
 import dev.nokee.platform.base.internal.NamingScheme;
 import dev.nokee.platform.nativebase.internal.ConfigurationUtils;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.model.ObjectFactory;
 
 import javax.inject.Inject;
 
-public abstract class NativeLibraryOutgoingDependencies extends AbstractNativeLibraryOutgoingDependencies implements NativeOutgoingDependencies {
-	private final ConfigurationUtils builder = getObjects().newInstance(ConfigurationUtils.class);
+public class NativeLibraryOutgoingDependencies extends AbstractNativeLibraryOutgoingDependencies implements NativeOutgoingDependencies {
+	private final ConfigurationUtils builder;
 
 	@Inject
-	public NativeLibraryOutgoingDependencies(NamingScheme names, BuildVariantInternal buildVariant, DefaultNativeLibraryComponentDependencies dependencies) {
-		super(names, buildVariant, dependencies);
+	public NativeLibraryOutgoingDependencies(NamingScheme names, BuildVariantInternal buildVariant, DefaultNativeLibraryComponentDependencies dependencies, ConfigurationContainer configurations, ObjectFactory objects) {
+		super(names, buildVariant, dependencies, configurations, objects);
+		builder = objects.newInstance(ConfigurationUtils.class);
 
 		Configuration apiElements = getConfigurations().create(names.getConfigurationName("apiElements"), builder.asOutgoingHeaderSearchPathFrom(dependencies.getApi().getAsConfiguration(), dependencies.getCompileOnly().getAsConfiguration()).withVariant(buildVariant).withDescription("API elements for %s."));
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/dependencies/SwiftLibraryOutgoingDependencies.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/dependencies/SwiftLibraryOutgoingDependencies.java
@@ -4,15 +4,18 @@ import dev.nokee.platform.base.internal.BuildVariantInternal;
 import dev.nokee.platform.base.internal.NamingScheme;
 import dev.nokee.platform.nativebase.internal.ConfigurationUtils;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.model.ObjectFactory;
 
 import javax.inject.Inject;
 
-public abstract class SwiftLibraryOutgoingDependencies extends AbstractNativeLibraryOutgoingDependencies implements NativeOutgoingDependencies {
-	private final ConfigurationUtils builder = getObjects().newInstance(ConfigurationUtils.class);
+public class SwiftLibraryOutgoingDependencies extends AbstractNativeLibraryOutgoingDependencies implements NativeOutgoingDependencies {
+	private final ConfigurationUtils builder;
 
 	@Inject
-	public SwiftLibraryOutgoingDependencies(NamingScheme names, BuildVariantInternal buildVariant, DefaultNativeLibraryComponentDependencies dependencies) {
-		super(names, buildVariant, dependencies);
+	public SwiftLibraryOutgoingDependencies(NamingScheme names, BuildVariantInternal buildVariant, DefaultNativeLibraryComponentDependencies dependencies, ConfigurationContainer configurations, ObjectFactory objects) {
+		super(names, buildVariant, dependencies, configurations, objects);
+		this.builder = objects.newInstance(ConfigurationUtils.class);
 
 		Configuration apiElements = getConfigurations().create(names.getConfigurationName("apiElements"), builder.asOutgoingSwiftModuleFrom(dependencies.getApi().getAsConfiguration(), dependencies.getCompileOnly().getAsConfiguration()).withVariant(buildVariant).withDescription(names.getConfigurationDescription("API elements for %s.")));
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/DefaultObjectiveCApplicationExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/DefaultObjectiveCApplicationExtension.java
@@ -8,15 +8,33 @@ import dev.nokee.platform.nativebase.NativeApplicationComponentDependencies;
 import dev.nokee.platform.nativebase.internal.BaseNativeExtension;
 import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
 import dev.nokee.platform.objectivec.ObjectiveCApplicationExtension;
+import dev.nokee.runtime.nativebase.TargetBuildType;
+import dev.nokee.runtime.nativebase.TargetMachine;
+import lombok.Getter;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.provider.SetProperty;
 
 import javax.inject.Inject;
 
-public abstract class DefaultObjectiveCApplicationExtension extends BaseNativeExtension<DefaultNativeApplicationComponent> implements ObjectiveCApplicationExtension {
+public class DefaultObjectiveCApplicationExtension extends BaseNativeExtension<DefaultNativeApplicationComponent> implements ObjectiveCApplicationExtension {
+	@Getter private final ConfigurableFileCollection sources;
+	@Getter private final ConfigurableFileCollection privateHeaders;
+	@Getter private final SetProperty<TargetMachine> targetMachines;
+	@Getter private final SetProperty<TargetBuildType> targetBuildTypes;
+
 	@Inject
-	public DefaultObjectiveCApplicationExtension(DefaultNativeApplicationComponent component) {
-		super(component);
+	public DefaultObjectiveCApplicationExtension(DefaultNativeApplicationComponent component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
+		super(component, objects, providers, layout);
+		this.sources = objects.fileCollection();
+		this.privateHeaders = objects.fileCollection();
+		this.targetMachines = objects.setProperty(TargetMachine.class);
+		this.targetBuildTypes = objects.setProperty(TargetBuildType.class);
+
 		getComponent().getSourceCollection().add(getObjects().newInstance(ObjectiveCSourceSet.class, "objc").from(getSources().getElements().map(toIfEmpty("src/main/objc"))));
 		getComponent().getSourceCollection().add(getObjects().newInstance(CHeaderSet.class, "headers").srcDir(getPrivateHeaders().getElements().map(toIfEmpty("src/main/headers"))));
 	}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/DefaultObjectiveCLibraryExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/DefaultObjectiveCLibraryExtension.java
@@ -8,15 +8,38 @@ import dev.nokee.platform.nativebase.NativeLibraryComponentDependencies;
 import dev.nokee.platform.nativebase.internal.BaseNativeExtension;
 import dev.nokee.platform.nativebase.internal.DefaultNativeLibraryComponent;
 import dev.nokee.platform.objectivec.ObjectiveCLibraryExtension;
+import dev.nokee.runtime.nativebase.TargetBuildType;
+import dev.nokee.runtime.nativebase.TargetLinkage;
+import dev.nokee.runtime.nativebase.TargetMachine;
+import lombok.Getter;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.provider.SetProperty;
 
 import javax.inject.Inject;
 
-public abstract class DefaultObjectiveCLibraryExtension extends BaseNativeExtension<DefaultNativeLibraryComponent> implements ObjectiveCLibraryExtension {
+public class DefaultObjectiveCLibraryExtension extends BaseNativeExtension<DefaultNativeLibraryComponent> implements ObjectiveCLibraryExtension {
+	@Getter private final ConfigurableFileCollection sources;
+	@Getter private final ConfigurableFileCollection privateHeaders;
+	@Getter private final ConfigurableFileCollection publicHeaders;
+	@Getter private final SetProperty<TargetLinkage> targetLinkages;
+	@Getter private final SetProperty<TargetMachine> targetMachines;
+	@Getter private final SetProperty<TargetBuildType> targetBuildTypes;
+
 	@Inject
-	public DefaultObjectiveCLibraryExtension(DefaultNativeLibraryComponent component) {
-		super(component);
+	public DefaultObjectiveCLibraryExtension(DefaultNativeLibraryComponent component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
+		super(component, objects, providers, layout);
+		this.sources = objects.fileCollection();
+		this.privateHeaders = objects.fileCollection();
+		this.publicHeaders = objects.fileCollection();
+		this.targetLinkages = objects.setProperty(TargetLinkage.class);
+		this.targetMachines = objects.setProperty(TargetMachine.class);
+		this.targetBuildTypes = objects.setProperty(TargetBuildType.class);
+
 		getComponent().getSourceCollection().add(getObjects().newInstance(ObjectiveCSourceSet.class, "objc").from(getSources().getElements().map(toIfEmpty("src/main/objc"))));
 		getComponent().getSourceCollection().add(getObjects().newInstance(CHeaderSet.class, "headers").srcDir(getPrivateHeaders().getElements().map(toIfEmpty("src/main/headers"))));
 		getComponent().getSourceCollection().add(getObjects().newInstance(CHeaderSet.class, "public").srcDir(getPublicHeaders().getElements().map(toIfEmpty("src/main/public"))));

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCApplicationPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCApplicationPlugin.java
@@ -8,6 +8,8 @@ import dev.nokee.platform.nativebase.internal.TargetBuildTypeRule;
 import dev.nokee.platform.nativebase.internal.TargetMachineRule;
 import dev.nokee.platform.objectivec.ObjectiveCApplicationExtension;
 import dev.nokee.platform.objectivec.internal.DefaultObjectiveCApplicationExtension;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.val;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -16,11 +18,14 @@ import org.gradle.nativeplatform.toolchain.internal.plugins.StandardToolChainsPl
 
 import javax.inject.Inject;
 
-public abstract class ObjectiveCApplicationPlugin implements Plugin<Project> {
+public class ObjectiveCApplicationPlugin implements Plugin<Project> {
 	private static final String EXTENSION_NAME = "application";
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
 
 	@Inject
-	protected abstract ObjectFactory getObjects();
+	public ObjectiveCApplicationPlugin(ObjectFactory objects) {
+		this.objects = objects;
+	}
 
 	@Override
 	public void apply(Project project) {

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCLibraryPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCLibraryPlugin.java
@@ -9,6 +9,8 @@ import dev.nokee.platform.nativebase.internal.TargetLinkageRule;
 import dev.nokee.platform.nativebase.internal.TargetMachineRule;
 import dev.nokee.platform.objectivec.ObjectiveCLibraryExtension;
 import dev.nokee.platform.objectivec.internal.DefaultObjectiveCLibraryExtension;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.val;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -17,11 +19,14 @@ import org.gradle.nativeplatform.toolchain.internal.plugins.StandardToolChainsPl
 
 import javax.inject.Inject;
 
-public abstract class ObjectiveCLibraryPlugin implements Plugin<Project> {
+public class ObjectiveCLibraryPlugin implements Plugin<Project> {
 	private static final String EXTENSION_NAME = "library";
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
 
 	@Inject
-	protected abstract ObjectFactory getObjects();
+	public ObjectiveCLibraryPlugin(ObjectFactory objects) {
+		this.objects = objects;
+	}
 
 	@Override
 	public void apply(Project project) {

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/DefaultObjectiveCppApplicationExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/DefaultObjectiveCppApplicationExtension.java
@@ -8,15 +8,33 @@ import dev.nokee.platform.nativebase.NativeApplicationComponentDependencies;
 import dev.nokee.platform.nativebase.internal.BaseNativeExtension;
 import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
 import dev.nokee.platform.objectivecpp.ObjectiveCppApplicationExtension;
+import dev.nokee.runtime.nativebase.TargetBuildType;
+import dev.nokee.runtime.nativebase.TargetMachine;
+import lombok.Getter;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.provider.SetProperty;
 
 import javax.inject.Inject;
 
-public abstract class DefaultObjectiveCppApplicationExtension extends BaseNativeExtension<DefaultNativeApplicationComponent> implements ObjectiveCppApplicationExtension {
+public class DefaultObjectiveCppApplicationExtension extends BaseNativeExtension<DefaultNativeApplicationComponent> implements ObjectiveCppApplicationExtension {
+	@Getter private final ConfigurableFileCollection sources;
+	@Getter private final ConfigurableFileCollection privateHeaders;
+	@Getter private final SetProperty<TargetMachine> targetMachines;
+	@Getter private final SetProperty<TargetBuildType> targetBuildTypes;
+
 	@Inject
-	public DefaultObjectiveCppApplicationExtension(DefaultNativeApplicationComponent component) {
-		super(component);
+	public DefaultObjectiveCppApplicationExtension(DefaultNativeApplicationComponent component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
+		super(component, objects, providers, layout);
+		this.sources = objects.fileCollection();
+		this.privateHeaders = objects.fileCollection();
+		this.targetMachines = objects.setProperty(TargetMachine.class);
+		this.targetBuildTypes = objects.setProperty(TargetBuildType.class);
+
 		getComponent().getSourceCollection().add(getObjects().newInstance(ObjectiveCppSourceSet.class, "objcpp").from(getSources().getElements().map(toIfEmpty("src/main/objcpp"))));
 		getComponent().getSourceCollection().add(getObjects().newInstance(CppHeaderSet.class, "headers").srcDir(getPrivateHeaders().getElements().map(toIfEmpty("src/main/headers"))));
 	}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/DefaultObjectiveCppLibraryExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/DefaultObjectiveCppLibraryExtension.java
@@ -8,15 +8,38 @@ import dev.nokee.platform.nativebase.NativeLibraryComponentDependencies;
 import dev.nokee.platform.nativebase.internal.BaseNativeExtension;
 import dev.nokee.platform.nativebase.internal.DefaultNativeLibraryComponent;
 import dev.nokee.platform.objectivecpp.ObjectiveCppLibraryExtension;
+import dev.nokee.runtime.nativebase.TargetBuildType;
+import dev.nokee.runtime.nativebase.TargetLinkage;
+import dev.nokee.runtime.nativebase.TargetMachine;
+import lombok.Getter;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.provider.SetProperty;
 
 import javax.inject.Inject;
 
-public abstract class DefaultObjectiveCppLibraryExtension extends BaseNativeExtension<DefaultNativeLibraryComponent> implements ObjectiveCppLibraryExtension {
+public class DefaultObjectiveCppLibraryExtension extends BaseNativeExtension<DefaultNativeLibraryComponent> implements ObjectiveCppLibraryExtension {
+	@Getter private final ConfigurableFileCollection sources;
+	@Getter private final ConfigurableFileCollection privateHeaders;
+	@Getter private final ConfigurableFileCollection publicHeaders;
+	@Getter private final SetProperty<TargetLinkage> targetLinkages;
+	@Getter private final SetProperty<TargetMachine> targetMachines;
+	@Getter private final SetProperty<TargetBuildType> targetBuildTypes;
+
 	@Inject
-	public DefaultObjectiveCppLibraryExtension(DefaultNativeLibraryComponent component) {
-		super(component);
+	public DefaultObjectiveCppLibraryExtension(DefaultNativeLibraryComponent component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
+		super(component, objects, providers, layout);
+		this.sources = objects.fileCollection();
+		this.privateHeaders = objects.fileCollection();
+		this.publicHeaders = objects.fileCollection();
+		this.targetLinkages = objects.setProperty(TargetLinkage.class);
+		this.targetMachines = objects.setProperty(TargetMachine.class);
+		this.targetBuildTypes = objects.setProperty(TargetBuildType.class);
+
 		getComponent().getSourceCollection().add(getObjects().newInstance(ObjectiveCppSourceSet.class, "objcpp").from(getSources().getElements().map(toIfEmpty("src/main/objcpp"))));
 		getComponent().getSourceCollection().add(getObjects().newInstance(CppHeaderSet.class, "headers").srcDir(getPrivateHeaders().getElements().map(toIfEmpty("src/main/headers"))));
 		getComponent().getSourceCollection().add(getObjects().newInstance(CppHeaderSet.class, "public").srcDir(getPublicHeaders().getElements().map(toIfEmpty("src/main/public"))));

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/plugins/ObjectiveCppApplicationPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/plugins/ObjectiveCppApplicationPlugin.java
@@ -8,6 +8,8 @@ import dev.nokee.platform.nativebase.internal.TargetBuildTypeRule;
 import dev.nokee.platform.nativebase.internal.TargetMachineRule;
 import dev.nokee.platform.objectivecpp.ObjectiveCppApplicationExtension;
 import dev.nokee.platform.objectivecpp.internal.DefaultObjectiveCppApplicationExtension;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.val;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -16,11 +18,14 @@ import org.gradle.nativeplatform.toolchain.internal.plugins.StandardToolChainsPl
 
 import javax.inject.Inject;
 
-public abstract class ObjectiveCppApplicationPlugin implements Plugin<Project> {
+public class ObjectiveCppApplicationPlugin implements Plugin<Project> {
 	private static final String EXTENSION_NAME = "application";
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
 
 	@Inject
-	protected abstract ObjectFactory getObjects();
+	public ObjectiveCppApplicationPlugin(ObjectFactory objects) {
+		this.objects = objects;
+	}
 
 	@Override
 	public void apply(Project project) {

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/plugins/ObjectiveCppLibraryPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/plugins/ObjectiveCppLibraryPlugin.java
@@ -9,6 +9,8 @@ import dev.nokee.platform.nativebase.internal.TargetLinkageRule;
 import dev.nokee.platform.nativebase.internal.TargetMachineRule;
 import dev.nokee.platform.objectivecpp.ObjectiveCppLibraryExtension;
 import dev.nokee.platform.objectivecpp.internal.DefaultObjectiveCppLibraryExtension;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.val;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -17,11 +19,14 @@ import org.gradle.nativeplatform.toolchain.internal.plugins.StandardToolChainsPl
 
 import javax.inject.Inject;
 
-public abstract class ObjectiveCppLibraryPlugin implements Plugin<Project> {
+public class ObjectiveCppLibraryPlugin implements Plugin<Project> {
 	private static final String EXTENSION_NAME = "library";
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
 
 	@Inject
-	protected abstract ObjectFactory getObjects();
+	public ObjectiveCppLibraryPlugin(ObjectFactory objects) {
+		this.objects = objects;
+	}
 
 	@Override
 	public void apply(Project project) {

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/DefaultSwiftApplicationExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/DefaultSwiftApplicationExtension.java
@@ -7,15 +7,31 @@ import dev.nokee.platform.nativebase.NativeApplicationComponentDependencies;
 import dev.nokee.platform.nativebase.internal.BaseNativeExtension;
 import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
 import dev.nokee.platform.swift.SwiftApplicationExtension;
+import dev.nokee.runtime.nativebase.TargetBuildType;
+import dev.nokee.runtime.nativebase.TargetMachine;
+import lombok.Getter;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.provider.SetProperty;
 
 import javax.inject.Inject;
 
-public abstract class DefaultSwiftApplicationExtension extends BaseNativeExtension<DefaultNativeApplicationComponent> implements SwiftApplicationExtension {
+public class DefaultSwiftApplicationExtension extends BaseNativeExtension<DefaultNativeApplicationComponent> implements SwiftApplicationExtension {
+	@Getter private final ConfigurableFileCollection sources;
+	@Getter private final SetProperty<TargetMachine> targetMachines;
+	@Getter private final SetProperty<TargetBuildType> targetBuildTypes;
+
 	@Inject
-	public DefaultSwiftApplicationExtension(DefaultNativeApplicationComponent component) {
-		super(component);
+	public DefaultSwiftApplicationExtension(DefaultNativeApplicationComponent component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
+		super(component, objects, providers, layout);
+		this.sources = objects.fileCollection();
+		this.targetMachines = objects.setProperty(TargetMachine.class);
+		this.targetBuildTypes = objects.setProperty(TargetBuildType.class);
+
 		getComponent().getSourceCollection().add(getObjects().newInstance(SwiftSourceSet.class, "swift").from(getSources().getElements().map(toIfEmpty("src/main/swift"))));
 	}
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/DefaultSwiftLibraryExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/DefaultSwiftLibraryExtension.java
@@ -7,15 +7,34 @@ import dev.nokee.platform.nativebase.NativeLibraryComponentDependencies;
 import dev.nokee.platform.nativebase.internal.BaseNativeExtension;
 import dev.nokee.platform.nativebase.internal.DefaultNativeLibraryComponent;
 import dev.nokee.platform.swift.SwiftLibraryExtension;
+import dev.nokee.runtime.nativebase.TargetBuildType;
+import dev.nokee.runtime.nativebase.TargetLinkage;
+import dev.nokee.runtime.nativebase.TargetMachine;
+import lombok.Getter;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.provider.SetProperty;
 
 import javax.inject.Inject;
 
-public abstract class DefaultSwiftLibraryExtension extends BaseNativeExtension<DefaultNativeLibraryComponent> implements SwiftLibraryExtension {
+public class DefaultSwiftLibraryExtension extends BaseNativeExtension<DefaultNativeLibraryComponent> implements SwiftLibraryExtension {
+	@Getter private final ConfigurableFileCollection sources;
+	@Getter private final SetProperty<TargetLinkage> targetLinkages;
+	@Getter private final SetProperty<TargetMachine> targetMachines;
+	@Getter private final SetProperty<TargetBuildType> targetBuildTypes;
+
 	@Inject
-	public DefaultSwiftLibraryExtension(DefaultNativeLibraryComponent component) {
-		super(component);
+	public DefaultSwiftLibraryExtension(DefaultNativeLibraryComponent component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
+		super(component, objects, providers, layout);
+		this.sources = objects.fileCollection();
+		this.targetLinkages = objects.setProperty(TargetLinkage.class);
+		this.targetMachines = objects.setProperty(TargetMachine.class);
+		this.targetBuildTypes = objects.setProperty(TargetBuildType.class);
+
 		getComponent().getSourceCollection().add(getObjects().newInstance(SwiftSourceSet.class, "swift").from(getSources().getElements().map(toIfEmpty("src/main/swift"))));
 	}
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftApplicationPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftApplicationPlugin.java
@@ -8,6 +8,8 @@ import dev.nokee.platform.nativebase.internal.TargetBuildTypeRule;
 import dev.nokee.platform.nativebase.internal.TargetMachineRule;
 import dev.nokee.platform.swift.SwiftApplicationExtension;
 import dev.nokee.platform.swift.internal.DefaultSwiftApplicationExtension;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.val;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -17,11 +19,14 @@ import org.gradle.util.GUtil;
 
 import javax.inject.Inject;
 
-public abstract class SwiftApplicationPlugin implements Plugin<Project> {
+public class SwiftApplicationPlugin implements Plugin<Project> {
 	private static final String EXTENSION_NAME = "application";
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
 
 	@Inject
-	protected abstract ObjectFactory getObjects();
+	public SwiftApplicationPlugin(ObjectFactory objects) {
+		this.objects = objects;
+	}
 
 	@Override
 	public void apply(Project project) {

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftLibraryPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftLibraryPlugin.java
@@ -9,6 +9,8 @@ import dev.nokee.platform.nativebase.internal.TargetLinkageRule;
 import dev.nokee.platform.nativebase.internal.TargetMachineRule;
 import dev.nokee.platform.swift.SwiftLibraryExtension;
 import dev.nokee.platform.swift.internal.DefaultSwiftLibraryExtension;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.val;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -18,11 +20,14 @@ import org.gradle.util.GUtil;
 
 import javax.inject.Inject;
 
-public abstract class SwiftLibraryPlugin implements Plugin<Project> {
+public class SwiftLibraryPlugin implements Plugin<Project> {
 	private static final String EXTENSION_NAME = "library";
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
 
 	@Inject
-	protected abstract ObjectFactory getObjects();
+	public SwiftLibraryPlugin(ObjectFactory objects) {
+		this.objects = objects;
+	}
 
 	@Override
 	public void apply(Project project) {

--- a/subprojects/runtime-base/src/main/java/dev/nokee/runtime/base/internal/plugins/FakeMavenRepositoryPlugin.java
+++ b/subprojects/runtime-base/src/main/java/dev/nokee/runtime/base/internal/plugins/FakeMavenRepositoryPlugin.java
@@ -9,7 +9,7 @@ import org.gradle.api.provider.Provider;
 
 import static dev.nokee.runtime.base.internal.repositories.NokeeServerService.NOKEE_LOCAL_REPOSITORY_NAME;
 
-public abstract class FakeMavenRepositoryPlugin implements Plugin<Project> {
+public class FakeMavenRepositoryPlugin implements Plugin<Project> {
 	public static final String NOKEE_SERVER_SERVICE_NAME = "nokeeServer";
 
 	@Override

--- a/subprojects/runtime-base/src/main/java/dev/nokee/runtime/base/internal/plugins/ToolResolutionBasePlugin.java
+++ b/subprojects/runtime-base/src/main/java/dev/nokee/runtime/base/internal/plugins/ToolResolutionBasePlugin.java
@@ -9,7 +9,7 @@ import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import static dev.nokee.runtime.base.internal.plugins.FakeMavenRepositoryPlugin.NOKEE_SERVER_SERVICE_NAME;
 import static dev.nokee.runtime.base.internal.repositories.NokeeServerService.NOKEE_LOCAL_REPOSITORY_NAME;
 
-public abstract class ToolResolutionBasePlugin implements Plugin<Project> {
+public class ToolResolutionBasePlugin implements Plugin<Project> {
 	@Override
 	public void apply(Project project) {
 		project.getPluginManager().apply(FakeMavenRepositoryPlugin.class);

--- a/subprojects/runtime-base/src/main/java/dev/nokee/runtime/base/internal/repositories/NokeeServerService.java
+++ b/subprojects/runtime-base/src/main/java/dev/nokee/runtime/base/internal/repositories/NokeeServerService.java
@@ -2,6 +2,8 @@ package dev.nokee.runtime.base.internal.repositories;
 
 import dev.nokee.runtime.base.internal.tools.CommandLineToolLocator;
 import dev.nokee.runtime.base.internal.tools.ToolRepository;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.SneakyThrows;
 import org.eclipse.jetty.server.Server;
 import org.gradle.api.model.ObjectFactory;
@@ -22,9 +24,11 @@ public abstract class NokeeServerService implements BuildService<NokeeServerServ
 	private static final Logger LOGGER = Logger.getLogger(NokeeServerService.class.getName());
 	private final Object lock = new Object();
 	private final Server server;
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
 
 	@Inject
-	public NokeeServerService() {
+	public NokeeServerService(ObjectFactory objects) {
+		this.objects = objects;
 		ToolRepository toolRepository = newToolRepository();
 		Map<String, RouteHandler> routeMapping = getParameters().getRouteHandlers().get().stream().map(it -> getObjects().newInstance(toClass(AbstractRouteHandler.class, it), toolRepository)).collect(Collectors.toMap(NokeeServerService::getContextPath, Function.identity()));
 
@@ -69,9 +73,6 @@ public abstract class NokeeServerService implements BuildService<NokeeServerServ
 			throw new RuntimeException(e);
 		}
 	}
-
-	@Inject
-	protected abstract ObjectFactory getObjects();
 
 	@SneakyThrows
 	public URI getUri() {

--- a/subprojects/runtime-darwin/src/main/java/dev/nokee/runtime/darwin/internal/plugins/DarwinFrameworkResolutionSupportPlugin.java
+++ b/subprojects/runtime-darwin/src/main/java/dev/nokee/runtime/darwin/internal/plugins/DarwinFrameworkResolutionSupportPlugin.java
@@ -5,6 +5,8 @@ import dev.nokee.runtime.base.internal.repositories.NokeeServerService;
 import dev.nokee.runtime.darwin.internal.FrameworkRouteHandler;
 import dev.nokee.runtime.darwin.internal.locators.XcodebuildLocator;
 import dev.nokee.runtime.darwin.internal.locators.XcrunLocator;
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.gradle.api.Plugin;
@@ -36,11 +38,14 @@ import static dev.nokee.runtime.nativebase.internal.ArtifactTypes.ARTIFACT_TYPES
 import static dev.nokee.runtime.nativebase.internal.ArtifactTypes.FRAMEWORK_TYPE;
 import static dev.nokee.runtime.nativebase.internal.LibraryElements.FRAMEWORK_BUNDLE;
 
-public abstract class DarwinFrameworkResolutionSupportPlugin implements Plugin<Project> {
+public class DarwinFrameworkResolutionSupportPlugin implements Plugin<Project> {
 	private static final Logger LOGGER = Logging.getLogger(DarwinFrameworkResolutionSupportPlugin.class);
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
 
 	@Inject
-	protected abstract ObjectFactory getObjects();
+	public DarwinFrameworkResolutionSupportPlugin(ObjectFactory objects) {
+		this.objects = objects;
+	}
 
 	@Override
 	public void apply(Project project) {

--- a/subprojects/runtime-darwin/src/main/java/dev/nokee/runtime/darwin/internal/plugins/DarwinRuntimePlugin.java
+++ b/subprojects/runtime-darwin/src/main/java/dev/nokee/runtime/darwin/internal/plugins/DarwinRuntimePlugin.java
@@ -3,7 +3,7 @@ package dev.nokee.runtime.darwin.internal.plugins;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
-public abstract class DarwinRuntimePlugin implements Plugin<Project> {
+public class DarwinRuntimePlugin implements Plugin<Project> {
 	@Override
 	public void apply(Project project) {
 		project.getPluginManager().apply(DarwinToolLocatorSupportPlugin.class);

--- a/subprojects/runtime-darwin/src/main/java/dev/nokee/runtime/darwin/internal/plugins/DarwinToolLocatorSupportPlugin.java
+++ b/subprojects/runtime-darwin/src/main/java/dev/nokee/runtime/darwin/internal/plugins/DarwinToolLocatorSupportPlugin.java
@@ -8,7 +8,7 @@ import org.gradle.api.Project;
 
 import static dev.nokee.runtime.base.internal.plugins.FakeMavenRepositoryPlugin.NOKEE_SERVER_SERVICE_NAME;
 
-public abstract class DarwinToolLocatorSupportPlugin implements Plugin<Project> {
+public class DarwinToolLocatorSupportPlugin implements Plugin<Project> {
 	@Override
 	public void apply(Project project) {
 		project.getPluginManager().apply(ToolResolutionBasePlugin.class);

--- a/subprojects/testing-base/src/main/java/dev/nokee/testing/base/internal/DefaultTestSuiteContainer.java
+++ b/subprojects/testing-base/src/main/java/dev/nokee/testing/base/internal/DefaultTestSuiteContainer.java
@@ -12,6 +12,7 @@ import groovy.lang.Closure;
 import lombok.val;
 import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectFactory;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.internal.metaobject.*;
 import org.gradle.util.ConfigureUtil;
 
@@ -19,13 +20,13 @@ import javax.inject.Inject;
 import java.util.HashMap;
 import java.util.Map;
 
-public abstract class DefaultTestSuiteContainer extends AbstractDomainObjectContainer<TestSuiteComponent> implements TestSuiteContainer, MethodMixIn {
+public class DefaultTestSuiteContainer extends AbstractDomainObjectContainer<TestSuiteComponent> implements TestSuiteContainer, MethodMixIn {
 	private final Map<Class<?>, NamedDomainObjectFactory<?>> bindings = new HashMap<>();
 	private final Map<Class<?>, Class<?>> implementationTypes = new HashMap<>();
 
 	@Inject
-	public DefaultTestSuiteContainer(DomainObjectStore store) {
-		super(TestSuiteComponent.class, store);
+	public DefaultTestSuiteContainer(DomainObjectStore store, ObjectFactory objectFactory) {
+		super(TestSuiteComponent.class, store, objectFactory);
 	}
 
 	public <U extends TestSuiteComponent> void registerFactory(Class<U> type, Class<? extends U> implementationType, NamedDomainObjectFactory<U> factory) {

--- a/subprojects/testing-base/src/main/java/dev/nokee/testing/base/internal/plugins/TestingBasePlugin.java
+++ b/subprojects/testing-base/src/main/java/dev/nokee/testing/base/internal/plugins/TestingBasePlugin.java
@@ -5,6 +5,8 @@ import dev.nokee.platform.base.internal.DomainObjectStore;
 import dev.nokee.platform.base.internal.plugins.ProjectStorePlugin;
 import dev.nokee.testing.base.TestSuiteContainer;
 import dev.nokee.testing.base.internal.DefaultTestSuiteContainer;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.val;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -13,7 +15,16 @@ import org.gradle.api.tasks.TaskContainer;
 
 import javax.inject.Inject;
 
-public abstract class TestingBasePlugin implements Plugin<Project> {
+public class TestingBasePlugin implements Plugin<Project> {
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
+	@Getter(AccessLevel.PROTECTED) private final TaskContainer tasks;
+
+	@Inject
+	public TestingBasePlugin(ObjectFactory objects, TaskContainer tasks) {
+		this.objects = objects;
+		this.tasks = tasks;
+	}
+
 	@Override
 	public void apply(Project project) {
 		project.getPluginManager().apply(ProjectStorePlugin.class);
@@ -21,10 +32,4 @@ public abstract class TestingBasePlugin implements Plugin<Project> {
 		val extension = getObjects().newInstance(DefaultTestSuiteContainer.class, store);
 		project.getExtensions().add(TestSuiteContainer.class, "testSuites", extension);
 	}
-
-	@Inject
-	protected abstract ObjectFactory getObjects();
-
-	@Inject
-	protected abstract TaskContainer getTasks();
 }

--- a/subprojects/testing-base/src/test/groovy/dev/nokee/testing/base/internal/DefaultTestSuiteContainerTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/dev/nokee/testing/base/internal/DefaultTestSuiteContainerTest.groovy
@@ -8,7 +8,7 @@ import spock.lang.Specification
 
 class DefaultTestSuiteContainerTest extends Specification {
 	def objects = ProjectBuilder.builder().build().objects
-	def store = objects.newInstance(DefaultDomainObjectStore)
+	def store = objects.newInstance(DefaultDomainObjectStore, )
 	def containerUnderTest
 
 	def setup() {

--- a/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteComponent.java
+++ b/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteComponent.java
@@ -70,7 +70,7 @@ public class DefaultNativeTestSuiteComponent extends BaseNativeComponent<Default
 		val dependencyContainer = objects.newInstance(DefaultComponentDependencies.class, names.getComponentDisplayName(), new FrameworkAwareDependencyBucketFactory(new DefaultDependencyBucketFactory(new ConfigurationFactories.Prefixing(new ConfigurationFactories.Creating(getConfigurations()), names::getConfigurationName), new DefaultDependencyFactory(getDependencyHandler()))));
 		this.dependencies = objects.newInstance(DefaultNativeComponentDependencies.class, dependencyContainer);
 		this.testedComponent = Cast.uncheckedCast(getObjects().property(BaseComponent.class));
-		this.getDimensions().convention(ImmutableList.of(DefaultOperatingSystemFamily.DIMENSION_TYPE, DefaultBinaryLinkage.DIMENSION_TYPE, DefaultMachineArchitecture.DIMENSION_TYPE));
+		this.getDimensions().convention(ImmutableList.of(DefaultBinaryLinkage.DIMENSION_TYPE, DefaultOperatingSystemFamily.DIMENSION_TYPE, DefaultMachineArchitecture.DIMENSION_TYPE));
 		this.getBaseName().convention(names.getBaseName().getAsString());
 
 		this.getBuildVariants().convention(getProviders().provider(this::createBuildVariants));

--- a/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteComponent.java
+++ b/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteComponent.java
@@ -9,9 +9,14 @@ import dev.nokee.language.nativebase.internal.UTTypeObjectCode;
 import dev.nokee.language.nativebase.tasks.internal.NativeSourceCompileTask;
 import dev.nokee.language.swift.internal.SwiftSourceSet;
 import dev.nokee.language.swift.tasks.internal.SwiftCompileTask;
-import dev.nokee.platform.base.Variant;
-import dev.nokee.platform.base.internal.*;
-import dev.nokee.platform.base.internal.dependencies.*;
+import dev.nokee.platform.base.internal.BaseComponent;
+import dev.nokee.platform.base.internal.BuildVariantInternal;
+import dev.nokee.platform.base.internal.DefaultBuildVariant;
+import dev.nokee.platform.base.internal.NamingScheme;
+import dev.nokee.platform.base.internal.dependencies.ConfigurationFactories;
+import dev.nokee.platform.base.internal.dependencies.DefaultComponentDependencies;
+import dev.nokee.platform.base.internal.dependencies.DefaultDependencyBucketFactory;
+import dev.nokee.platform.base.internal.dependencies.DefaultDependencyFactory;
 import dev.nokee.platform.nativebase.ExecutableBinary;
 import dev.nokee.platform.nativebase.NativeBinary;
 import dev.nokee.platform.nativebase.NativeComponentDependencies;
@@ -21,23 +26,29 @@ import dev.nokee.platform.nativebase.tasks.LinkExecutable;
 import dev.nokee.platform.nativebase.tasks.internal.LinkExecutableTask;
 import dev.nokee.runtime.nativebase.internal.DefaultMachineArchitecture;
 import dev.nokee.runtime.nativebase.internal.DefaultOperatingSystemFamily;
-import dev.nokee.runtime.nativebase.internal.DefaultTargetMachine;
 import dev.nokee.testing.base.TestSuiteComponent;
 import dev.nokee.testing.nativebase.NativeTestSuite;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.val;
 import lombok.var;
 import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileTree;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.tasks.TaskContainer;
+import org.gradle.internal.Cast;
 import org.gradle.language.nativeplatform.tasks.AbstractNativeSourceCompileTask;
 import org.gradle.language.nativeplatform.tasks.UnexportMainSymbol;
 import org.gradle.language.swift.tasks.SwiftCompile;
-import org.gradle.launcher.daemon.protocol.Build;
 import org.gradle.nativeplatform.test.tasks.RunTestExecutable;
 
 import javax.inject.Inject;
@@ -46,16 +57,20 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
-public abstract class DefaultNativeTestSuiteComponent extends BaseNativeComponent<DefaultNativeTestSuiteVariant> implements NativeTestSuite {
+public class DefaultNativeTestSuiteComponent extends BaseNativeComponent<DefaultNativeTestSuiteVariant> implements NativeTestSuite {
 	private final DefaultNativeComponentDependencies dependencies;
+	@Getter(AccessLevel.PROTECTED) private final DependencyHandler dependencyHandler;
+	@Getter Property<BaseComponent<?>> testedComponent;
 
 	@Inject
-	public DefaultNativeTestSuiteComponent(NamingScheme names) {
-		super(names, DefaultNativeTestSuiteVariant.class);
+	public DefaultNativeTestSuiteComponent(NamingScheme names, ObjectFactory objects, ProviderFactory providers, TaskContainer tasks, ProjectLayout layout, ConfigurationContainer configurations, DependencyHandler dependencyHandler) {
+		super(names, DefaultNativeTestSuiteVariant.class, objects, providers, tasks, layout, configurations);
+		this.dependencyHandler = dependencyHandler;
 
-		val dependencyContainer = getObjects().newInstance(DefaultComponentDependencies.class, names.getComponentDisplayName(), new FrameworkAwareDependencyBucketFactory(new DefaultDependencyBucketFactory(new ConfigurationFactories.Prefixing(new ConfigurationFactories.Creating(getConfigurations()), names::getConfigurationName), new DefaultDependencyFactory(getDependencyHandler()))));
-		this.dependencies = getObjects().newInstance(DefaultNativeComponentDependencies.class, dependencyContainer);
-		this.getDimensions().convention(ImmutableList.of(DefaultOperatingSystemFamily.DIMENSION_TYPE, DefaultBinaryLinkage.DIMENSION_TYPE, DefaultMachineArchitecture.DIMENSION_TYPE, BaseTargetBuildType.DIMENSION_TYPE));
+		val dependencyContainer = objects.newInstance(DefaultComponentDependencies.class, names.getComponentDisplayName(), new FrameworkAwareDependencyBucketFactory(new DefaultDependencyBucketFactory(new ConfigurationFactories.Prefixing(new ConfigurationFactories.Creating(getConfigurations()), names::getConfigurationName), new DefaultDependencyFactory(getDependencyHandler()))));
+		this.dependencies = objects.newInstance(DefaultNativeComponentDependencies.class, dependencyContainer);
+		this.testedComponent = Cast.uncheckedCast(getObjects().property(BaseComponent.class));
+		this.getDimensions().convention(ImmutableList.of(DefaultOperatingSystemFamily.DIMENSION_TYPE, DefaultBinaryLinkage.DIMENSION_TYPE, DefaultMachineArchitecture.DIMENSION_TYPE));
 		this.getBaseName().convention(names.getBaseName().getAsString());
 
 		this.getBuildVariants().convention(getProviders().provider(this::createBuildVariants));
@@ -64,9 +79,6 @@ public abstract class DefaultNativeTestSuiteComponent extends BaseNativeComponen
 
 		this.getDimensions().disallowChanges(); // Let's disallow changing them for now.
 	}
-
-	@Inject
-	protected abstract DependencyHandler getDependencyHandler();
 
 	@Override
 	public String getName() {
@@ -135,8 +147,6 @@ public abstract class DefaultNativeTestSuiteComponent extends BaseNativeComponen
 		val result = getObjects().newInstance(DefaultNativeTestSuiteVariant.class, name, names, buildVariant, variantDependencies);
 		return result;
 	}
-
-	public abstract Property<BaseComponent<?>> getTestedComponent();
 
 	@Override
 	public TestSuiteComponent testedComponent(Object component) {

--- a/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteVariant.java
+++ b/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteVariant.java
@@ -5,12 +5,15 @@ import dev.nokee.platform.base.internal.NamingScheme;
 import dev.nokee.platform.nativebase.internal.BaseNativeVariant;
 import dev.nokee.platform.nativebase.internal.dependencies.VariantComponentDependencies;
 import dev.nokee.testing.nativebase.NativeTestSuiteVariant;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.tasks.TaskContainer;
 
 import javax.inject.Inject;
 
-public abstract class DefaultNativeTestSuiteVariant extends BaseNativeVariant implements NativeTestSuiteVariant {
+public class DefaultNativeTestSuiteVariant extends BaseNativeVariant implements NativeTestSuiteVariant {
 	@Inject
-	public DefaultNativeTestSuiteVariant(String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<?> variantDependencies) {
-		super(name, names, buildVariant);
+	public DefaultNativeTestSuiteVariant(String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<?> variantDependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
+		super(name, names, buildVariant, objects, tasks, providers);
 	}
 }

--- a/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/plugins/NativeUnitTestingPlugin.java
+++ b/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/plugins/NativeUnitTestingPlugin.java
@@ -11,6 +11,8 @@ import dev.nokee.testing.base.internal.DefaultTestSuiteContainer;
 import dev.nokee.testing.base.internal.plugins.TestingBasePlugin;
 import dev.nokee.testing.nativebase.NativeTestSuite;
 import dev.nokee.testing.nativebase.internal.DefaultNativeTestSuiteComponent;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.val;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -19,7 +21,16 @@ import org.gradle.api.tasks.TaskContainer;
 
 import javax.inject.Inject;
 
-public abstract class NativeUnitTestingPlugin implements Plugin<Project> {
+public class NativeUnitTestingPlugin implements Plugin<Project> {
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
+	@Getter(AccessLevel.PROTECTED) private final TaskContainer tasks;
+
+	@Inject
+	public NativeUnitTestingPlugin(ObjectFactory objects, TaskContainer tasks) {
+		this.objects = objects;
+		this.tasks = tasks;
+	}
+
 	@Override
 	public void apply(Project project) {
 		project.getPluginManager().apply("lifecycle-base");
@@ -55,12 +66,6 @@ public abstract class NativeUnitTestingPlugin implements Plugin<Project> {
 			extension.forceRealize();
 		});
 	}
-
-	@Inject
-	protected abstract ObjectFactory getObjects();
-
-	@Inject
-	protected abstract TaskContainer getTasks();
 
 	private NativeTestSuite createNativeTestSuite(String name) {
 		return getObjects().newInstance(DefaultNativeTestSuiteComponent.class, NamingScheme.asComponent(name, name).withComponentDisplayName("Test Suite"));

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultUiTestXCTestTestSuiteComponent.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultUiTestXCTestTestSuiteComponent.java
@@ -14,8 +14,13 @@ import dev.nokee.testing.xctest.tasks.internal.CreateIosXCTestBundleTask;
 import lombok.val;
 import org.apache.commons.io.IOUtils;
 import org.gradle.api.Task;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 
 import javax.inject.Inject;
@@ -25,10 +30,10 @@ import java.nio.charset.Charset;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public abstract class DefaultUiTestXCTestTestSuiteComponent extends BaseXCTestTestSuiteComponent implements Component {
+public class DefaultUiTestXCTestTestSuiteComponent extends BaseXCTestTestSuiteComponent implements Component {
 	@Inject
-	public DefaultUiTestXCTestTestSuiteComponent(NamingScheme names) {
-		super(names);
+	public DefaultUiTestXCTestTestSuiteComponent(NamingScheme names, ObjectFactory objects, ProviderFactory providers, TaskContainer tasks, ProjectLayout layout, ConfigurationContainer configurations, DependencyHandler dependencyHandler) {
+		super(names, objects, providers, tasks, layout, configurations, dependencyHandler);
 	}
 
 	@Override

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultUnitTestXCTestTestSuiteComponent.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultUnitTestXCTestTestSuiteComponent.java
@@ -15,8 +15,13 @@ import dev.nokee.testing.xctest.tasks.internal.CreateIosXCTestBundleTask;
 import lombok.val;
 import org.apache.commons.io.IOUtils;
 import org.gradle.api.Task;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 
 import javax.inject.Inject;
@@ -26,11 +31,10 @@ import java.nio.charset.Charset;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public abstract class DefaultUnitTestXCTestTestSuiteComponent extends BaseXCTestTestSuiteComponent implements Component {
-
+public class DefaultUnitTestXCTestTestSuiteComponent extends BaseXCTestTestSuiteComponent implements Component {
 	@Inject
-	public DefaultUnitTestXCTestTestSuiteComponent(NamingScheme names) {
-		super(names);
+	public DefaultUnitTestXCTestTestSuiteComponent(NamingScheme names, ObjectFactory objects, ProviderFactory providers, TaskContainer tasks, ProjectLayout layout, ConfigurationContainer configurations, DependencyHandler dependencyHandler) {
+		super(names, objects, providers, tasks, layout, configurations, dependencyHandler);
 	}
 
 	@Override

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultXCTestTestSuiteVariant.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultXCTestTestSuiteVariant.java
@@ -11,17 +11,20 @@ import dev.nokee.platform.nativebase.internal.BaseNativeVariant;
 import dev.nokee.platform.nativebase.internal.dependencies.DefaultNativeComponentDependencies;
 import dev.nokee.platform.nativebase.internal.dependencies.VariantComponentDependencies;
 import org.gradle.api.Action;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.tasks.TaskContainer;
 
 import javax.inject.Inject;
 import java.util.List;
 
-public abstract class DefaultXCTestTestSuiteVariant extends BaseNativeVariant implements IosApplication {
+public class DefaultXCTestTestSuiteVariant extends BaseNativeVariant implements IosApplication {
 	private final DefaultNativeComponentDependencies dependencies;
 
 	@Inject
-	public DefaultXCTestTestSuiteVariant(String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<DefaultNativeComponentDependencies> dependencies) {
-		super(name, names, buildVariant);
+	public DefaultXCTestTestSuiteVariant(String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<DefaultNativeComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
+		super(name, names, buildVariant, objects, tasks, providers);
 		this.dependencies = dependencies.getDependencies();
 	}
 

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/plugins/ObjectiveCXCTestTestSuitePlugin.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/plugins/ObjectiveCXCTestTestSuitePlugin.java
@@ -10,6 +10,8 @@ import dev.nokee.platform.ios.internal.DefaultObjectiveCIosApplicationExtension;
 import dev.nokee.platform.nativebase.internal.BaseNativeComponent;
 import dev.nokee.testing.xctest.internal.DefaultUiTestXCTestTestSuiteComponent;
 import dev.nokee.testing.xctest.internal.DefaultUnitTestXCTestTestSuiteComponent;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.val;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -20,19 +22,19 @@ import org.gradle.api.tasks.TaskContainer;
 
 import javax.inject.Inject;
 
-public abstract class ObjectiveCXCTestTestSuitePlugin implements Plugin<Project> {
+public class ObjectiveCXCTestTestSuitePlugin implements Plugin<Project> {
+	@Getter(AccessLevel.PROTECTED) private final TaskContainer tasks;
+	@Getter(AccessLevel.PROTECTED) private final ProjectLayout layout;
+	@Getter(AccessLevel.PROTECTED) private final ProviderFactory providers;
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
 
 	@Inject
-	protected abstract TaskContainer getTasks();
-
-	@Inject
-	protected abstract ProjectLayout getLayout();
-
-	@Inject
-	protected abstract ProviderFactory getProviders();
-
-	@Inject
-	protected abstract ObjectFactory getObjects();
+	public ObjectiveCXCTestTestSuitePlugin(TaskContainer tasks, ProjectLayout layout, ProviderFactory providers, ObjectFactory objects) {
+		this.tasks = tasks;
+		this.layout = layout;
+		this.providers = providers;
+		this.objects = objects;
+	}
 
 	@Override
 	public void apply(Project project) {

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/tasks/internal/CreateIosXCTestBundleTask.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/tasks/internal/CreateIosXCTestBundleTask.java
@@ -1,9 +1,12 @@
 package dev.nokee.testing.xctest.tasks.internal;
 
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.file.FileSystemOperations;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputDirectory;
@@ -11,15 +14,27 @@ import org.gradle.api.tasks.TaskAction;
 
 import javax.inject.Inject;
 
-public abstract class CreateIosXCTestBundleTask extends DefaultTask {
+public class CreateIosXCTestBundleTask extends DefaultTask {
+	private final Property<FileSystemLocation> xCTestBundle;
+	private final ConfigurableFileCollection sources;
+	@Getter(value=AccessLevel.PROTECTED, onMethod_={@Inject}) private final FileSystemOperations fileOperations;
+
 	@OutputDirectory
-	public abstract Property<FileSystemLocation> getXCTestBundle();
+	public Property<FileSystemLocation> getXCTestBundle() {
+		return xCTestBundle;
+	}
 
 	@InputFiles
-	public abstract ConfigurableFileCollection getSources();
+	public ConfigurableFileCollection getSources() {
+		return sources;
+	}
 
 	@Inject
-	protected abstract FileSystemOperations getFileOperations();
+	public CreateIosXCTestBundleTask(ObjectFactory objects, FileSystemOperations fileOperations) {
+		this.xCTestBundle = objects.property(FileSystemLocation.class);
+		this.sources = objects.fileCollection();
+		this.fileOperations = fileOperations;
+	}
 
 	@TaskAction
 	private void create() {


### PR DESCRIPTION
The reason for ungradlefying the codebase is flexibility. Gradle
provides some conveniences to the plugin authors but those are either
limited, imcomplete, or too rigid for our need. We are left to manually
implements everything as the "Gradle-way" is just different enough to be
incompatible with other framework such as Dagger which we will be
adopting. Going forward, we are going to engineer Nokee using common
software engineering practice instead of using the opinionated Gradle
practice. All this work will be in sync with Gradle idiomatic way of
developing with Gradle meaning it should not affect performance,
usability and DSL compatibility.