### PR TITLE
A bunch of refactoring to break down the base component mess

### DIFF
--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/DomainObjectIdentifierInternal.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/DomainObjectIdentifierInternal.java
@@ -1,0 +1,9 @@
+package dev.nokee.model.internal;
+
+import dev.nokee.model.DomainObjectIdentifier;
+
+import java.util.Optional;
+
+public interface DomainObjectIdentifierInternal extends DomainObjectIdentifier {
+	Optional<? extends DomainObjectIdentifierInternal> getParentIdentifier();
+}

--- a/subprojects/language-native/src/main/java/dev/nokee/language/c/internal/CHeaderSet.java
+++ b/subprojects/language-native/src/main/java/dev/nokee/language/c/internal/CHeaderSet.java
@@ -2,14 +2,15 @@ package dev.nokee.language.c.internal;
 
 import dev.nokee.language.base.internal.BaseSourceSet;
 import dev.nokee.language.nativebase.internal.HeaderExportingSourceSet;
+import org.gradle.api.model.ObjectFactory;
 
 import javax.inject.Inject;
 import java.io.File;
 
-public abstract class CHeaderSet extends BaseSourceSet implements HeaderExportingSourceSet {
+public class CHeaderSet extends BaseSourceSet implements HeaderExportingSourceSet {
 	@Inject
-	public CHeaderSet(String name) {
-		super(name, UTTypeCHeader.INSTANCE);
+	public CHeaderSet(String name, ObjectFactory objectFactory) {
+		super(name, UTTypeCHeader.INSTANCE, objectFactory);
 		sources.setFrom(getSourceDirectorySet().getSourceDirectories());
 	}
 

--- a/subprojects/language-native/src/main/java/dev/nokee/language/c/internal/CSourceSet.java
+++ b/subprojects/language-native/src/main/java/dev/nokee/language/c/internal/CSourceSet.java
@@ -2,12 +2,13 @@ package dev.nokee.language.c.internal;
 
 import dev.nokee.language.base.internal.BaseSourceSet;
 import dev.nokee.language.nativebase.internal.HeaderExportingSourceSet;
+import org.gradle.api.model.ObjectFactory;
 
 import javax.inject.Inject;
 
-public abstract class CSourceSet extends BaseSourceSet implements HeaderExportingSourceSet {
+public class CSourceSet extends BaseSourceSet implements HeaderExportingSourceSet {
 	@Inject
-	public CSourceSet(String name) {
-		super(name, UTTypeCSource.INSTANCE);
+	public CSourceSet(String name, ObjectFactory objectFactory) {
+		super(name, UTTypeCSource.INSTANCE, objectFactory);
 	}
 }

--- a/subprojects/language-native/src/main/java/dev/nokee/language/cpp/internal/CppHeaderSet.java
+++ b/subprojects/language-native/src/main/java/dev/nokee/language/cpp/internal/CppHeaderSet.java
@@ -2,14 +2,15 @@ package dev.nokee.language.cpp.internal;
 
 import dev.nokee.language.base.internal.BaseSourceSet;
 import dev.nokee.language.nativebase.internal.HeaderExportingSourceSet;
+import org.gradle.api.model.ObjectFactory;
 
 import javax.inject.Inject;
 import java.io.File;
 
-public abstract class CppHeaderSet extends BaseSourceSet implements HeaderExportingSourceSet {
+public class CppHeaderSet extends BaseSourceSet implements HeaderExportingSourceSet {
 	@Inject
-	public CppHeaderSet(String name) {
-		super(name, UTTypeCppHeader.INSTANCE);
+	public CppHeaderSet(String name, ObjectFactory objectFactory) {
+		super(name, UTTypeCppHeader.INSTANCE, objectFactory);
 		sources.setFrom(getSourceDirectorySet().getSourceDirectories());
 	}
 

--- a/subprojects/language-native/src/main/java/dev/nokee/language/cpp/internal/CppSourceSet.java
+++ b/subprojects/language-native/src/main/java/dev/nokee/language/cpp/internal/CppSourceSet.java
@@ -2,12 +2,13 @@ package dev.nokee.language.cpp.internal;
 
 import dev.nokee.language.base.internal.BaseSourceSet;
 import dev.nokee.language.nativebase.internal.HeaderExportingSourceSet;
+import org.gradle.api.model.ObjectFactory;
 
 import javax.inject.Inject;
 
-public abstract class CppSourceSet extends BaseSourceSet implements HeaderExportingSourceSet {
+public class CppSourceSet extends BaseSourceSet implements HeaderExportingSourceSet {
 	@Inject
-	public CppSourceSet(String name) {
-		super(name, UTTypeCppSource.INSTANCE);
+	public CppSourceSet(String name, ObjectFactory objectFactory) {
+		super(name, UTTypeCppSource.INSTANCE, objectFactory);
 	}
 }

--- a/subprojects/language-native/src/main/java/dev/nokee/language/objectivec/internal/ObjectiveCSourceSet.java
+++ b/subprojects/language-native/src/main/java/dev/nokee/language/objectivec/internal/ObjectiveCSourceSet.java
@@ -2,12 +2,13 @@ package dev.nokee.language.objectivec.internal;
 
 import dev.nokee.language.base.internal.BaseSourceSet;
 import dev.nokee.language.nativebase.internal.HeaderExportingSourceSet;
+import org.gradle.api.model.ObjectFactory;
 
 import javax.inject.Inject;
 
-public abstract class ObjectiveCSourceSet extends BaseSourceSet implements HeaderExportingSourceSet {
+public class ObjectiveCSourceSet extends BaseSourceSet implements HeaderExportingSourceSet {
 	@Inject
-	public ObjectiveCSourceSet(String name) {
-		super(name, UTTypeObjectiveCSource.INSTANCE);
+	public ObjectiveCSourceSet(String name, ObjectFactory objectFactory) {
+		super(name, UTTypeObjectiveCSource.INSTANCE, objectFactory);
 	}
 }

--- a/subprojects/language-native/src/main/java/dev/nokee/language/objectivecpp/internal/ObjectiveCppSourceSet.java
+++ b/subprojects/language-native/src/main/java/dev/nokee/language/objectivecpp/internal/ObjectiveCppSourceSet.java
@@ -2,12 +2,13 @@ package dev.nokee.language.objectivecpp.internal;
 
 import dev.nokee.language.base.internal.BaseSourceSet;
 import dev.nokee.language.nativebase.internal.HeaderExportingSourceSet;
+import org.gradle.api.model.ObjectFactory;
 
 import javax.inject.Inject;
 
-public abstract class ObjectiveCppSourceSet extends BaseSourceSet implements HeaderExportingSourceSet {
+public class ObjectiveCppSourceSet extends BaseSourceSet implements HeaderExportingSourceSet {
 	@Inject
-	public ObjectiveCppSourceSet(String name) {
-		super(name, UTTypeObjectiveCppSource.INSTANCE);
+	public ObjectiveCppSourceSet(String name, ObjectFactory objectFactory) {
+		super(name, UTTypeObjectiveCppSource.INSTANCE, objectFactory);
 	}
 }

--- a/subprojects/language-native/src/main/java/dev/nokee/language/swift/internal/SwiftSourceSet.java
+++ b/subprojects/language-native/src/main/java/dev/nokee/language/swift/internal/SwiftSourceSet.java
@@ -1,12 +1,13 @@
 package dev.nokee.language.swift.internal;
 
 import dev.nokee.language.base.internal.BaseSourceSet;
+import org.gradle.api.model.ObjectFactory;
 
 import javax.inject.Inject;
 
-public abstract class SwiftSourceSet extends BaseSourceSet {
+public class SwiftSourceSet extends BaseSourceSet {
 	@Inject
-	public SwiftSourceSet(String name) {
-		super(name, UTTypeSwiftSource.INSTANCE);
+	public SwiftSourceSet(String name, ObjectFactory objectFactory) {
+		super(name, UTTypeSwiftSource.INSTANCE, objectFactory);
 	}
 }

--- a/subprojects/platform-base/platform-base.gradle
+++ b/subprojects/platform-base/platform-base.gradle
@@ -18,6 +18,7 @@ dependencies {
 	implementation "com.google.guava:guava:${guavaVersion}"
 	implementation "org.apache.commons:commons-lang3:${commonsLangVersion}"
 	compileOnly gradleApi(minimumGradleVersion)
+	api project(':coreModel')
 
 	compileOnly "org.projectlombok:lombok:${lombokVersion}"
 	annotationProcessor "org.projectlombok:lombok:${lombokVersion}"

--- a/subprojects/platform-base/platform-base.gradle
+++ b/subprojects/platform-base/platform-base.gradle
@@ -23,6 +23,9 @@ dependencies {
 	compileOnly "org.projectlombok:lombok:${lombokVersion}"
 	annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 
+	api 'com.google.dagger:dagger:latest.release'
+	annotationProcessor 'com.google.dagger:dagger-compiler:latest.release'
+
 	testImplementation platform("org.spockframework:spock-bom:${spockVersion}")
 	testImplementation 'org.spockframework:spock-core'
 	testImplementation gradleApi(minimumGradleVersion)

--- a/subprojects/platform-base/src/main/java/dev/nokee/language/base/internal/BaseSourceSet.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/language/base/internal/BaseSourceSet.java
@@ -1,28 +1,29 @@
 package dev.nokee.language.base.internal;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.model.ObjectFactory;
 
-import javax.inject.Inject;
-
 import static dev.nokee.language.base.internal.UTTypeUtils.onlyIf;
 
 // TODO: Introduce a directory source set vs file source set
-public abstract class BaseSourceSet implements ConfigurableSourceSet {
+public class BaseSourceSet implements ConfigurableSourceSet {
 	private final String name;
 	private final UTType type;
-	@Getter private final SourceDirectorySet sourceDirectorySet = getObjects().sourceDirectorySet("foo", "bar");
-	protected final ConfigurableFileCollection sources = getObjects().fileCollection();
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
+	@Getter private final SourceDirectorySet sourceDirectorySet;
+	protected final ConfigurableFileCollection sources;
 
-	@Inject
-	protected abstract ObjectFactory getObjects();
-
-	protected BaseSourceSet(String name, UTType type) {
+	protected BaseSourceSet(String name, UTType type, ObjectFactory objects) {
 		this.name = name;
 		this.type = type;
+		this.objects = objects;
+		this.sourceDirectorySet = objects.sourceDirectorySet("foo", "bar");
+		this.sources = objects.fileCollection();
+
 		sourceDirectorySet.getFilter().include(onlyIf(type).getIncludes());
 		sources.from(sourceDirectorySet.getAsFileTree());
 	}

--- a/subprojects/platform-base/src/main/java/dev/nokee/language/base/internal/DefaultSourceSet.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/language/base/internal/DefaultSourceSet.java
@@ -1,10 +1,12 @@
 package dev.nokee.language.base.internal;
 
+import org.gradle.api.model.ObjectFactory;
+
 import javax.inject.Inject;
 
-public abstract class DefaultSourceSet extends BaseSourceSet {
+public class DefaultSourceSet extends BaseSourceSet {
 	@Inject
-	public DefaultSourceSet(String name, UTType type) {
-		super(name, type);
+	public DefaultSourceSet(String name, UTType type, ObjectFactory objectFactory) {
+		super(name, type, objectFactory);
 	}
 }

--- a/subprojects/platform-base/src/main/java/dev/nokee/language/base/internal/GeneratedSourceSet.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/language/base/internal/GeneratedSourceSet.java
@@ -1,5 +1,7 @@
 package dev.nokee.language.base.internal;
 
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.gradle.api.Task;
 import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.Directory;
@@ -12,20 +14,20 @@ import javax.inject.Inject;
 
 import static dev.nokee.language.base.internal.UTTypeUtils.onlyIf;
 
-public abstract class GeneratedSourceSet implements SourceSet {
+public class GeneratedSourceSet implements SourceSet {
 	private final UTType type;
 	private final Provider<Directory> sourceDirectory;
 	private final TaskProvider<? extends Task> generatedByTask;
-	private final ConfigurableFileTree fileTree = getObjects().fileTree();
+	private final ConfigurableFileTree fileTree;
 	private final String name;
+	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
 
 	@Inject
-	protected abstract ObjectFactory getObjects();
-
-	@Inject
-	public GeneratedSourceSet(String name, UTType type, Provider<Directory> sourceDirectory, TaskProvider<? extends Task> generatedByTask) {
+	public GeneratedSourceSet(String name, UTType type, Provider<Directory> sourceDirectory, TaskProvider<? extends Task> generatedByTask, ObjectFactory objects) {
 		this.name = name;
 		this.type = type;
+		this.objects = objects;
+		this.fileTree = objects.fileTree();
 		this.sourceDirectory = sourceDirectory;
 		this.generatedByTask = generatedByTask;
 		fileTree.setDir(sourceDirectory).builtBy(generatedByTask).include(onlyIf(type).getIncludes());

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/ComponentTasks.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/ComponentTasks.java
@@ -1,0 +1,4 @@
+package dev.nokee.platform.base;
+
+public interface ComponentTasks {
+}

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/DomainObjectProvider.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/DomainObjectProvider.java
@@ -1,6 +1,6 @@
 package dev.nokee.platform.base;
 
-import dev.nokee.platform.base.internal.DomainObjectIdentity;
+import dev.nokee.model.DomainObjectIdentifier;
 import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.provider.Provider;
@@ -12,7 +12,7 @@ public interface DomainObjectProvider<T> {
 
 	Class<T> getType();
 
-	DomainObjectIdentity getIdentity();
+	DomainObjectIdentifier getIdentity();
 
 	<S> Provider<S> map(Transformer<? extends S, ? super T> transformer);
 

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/KnownDomainObject.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/KnownDomainObject.java
@@ -1,6 +1,6 @@
 package dev.nokee.platform.base;
 
-import dev.nokee.platform.base.internal.DomainObjectIdentity;
+import dev.nokee.model.DomainObjectIdentifier;
 import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.provider.Provider;
@@ -10,7 +10,7 @@ public interface KnownDomainObject<T> {
 
 	Class<T> getType();
 
-	DomainObjectIdentity getIdentity();
+	DomainObjectIdentifier getIdentity();
 
 	<S> Provider<S> map(Transformer<? extends S, ? super T> transformer);
 

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ComponentIdentifier.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ComponentIdentifier.java
@@ -1,0 +1,17 @@
+package dev.nokee.platform.base.internal;
+
+import dev.nokee.model.internal.DomainObjectIdentifierInternal;
+import lombok.Value;
+
+import java.util.Optional;
+
+@Value
+public class ComponentIdentifier implements DomainObjectIdentifierInternal {
+	String name;
+	ProjectIdentifier projectIdentifier;
+
+	@Override
+	public Optional<ProjectIdentifier> getParentIdentifier() {
+		return Optional.of(projectIdentifier);
+	}
+}

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/DefaultDomainObjectStore.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/DefaultDomainObjectStore.java
@@ -53,6 +53,12 @@ public class DefaultDomainObjectStore implements DomainObjectStore {
 	}
 
 	@Override
+	public <U> DomainObjectProvider<U> add(DomainObjectElement<U> element) {
+		store.add(Cast.uncheckedCastBecauseOfTypeErasure(element));
+		return Cast.uncheckedCastBecauseOfTypeErasure(store.get(element.getIdentity()));
+	}
+
+	@Override
 	public void whenElementKnown(Action<KnownDomainObject<?>> action) {
 		store.whenElementKnown(action);
 	}

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/DefaultKnownDomainObject.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/DefaultKnownDomainObject.java
@@ -1,5 +1,6 @@
 package dev.nokee.platform.base.internal;
 
+import dev.nokee.model.DomainObjectIdentifier;
 import dev.nokee.platform.base.DomainObjectProvider;
 import dev.nokee.platform.base.KnownDomainObject;
 import lombok.EqualsAndHashCode;
@@ -31,7 +32,7 @@ public class DefaultKnownDomainObject<T> implements KnownDomainObject<T> {
 	}
 
 	@Override
-	public DomainObjectIdentity getIdentity() {
+	public DomainObjectIdentifier getIdentity() {
 		return provider.getIdentity();
 	}
 

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/DomainObjectIdentity.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/DomainObjectIdentity.java
@@ -1,6 +1,8 @@
 package dev.nokee.platform.base.internal;
 
-public interface DomainObjectIdentity {
+import dev.nokee.model.DomainObjectIdentifier;
+
+public interface DomainObjectIdentity extends DomainObjectIdentifier {
 
 	static DomainObjectIdentity named(String name) {
 		return new DefaultNamedDomainObjectIdentity(name);

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/DomainObjectStore.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/DomainObjectStore.java
@@ -1,5 +1,6 @@
 package dev.nokee.platform.base.internal;
 
+import dev.nokee.platform.base.DomainObjectElement;
 import dev.nokee.platform.base.DomainObjectProvider;
 import dev.nokee.platform.base.KnownDomainObject;
 import org.gradle.api.Action;
@@ -11,6 +12,7 @@ import java.util.List;
 
 public interface DomainObjectStore {
 	<U> DomainObjectProvider<U> register(DomainObjectFactory<U> factory);
+	<U> DomainObjectProvider<U> add(DomainObjectElement<U> element);
 
 	void whenElementKnown(Action<KnownDomainObject<?>> action);
 	<U> void whenElementKnown(Class<U> type, Action<KnownDomainObject<? extends U>> action);

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ProjectIdentifier.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ProjectIdentifier.java
@@ -1,0 +1,21 @@
+package dev.nokee.platform.base.internal;
+
+import dev.nokee.model.internal.DomainObjectIdentifierInternal;
+import lombok.Value;
+import org.gradle.api.Project;
+
+import java.util.Optional;
+
+@Value
+public class ProjectIdentifier implements DomainObjectIdentifierInternal {
+	String name;
+
+	@Override
+	public Optional<? extends DomainObjectIdentifierInternal> getParentIdentifier() {
+		return Optional.empty();
+	}
+
+	public static ProjectIdentifier of(Project project) {
+		return new ProjectIdentifier(project.getName());
+	}
+}

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantIdentifier.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantIdentifier.java
@@ -1,0 +1,17 @@
+package dev.nokee.platform.base.internal;
+
+import dev.nokee.model.internal.DomainObjectIdentifierInternal;
+import lombok.Value;
+
+import java.util.Optional;
+
+@Value
+public class VariantIdentifier implements DomainObjectIdentifierInternal {
+	String unambiguousName;
+	ComponentIdentifier componentIdentifier;
+
+	@Override
+	public Optional<ComponentIdentifier> getParentIdentifier() {
+		return Optional.of(componentIdentifier);
+	}
+}

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/ComponentTasksAdapter.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/ComponentTasksAdapter.java
@@ -1,0 +1,51 @@
+package dev.nokee.platform.base.internal.tasks;
+
+import dev.nokee.model.internal.DomainObjectIdentifierInternal;
+import dev.nokee.platform.base.DomainObjectProvider;
+import lombok.val;
+import org.gradle.api.Action;
+import org.gradle.api.Task;
+import org.gradle.api.tasks.TaskContainer;
+
+final class ComponentTasksAdapter implements ComponentTasksInternal {
+	private final KnownTaskIdentifierRegistry knownIdentifierRegistry;
+	private final TaskContainer tasks;
+	private final KnownTaskIdentifiers knownIdentifiers;
+	private final TaskIdentifierFactory identifierFactory;
+
+	public ComponentTasksAdapter(DomainObjectIdentifierInternal identifier, TaskContainer tasks, KnownTaskIdentifierRegistry knownIdentifierRegistry) {
+		this(tasks, knownIdentifierRegistry, new KnownTaskIdentifiersImpl(identifier, knownIdentifierRegistry), TaskIdentifierFactory.childOf(identifier));
+	}
+
+	public ComponentTasksAdapter(DomainObjectIdentifierInternal identifier, TaskContainer tasks, KnownTaskIdentifierRegistry knownIdentifierRegistry, TaskIdentifierFactory identifierFactory) {
+		this(tasks, knownIdentifierRegistry, new KnownTaskIdentifiersImpl(identifier, knownIdentifierRegistry), identifierFactory);
+	}
+
+	private ComponentTasksAdapter(TaskContainer tasks, KnownTaskIdentifierRegistry knownIdentifierRegistry, KnownTaskIdentifiers knownIdentifiers, TaskIdentifierFactory identifierFactory) {
+		this.tasks = tasks;
+		this.knownIdentifierRegistry = knownIdentifierRegistry;
+		this.knownIdentifiers = knownIdentifiers;
+		this.identifierFactory = identifierFactory;
+	}
+
+	@Override
+	public <T extends Task> DomainObjectProvider<T> register(TaskName taskName, Class<T> type) {
+		val identifier = identifierFactory.create(taskName, type);
+		knownIdentifierRegistry.add(identifier);
+		val result = tasks.register(identifier.getTaskName(), identifier.getType());
+		return new TaskDomainObjectProvider<>(identifier, result);
+	}
+
+	@Override
+	public <T extends Task> DomainObjectProvider<T> register(TaskName taskName, Class<T> type, Action<? super T> action) {
+		val identifier = identifierFactory.create(taskName, type);
+		knownIdentifierRegistry.add(identifier);
+		val result = tasks.register(identifier.getTaskName(), identifier.getType(), action);
+		return new TaskDomainObjectProvider<>(identifier, result);
+	}
+
+	@Override
+	public void configureEach(Action<? super Task> action) {
+		tasks.configureEach(new KnownTaskIdentifierActionAdapter(knownIdentifiers, action));
+	}
+}

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/ComponentTasksInternal.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/ComponentTasksInternal.java
@@ -1,0 +1,12 @@
+package dev.nokee.platform.base.internal.tasks;
+
+import dev.nokee.platform.base.ComponentTasks;
+import dev.nokee.platform.base.DomainObjectProvider;
+import org.gradle.api.Action;
+import org.gradle.api.Task;
+
+public interface ComponentTasksInternal extends ComponentTasks {
+	<T extends Task> DomainObjectProvider<T> register(TaskName taskName, Class<T> type);
+	<T extends Task> DomainObjectProvider<T> register(TaskName taskName, Class<T> type, Action<? super T> action);
+	void configureEach(Action<? super Task> action);
+}

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/ComponentTasksModule.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/ComponentTasksModule.java
@@ -1,0 +1,22 @@
+package dev.nokee.platform.base.internal.tasks;
+
+import dagger.Module;
+import dagger.Provides;
+import dev.nokee.model.internal.DomainObjectIdentifierInternal;
+import org.gradle.api.tasks.TaskContainer;
+
+import javax.inject.Singleton;
+
+@Module
+public interface ComponentTasksModule {
+	@Provides
+	static ComponentTasksInternal theComponentTasks(DomainObjectIdentifierInternal identifier, TaskContainer taskContainer, KnownTaskIdentifierRegistry identifierRegistry) {
+		return new ComponentTasksAdapter(identifier, taskContainer, identifierRegistry);
+	}
+
+	@Provides
+	@Singleton
+	static KnownTaskIdentifierRegistry theKnownTaskIdentifierRegistry() {
+		return new KnownTaskIdentifierRegistryImpl();
+	}
+}

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/KnownTaskIdentifierActionAdapter.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/KnownTaskIdentifierActionAdapter.java
@@ -1,0 +1,21 @@
+package dev.nokee.platform.base.internal.tasks;
+
+import org.gradle.api.Action;
+import org.gradle.api.Task;
+
+final class KnownTaskIdentifierActionAdapter implements Action<Task> {
+	private final KnownTaskIdentifiers knownTaskIdentifiers;
+	private final Action<? super Task> delegate;
+
+	public KnownTaskIdentifierActionAdapter(KnownTaskIdentifiers knownTaskIdentifiers, Action<? super Task> delegate) {
+		this.knownTaskIdentifiers = knownTaskIdentifiers;
+		this.delegate = delegate;
+	}
+
+	@Override
+	public void execute(Task task) {
+		if (knownTaskIdentifiers.contains(task.getName())) {
+			delegate.execute(task);
+		}
+	}
+}

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/KnownTaskIdentifierRegistry.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/KnownTaskIdentifierRegistry.java
@@ -1,0 +1,12 @@
+package dev.nokee.platform.base.internal.tasks;
+
+import dev.nokee.model.DomainObjectIdentifier;
+import org.gradle.api.Task;
+
+import java.util.Set;
+
+interface KnownTaskIdentifierRegistry {
+	void add(TaskIdentifier<? extends Task> identifier);
+
+	Set<String> getTaskNamesFor(DomainObjectIdentifier identifier);
+}

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/KnownTaskIdentifierRegistryImpl.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/KnownTaskIdentifierRegistryImpl.java
@@ -1,0 +1,36 @@
+package dev.nokee.platform.base.internal.tasks;
+
+import dev.nokee.model.DomainObjectIdentifier;
+import lombok.val;
+import lombok.var;
+import org.gradle.api.Task;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+final class KnownTaskIdentifierRegistryImpl implements KnownTaskIdentifierRegistry {
+	private final Set<TaskIdentifier<? extends Task>> knownIdentifiers = new HashSet<>();
+
+	public void add(TaskIdentifier<? extends Task> identifier) {
+		assert identifier != null;
+		val identifierAdded = knownIdentifiers.add(identifier);
+		assert identifierAdded : "Task identifier collision detected.";
+	}
+
+	public Set<String> getTaskNamesFor(DomainObjectIdentifier identifier) {
+		Predicate<TaskIdentifier<?>> predicate = (TaskIdentifier<?> id) -> {
+			var parentIdentifier = id.getOwnerIdentifier();
+			while (!identifier.getClass().isInstance(parentIdentifier)) {
+				if (parentIdentifier.getParentIdentifier().isPresent()) {
+					parentIdentifier = parentIdentifier.getParentIdentifier().get();
+				} else {
+					return false;
+				}
+			}
+			return identifier.equals(parentIdentifier);
+		};
+		return knownIdentifiers.stream().filter(predicate).map(TaskIdentifier::getTaskName).collect(Collectors.toSet());
+	}
+}

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/KnownTaskIdentifiers.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/KnownTaskIdentifiers.java
@@ -1,0 +1,5 @@
+package dev.nokee.platform.base.internal.tasks;
+
+interface KnownTaskIdentifiers {
+	boolean contains(String taskName);
+}

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/KnownTaskIdentifiersImpl.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/KnownTaskIdentifiersImpl.java
@@ -1,0 +1,18 @@
+package dev.nokee.platform.base.internal.tasks;
+
+import dev.nokee.model.DomainObjectIdentifier;
+
+class KnownTaskIdentifiersImpl implements KnownTaskIdentifiers {
+	private final DomainObjectIdentifier identifier;
+	private final KnownTaskIdentifierRegistry knownIdentifierRegistry;
+
+	public KnownTaskIdentifiersImpl(DomainObjectIdentifier identifier, KnownTaskIdentifierRegistry knownIdentifierRegistry) {
+		this.identifier = identifier;
+		this.knownIdentifierRegistry = knownIdentifierRegistry;
+	}
+
+	public boolean contains(String taskName) {
+		assert taskName != null;
+		return knownIdentifierRegistry.getTaskNamesFor(identifier).contains(taskName);
+	}
+}

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/TaskDomainObjectProvider.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/TaskDomainObjectProvider.java
@@ -1,0 +1,50 @@
+package dev.nokee.platform.base.internal.tasks;
+
+import dev.nokee.platform.base.DomainObjectProvider;
+import lombok.ToString;
+import org.gradle.api.Action;
+import org.gradle.api.Task;
+import org.gradle.api.Transformer;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.TaskProvider;
+
+@ToString
+final class TaskDomainObjectProvider<I extends Task> implements DomainObjectProvider<I> {
+	private final TaskIdentifier<I> identifier;
+	private final TaskProvider<I> delegate;
+
+	public TaskDomainObjectProvider(TaskIdentifier<I> identifier, TaskProvider<I> delegate) {
+		this.identifier = identifier;
+		this.delegate = delegate;
+	}
+
+	@Override
+	public I get() {
+		return delegate.get();
+	}
+
+	@Override
+	public Class<I> getType() {
+		return identifier.getType();
+	}
+
+	@Override
+	public TaskIdentifier<I> getIdentity() {
+		return identifier;
+	}
+
+	@Override
+	public void configure(Action<? super I> action) {
+		delegate.configure(action);
+	}
+
+	@Override
+	public <S> Provider<S> map(Transformer<? extends S, ? super I> transformer) {
+		return delegate.map(transformer);
+	}
+
+	@Override
+	public <S> Provider<S> flatMap(Transformer<? extends Provider<? extends S>, ? super I> transformer) {
+		return delegate.flatMap(transformer);
+	}
+}

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/TaskIdentifier.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/TaskIdentifier.java
@@ -1,0 +1,19 @@
+package dev.nokee.platform.base.internal.tasks;
+
+import dev.nokee.model.internal.DomainObjectIdentifierInternal;
+import lombok.Value;
+import org.gradle.api.Task;
+
+import java.util.Optional;
+
+@Value
+class TaskIdentifier<T extends Task> implements DomainObjectIdentifierInternal {
+	String taskName;
+	Class<T> type;
+	DomainObjectIdentifierInternal ownerIdentifier;
+
+	@Override
+	public Optional<? extends DomainObjectIdentifierInternal> getParentIdentifier() {
+		return Optional.of(ownerIdentifier);
+	}
+}

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/TaskIdentifierFactory.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/TaskIdentifierFactory.java
@@ -1,0 +1,56 @@
+package dev.nokee.platform.base.internal.tasks;
+
+import dev.nokee.model.internal.DomainObjectIdentifierInternal;
+import dev.nokee.platform.base.internal.ComponentIdentifier;
+import dev.nokee.platform.base.internal.ProjectIdentifier;
+import dev.nokee.platform.base.internal.VariantIdentifier;
+import org.apache.commons.lang3.StringUtils;
+import org.gradle.api.Task;
+
+interface TaskIdentifierFactory {
+	<T extends Task> TaskIdentifier<T> create(TaskName taskName, Class<T> type);
+
+	static TaskIdentifierFactory childOf(ProjectIdentifier parentIdentifier) {
+		return new TaskIdentifierFactory() {
+			@Override
+			public <T extends Task> TaskIdentifier<T> create(TaskName taskName, Class<T> type) {
+				return new TaskIdentifier<>(taskName.getVerb() + taskName.getObject().map(StringUtils::capitalize).orElse(""), type, parentIdentifier);
+			}
+		};
+	}
+
+	static TaskIdentifierFactory childOf(ComponentIdentifier parentIdentifier) {
+		return new TaskIdentifierFactory() {
+			@Override
+			public <T extends Task> TaskIdentifier<T> create(TaskName taskName, Class<T> type) {
+				if (parentIdentifier.getName().equals("main")) {
+					return new TaskIdentifier<>(taskName.getVerb() + taskName.getObject().map(StringUtils::capitalize).orElse(""), type, parentIdentifier);
+				}
+				return new TaskIdentifier<>(taskName.getVerb() + StringUtils.capitalize(parentIdentifier.getName()) + taskName.getObject().map(StringUtils::capitalize).orElse(""), type, parentIdentifier);
+			}
+		};
+	}
+
+	static TaskIdentifierFactory childOf(VariantIdentifier parentIdentifier) {
+		return new TaskIdentifierFactory() {
+			@Override
+			public <T extends Task> TaskIdentifier<T> create(TaskName taskName, Class<T> type) {
+				if (parentIdentifier.getComponentIdentifier().getName().equals("main")) {
+					return new TaskIdentifier<>(taskName.getVerb() + StringUtils.capitalize(parentIdentifier.getUnambiguousName()) + taskName.getObject().map(StringUtils::capitalize).orElse(""), type, parentIdentifier);
+				}
+				return new TaskIdentifier<>(taskName.getVerb() + StringUtils.capitalize(parentIdentifier.getComponentIdentifier().getName()) + StringUtils.capitalize(parentIdentifier.getUnambiguousName()) + taskName.getObject().map(StringUtils::capitalize).orElse(""), type, parentIdentifier);
+			}
+		};
+	}
+
+	static TaskIdentifierFactory childOf(DomainObjectIdentifierInternal parentIdentifier) {
+		if (parentIdentifier instanceof ProjectIdentifier) {
+			return childOf((ProjectIdentifier) parentIdentifier);
+		} else if (parentIdentifier instanceof ComponentIdentifier) {
+			return childOf((ComponentIdentifier) parentIdentifier);
+		} else if (parentIdentifier instanceof VariantIdentifier) {
+			return childOf((VariantIdentifier) parentIdentifier);
+		}
+		throw new IllegalArgumentException();
+	}
+}

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/TaskName.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/TaskName.java
@@ -1,0 +1,33 @@
+package dev.nokee.platform.base.internal.tasks;
+
+import lombok.Value;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
+
+@Value
+public class TaskName {
+	String verb;
+	@Nullable String object;
+
+	public Optional<String> getObject() {
+		return Optional.ofNullable(object);
+	}
+
+	public static TaskName of(String taskName) {
+		assert taskName != null;
+		assert !taskName.isEmpty();
+		assert Character.isLowerCase(taskName.charAt(0));
+		return new TaskName(taskName, null);
+	}
+
+	public static TaskName of(String verb, String object) {
+		assert verb != null;
+		assert object != null;
+		assert !verb.isEmpty();
+		assert !object.isEmpty();
+		assert Character.isLowerCase(verb.charAt(0));
+		assert Character.isLowerCase(object.charAt(0));
+		return new TaskName(verb, object);
+	}
+}

--- a/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/tasks/ComponentTasksAdapterTest.groovy
+++ b/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/tasks/ComponentTasksAdapterTest.groovy
@@ -1,0 +1,376 @@
+package dev.nokee.platform.base.internal.tasks
+
+import dev.nokee.model.internal.DomainObjectIdentifierInternal
+import dev.nokee.platform.base.DomainObjectProvider
+import dev.nokee.platform.base.internal.ComponentIdentifier
+import dev.nokee.platform.base.internal.ProjectIdentifier
+import org.gradle.api.Action
+import org.gradle.api.DefaultTask
+import org.gradle.api.Task
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+import spock.lang.Subject
+
+import static dev.nokee.platform.base.internal.tasks.TaskName.of
+import static dev.nokee.utils.DeferredUtils.realize
+
+@Subject(ComponentTasksAdapter)
+class ComponentTasksAdapterTest extends Specification {
+	def "forwards register to task container"() {
+		given:
+		def tasks = Mock(TaskContainer)
+		def subject = create(tasks)
+
+		when:
+		subject.register(of('foo'), DummyTask)
+
+		then:
+		1 * tasks.register('foo', DummyTask)
+		0 * _
+	}
+
+	def "forwards register with action to task container"() {
+		given:
+		def tasks = Mock(TaskContainer)
+		def action = Mock(Action)
+		def subject = create(tasks)
+
+		when:
+		subject.register(of('foo'), DummyTask, action)
+
+		then:
+		1 * tasks.register('foo', DummyTask, action)
+		0 * _
+	}
+
+	def "forwards configure each action to task container as scoped"() {
+		given:
+		def tasks = Mock(TaskContainer)
+		def action = Mock(Action)
+		def subject = create(tasks)
+
+		when:
+		subject.configureEach(action)
+
+		then:
+		1 * tasks.configureEach(_ as KnownTaskIdentifierActionAdapter)
+		0 * _
+	}
+
+	def "returns provider when registering a task"() {
+		given:
+		def tasks = Mock(TaskContainer)
+		def subject = create(tasks)
+
+		when:
+		def result = subject.register(of('foo'), DummyTask)
+
+		then:
+		result instanceof DomainObjectProvider
+		result.identifier == identifierOf('foo', DummyTask)
+	}
+
+	def "returns provider when registering a task with action"() {
+		given:
+		def tasks = Mock(TaskContainer)
+		def action = Mock(Action)
+		def subject = create(tasks)
+
+		when:
+		def result = subject.register(of('foo'), DummyTask, action)
+
+		then:
+		result instanceof DomainObjectProvider
+		result.identifier == identifierOf('foo', DummyTask)
+	}
+
+	def "does not execute configuration actions for unknown task identifier"() {
+		given:
+		def forwardedAction = null
+		def tasks = Mock(TaskContainer) {
+			configureEach(_) >> { args -> forwardedAction = args[0] }
+		}
+		def subject = create(tasks)
+
+		and:
+		def action = Mock(Action)
+		subject.configureEach(action)
+
+		and:
+		def task = Mock(Task)
+
+		when:
+		forwardedAction.execute(task)
+		then:
+		1 * task.getName() >> 'foo'
+		0 * action.execute(_)
+	}
+
+	def "scopes configuration actions to known task identifier"() {
+		given:
+		def forwardedAction = null
+		def tasks = Mock(TaskContainer) {
+			configureEach(_) >> { args -> forwardedAction = args[0] }
+		}
+		def subject = create(tasks)
+
+		and:
+		def action = Mock(Action)
+		subject.configureEach(action)
+
+		and:
+		def task = Mock(Task)
+
+		when:
+		subject.register(of('foo'), DummyTask)
+		forwardedAction.execute(task)
+		then:
+		1 * task.getName() >> 'foo'
+		1 * action.execute(task)
+	}
+
+	def "scopes configuration actions to known task identifier registered with action"() {
+		given:
+		def forwardedAction = null
+		def tasks = Mock(TaskContainer) {
+			configureEach(_) >> { args -> forwardedAction = args[0] }
+		}
+		def subject = create(tasks)
+
+		and:
+		def action = Mock(Action)
+		subject.configureEach(action)
+
+		and:
+		def task = Mock(Task)
+
+		when:
+		subject.register(of('foo'), DummyTask, Mock(Action))
+		forwardedAction.execute(task)
+		then:
+		1 * task.getName() >> 'foo'
+		1 * action.execute(task)
+	}
+
+	def "can decorate task identifier"() {
+		given:
+		def tasks = Mock(TaskContainer)
+		def identifier = new ComponentIdentifier('test', new ProjectIdentifier('root'))
+		def subject = create(tasks, identifier)
+
+		when:
+		def result = subject.register(of('foo'), DummyTask)
+
+		then:
+		1 * tasks.register('fooTest', DummyTask)
+		0 * _
+
+		and:
+		result instanceof DomainObjectProvider
+		result.identifier == identifierOf('fooTest', DummyTask, identifier)
+
+//		where:
+//		parentIdentifier | childIdentifier
+//		new ComponentIdentifierEx('test', DummyComponent, new ProjectIdentifier('root'))
+	}
+
+	def "can decorate task identifier registered with action"() {
+		given:
+		def tasks = Mock(TaskContainer)
+		def action = Mock(Action)
+		def identifier = new ComponentIdentifier('test', new ProjectIdentifier('root'))
+		def subject = create(tasks, identifier)
+
+		when:
+		def result = subject.register(of('foo'), DummyTask, action)
+
+		then:
+		1 * tasks.register('fooTest', DummyTask, action)
+		0 * _
+
+		and:
+		result instanceof DomainObjectProvider
+		result.identifier == identifierOf('fooTest', DummyTask, identifier)
+	}
+
+	def "does not execute configuration actions for unknown decorated task identifier"() {
+		given:
+		def forwardedAction = null
+		def tasks = Mock(TaskContainer) {
+			configureEach(_) >> { args -> forwardedAction = args[0] }
+		}
+		def subject = create(tasks)
+
+		and:
+		def action = Mock(Action)
+		subject.configureEach(action)
+
+		and:
+		def task = Mock(Task)
+
+		when:
+		forwardedAction.execute(task)
+		then:
+		1 * task.getName() >> 'foo'
+		0 * action.execute(_)
+
+		when:
+		forwardedAction.execute(task)
+		then:
+		1 * task.getName() >> 'fooTest'
+		0 * action.execute(_)
+	}
+
+	def "scopes configuration actions to known decorated task identifier"() {
+		given:
+		def forwardedAction = null
+		def tasks = Mock(TaskContainer) {
+			configureEach(_) >> { args -> forwardedAction = args[0] }
+		}
+		def identifier = new ComponentIdentifier('test', new ProjectIdentifier('root'))
+		def subject = create(tasks, identifier)
+
+		and:
+		def action = Mock(Action)
+		subject.configureEach(action)
+
+		and:
+		def task = Mock(Task)
+
+		when:
+		subject.register(of('foo'), DummyTask)
+		forwardedAction.execute(task)
+		then:
+		1 * task.getName() >> 'fooTest'
+		1 * action.execute(task)
+
+		when:
+		forwardedAction.execute(task)
+		then:
+		1 * task.getName() >> 'foo'
+		0 * action.execute(_)
+	}
+
+	def "scopes configuration actions to known decorated task identifier registered with action"() {
+		given:
+		def forwardedAction = null
+		def tasks = Mock(TaskContainer) {
+			configureEach(_) >> { args -> forwardedAction = args[0] }
+		}
+		def identifier = new ComponentIdentifier('test', new ProjectIdentifier('root'))
+		def subject = create(tasks, identifier)
+
+		and:
+		def action = Mock(Action)
+		subject.configureEach(action)
+
+		and:
+		def task = Mock(Task)
+
+		when:
+		subject.register(of('foo'), DummyTask, Mock(Action))
+		forwardedAction.execute(task)
+		then:
+		1 * task.getName() >> 'fooTest'
+		1 * action.execute(task)
+
+		when:
+		forwardedAction.execute(task)
+		then:
+		1 * task.getName() >> 'foo'
+		0 * action.execute(_)
+	}
+
+
+	// Integration test
+	def "can configure each task registered"() {
+		given:
+		def project = ProjectBuilder.builder().build()
+		def subject = create(project.tasks, ProjectIdentifier.of(project))
+
+		and:
+		subject.register(of('foo'), DummyTask)
+		subject.register(of('bar'), DummyTask, Mock(Action))
+
+		when:
+		def configuredTasks = []
+		subject.configureEach { configuredTasks << it.name }
+
+		then:
+		realize(project.tasks)
+		configuredTasks == ['foo', 'bar']
+	}
+
+	def "can configure each decorated task registered"() {
+		given:
+		def project = ProjectBuilder.builder().build()
+		def identifier = new ComponentIdentifier('test', ProjectIdentifier.of(project))
+		def subject = create(project.tasks, identifier)
+
+		and:
+		subject.register(of('foo'), DummyTask)
+		subject.register(of('bar'), DummyTask, Mock(Action))
+
+		when:
+		def configuredTasks = []
+		subject.configureEach { configuredTasks << it.name }
+
+		then:
+		realize(project.tasks)
+		configuredTasks == ['fooTest', 'barTest']
+	}
+
+	def "can configure each task after the configuration action is registered"() {
+		given:
+		def project = ProjectBuilder.builder().build()
+		def subject = create(project.tasks, ProjectIdentifier.of(project))
+
+		and:
+		subject.register(of('foo'), DummyTask)
+		subject.register(of('bar'), DummyTask, Mock(Action))
+
+		and:
+		def configuredTasks = []
+		subject.configureEach { configuredTasks << it.name }
+
+		when:
+		subject.register(of('far'), DummyTask)
+
+		then:
+		realize(project.tasks)
+		configuredTasks == ['foo', 'bar', 'far']
+	}
+
+	def "can configure each task eagerly registered"() {
+		given:
+		def project = ProjectBuilder.builder().build()
+		def subject = create(project.tasks, ProjectIdentifier.of(project))
+
+		and:
+		def configuredTasks = []
+		subject.configureEach { configuredTasks << it.name }
+		project.tasks.all {} // force realization
+
+		when:
+		subject.register(of('foo'), DummyTask)
+		subject.register(of('bar'), DummyTask, Mock(Action))
+
+		then:
+		configuredTasks == ['foo', 'bar']
+	}
+
+	// TODO: Test laziness
+
+	// TODO: Unit test when known task identifier registry has other entries not under tasks component identifier
+
+	def <T extends Task> TaskIdentifier<T> identifierOf(String name, Class<T> type, DomainObjectIdentifierInternal owner = new ProjectIdentifier('root')) {
+		return new TaskIdentifier<>(name, type, owner)
+	}
+
+	ComponentTasksAdapter create(TaskContainer tasks, DomainObjectIdentifierInternal identifier = new ProjectIdentifier('root')) {
+		return new ComponentTasksAdapter(identifier, tasks, new KnownTaskIdentifierRegistryImpl())
+	}
+
+	static class DummyTask extends DefaultTask {}
+}

--- a/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/tasks/KnownTaskIdentifierActionAdapterTest.groovy
+++ b/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/tasks/KnownTaskIdentifierActionAdapterTest.groovy
@@ -1,0 +1,43 @@
+package dev.nokee.platform.base.internal.tasks
+
+import org.gradle.api.Action
+import org.gradle.api.Task
+import spock.lang.Specification
+import spock.lang.Subject
+
+@Subject(KnownTaskIdentifierActionAdapter)
+class KnownTaskIdentifierActionAdapterTest extends Specification {
+	def "forwards execution to action if task name is known"() {
+		given:
+		def knownTaskIdentifiers = Mock(KnownTaskIdentifiers)
+		def action = Mock(Action)
+		def task = Mock(Task)
+		def subject = new KnownTaskIdentifierActionAdapter(knownTaskIdentifiers, action)
+
+		when:
+		subject.execute(task)
+
+		then:
+		1 * knownTaskIdentifiers.contains('foo') >> true
+		1 * task.name >> 'foo'
+		1 * action.execute(task)
+		0 * _
+	}
+
+	def "does not forward execution to action if task name is unknown"() {
+		given:
+		def knownTaskIdentifiers = Mock(KnownTaskIdentifiers)
+		def action = Mock(Action)
+		def task = Mock(Task)
+		def subject = new KnownTaskIdentifierActionAdapter(knownTaskIdentifiers, action)
+
+		when:
+		subject.execute(task)
+
+		then:
+		1 * knownTaskIdentifiers.contains('bar') >> false
+		1 * task.name >> 'bar'
+		0 * action.execute(task)
+		0 * _
+	}
+}

--- a/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/tasks/KnownTaskIdentifierRegistryImplTest.groovy
+++ b/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/tasks/KnownTaskIdentifierRegistryImplTest.groovy
@@ -1,0 +1,61 @@
+package dev.nokee.platform.base.internal.tasks
+
+import dev.nokee.model.internal.DomainObjectIdentifierInternal
+import dev.nokee.platform.base.internal.ComponentIdentifier
+import dev.nokee.platform.base.internal.ProjectIdentifier
+import dev.nokee.platform.base.internal.VariantIdentifier
+import org.gradle.api.DefaultTask
+import spock.lang.Specification
+import spock.lang.Subject
+
+@Subject(KnownTaskIdentifierRegistryImpl)
+class KnownTaskIdentifierRegistryImplTest extends Specification {
+	def "can add identifier to registry"() {
+		given:
+		def subject = new KnownTaskIdentifierRegistryImpl()
+
+		when:
+		subject.add(identifierOf('foo'))
+
+		then:
+		noExceptionThrown()
+	}
+
+	def "can retrieve a list of previously added task name from registry"() {
+		given:
+		def owner = new ProjectIdentifier('root')
+		def subject = new KnownTaskIdentifierRegistryImpl()
+
+		when:
+		subject.add(identifierOf('foo', owner))
+		subject.add(identifierOf('bar', owner))
+		subject.add(identifierOf('far', owner))
+
+		then:
+		subject.getTaskNamesFor(owner) == ['foo', 'bar', 'far'] as Set
+	}
+
+	def "can retrieve a sub-list by owner identifier of previously added task name from registry"() {
+		given:
+		def ownerProject = new ProjectIdentifier('root')
+		def ownerComponent = new ComponentIdentifier('test', ownerProject)
+		def ownerVariant = new VariantIdentifier('macosDebug', ownerComponent)
+		def subject = new KnownTaskIdentifierRegistryImpl()
+
+		when:
+		subject.add(identifierOf('foo', ownerProject))
+		subject.add(identifierOf('bar', ownerComponent))
+		subject.add(identifierOf('far', ownerVariant))
+
+		then:
+		subject.getTaskNamesFor(ownerProject) == ['foo', 'bar', 'far'] as Set
+		subject.getTaskNamesFor(ownerComponent) == ['bar', 'far'] as Set
+		subject.getTaskNamesFor(ownerVariant) == ['far'] as Set
+	}
+
+	TaskIdentifier<?> identifierOf(String taskName, DomainObjectIdentifierInternal parentIdentifier = new ProjectIdentifier()) {
+		return new TaskIdentifier<DummyTask>(taskName, DummyTask, parentIdentifier)
+	}
+
+	static class DummyTask extends DefaultTask {}
+}

--- a/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/tasks/KnownTaskIdentifiersImplTest.groovy
+++ b/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/tasks/KnownTaskIdentifiersImplTest.groovy
@@ -1,0 +1,56 @@
+package dev.nokee.platform.base.internal.tasks
+
+import dev.nokee.model.DomainObjectIdentifier
+import spock.lang.Specification
+import spock.lang.Subject
+
+@Subject(KnownTaskIdentifiersImpl)
+class KnownTaskIdentifiersImplTest extends Specification {
+	def "requests known task names from registry"() {
+		given:
+		def identifier = Mock(DomainObjectIdentifier)
+		def registry = Mock(KnownTaskIdentifierRegistry)
+		def subject = new KnownTaskIdentifiersImpl(identifier, registry)
+
+		when:
+		subject.contains('foo')
+
+		then:
+		1 * registry.getTaskNamesFor(identifier) >> ([] as Set)
+		0 * _
+	}
+
+	def "returns true if task name contained in registry under identifier"() {
+		given:
+		def identifier = Mock(DomainObjectIdentifier)
+		def registry = Mock(KnownTaskIdentifierRegistry)
+		def subject = new KnownTaskIdentifiersImpl(identifier, registry)
+
+		when:
+		def found = subject.contains('foo')
+
+		then:
+		1 * registry.getTaskNamesFor(identifier) >> (['foo', 'bar'] as Set)
+		0 * _
+
+		and:
+		found
+	}
+
+	def "returns false if task name is not contained in registry under identifier"() {
+		given:
+		def identifier = Mock(DomainObjectIdentifier)
+		def registry = Mock(KnownTaskIdentifierRegistry)
+		def subject = new KnownTaskIdentifiersImpl(identifier, registry)
+
+		when:
+		def found = subject.contains('foo')
+
+		then:
+		1 * registry.getTaskNamesFor(identifier) >> (['fooTest', 'barTest'] as Set)
+		0 * _
+
+		and:
+		!found
+	}
+}

--- a/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/tasks/TaskIdentifierFactoryTest.groovy
+++ b/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/tasks/TaskIdentifierFactoryTest.groovy
@@ -1,0 +1,91 @@
+package dev.nokee.platform.base.internal.tasks
+
+
+import dev.nokee.platform.base.internal.ComponentIdentifier
+import dev.nokee.platform.base.internal.ProjectIdentifier
+import dev.nokee.platform.base.internal.VariantIdentifier
+import org.gradle.api.Task
+import spock.lang.Specification
+import spock.lang.Subject
+
+@Subject(TaskIdentifierFactory)
+class TaskIdentifierFactoryTest extends Specification {
+	def "generates bare task names when direct parent is project"() {
+		given:
+		def subject = TaskIdentifierFactory.childOf(new ProjectIdentifier('root'))
+
+		expect:
+		subject.create(TaskName.of('foo'), DummyTask).taskName == 'foo'
+		subject.create(TaskName.of('link'), DummyTask).taskName == 'link'
+		subject.create(TaskName.of('compile', 'c'), DummyTask).taskName == 'compileC'
+		subject.create(TaskName.of('generate', 'proto'), DummyTask).taskName == 'generateProto'
+	}
+
+	def "generates task names with component name when direct parent is component"() {
+		given:
+		def subject = TaskIdentifierFactory.childOf(new ComponentIdentifier('test', new ProjectIdentifier('root')))
+
+		expect:
+		subject.create(TaskName.of('foo'), DummyTask).taskName == 'fooTest'
+		subject.create(TaskName.of('link'), DummyTask).taskName == 'linkTest'
+		subject.create(TaskName.of('compile', 'c'), DummyTask).taskName == 'compileTestC'
+		subject.create(TaskName.of('generate', 'proto'), DummyTask).taskName == 'generateTestProto'
+	}
+
+	def "generates bare task names when direct parent is main component"() {
+		given:
+		def subject = TaskIdentifierFactory.childOf(new ComponentIdentifier('main', new ProjectIdentifier('root')))
+
+		expect:
+		subject.create(TaskName.of('foo'), DummyTask).taskName == 'foo'
+		subject.create(TaskName.of('link'), DummyTask).taskName == 'link'
+		subject.create(TaskName.of('compile', 'c'), DummyTask).taskName == 'compileC'
+		subject.create(TaskName.of('generate', 'proto'), DummyTask).taskName == 'generateProto'
+	}
+
+	def "generates task names with component name and unambiguous variant name when direct parent is variant of a non-main component"() {
+		given:
+		def subject = TaskIdentifierFactory.childOf(new VariantIdentifier('macosDebug', new ComponentIdentifier('test', new ProjectIdentifier('root'))))
+
+		expect:
+		subject.create(TaskName.of('foo'), DummyTask).taskName == 'fooTestMacosDebug'
+		subject.create(TaskName.of('link'), DummyTask).taskName == 'linkTestMacosDebug'
+		subject.create(TaskName.of('compile', 'c'), DummyTask).taskName == 'compileTestMacosDebugC'
+		subject.create(TaskName.of('generate', 'proto'), DummyTask).taskName == 'generateTestMacosDebugProto'
+	}
+
+	def "generates task names without component name but with unambiguous variant name when direct parent is variant of a main component"() {
+		given:
+		def subject = TaskIdentifierFactory.childOf(new VariantIdentifier('macosDebug', new ComponentIdentifier('main', new ProjectIdentifier('root'))))
+
+		expect:
+		subject.create(TaskName.of('foo'), DummyTask).taskName == 'fooMacosDebug'
+		subject.create(TaskName.of('link'), DummyTask).taskName == 'linkMacosDebug'
+		subject.create(TaskName.of('compile', 'c'), DummyTask).taskName == 'compileMacosDebugC'
+		subject.create(TaskName.of('generate', 'proto'), DummyTask).taskName == 'generateMacosDebugProto'
+	}
+
+	def "generates task names with component name and without variant name when direct parent is variant of a non-main component without unambiguous variant name"() {
+		given:
+		def subject = TaskIdentifierFactory.childOf(new VariantIdentifier('', new ComponentIdentifier('test', new ProjectIdentifier('root'))))
+
+		expect:
+		subject.create(TaskName.of('foo'), DummyTask).taskName == 'fooTest'
+		subject.create(TaskName.of('link'), DummyTask).taskName == 'linkTest'
+		subject.create(TaskName.of('compile', 'c'), DummyTask).taskName == 'compileTestC'
+		subject.create(TaskName.of('generate', 'proto'), DummyTask).taskName == 'generateTestProto'
+	}
+
+	def "generates task names without component name and without variant name when direct parent is variant of a main component without unambiguous variant name"() {
+		given:
+		def subject = TaskIdentifierFactory.childOf(new VariantIdentifier('', new ComponentIdentifier('main', new ProjectIdentifier('root'))))
+
+		expect:
+		subject.create(TaskName.of('foo'), DummyTask).taskName == 'foo'
+		subject.create(TaskName.of('link'), DummyTask).taskName == 'link'
+		subject.create(TaskName.of('compile', 'c'), DummyTask).taskName == 'compileC'
+		subject.create(TaskName.of('generate', 'proto'), DummyTask).taskName == 'generateProto'
+	}
+
+	interface DummyTask extends Task {}
+}

--- a/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/tasks/TaskIdentifierTest.groovy
+++ b/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/tasks/TaskIdentifierTest.groovy
@@ -1,0 +1,58 @@
+package dev.nokee.platform.base.internal.tasks
+
+
+import dev.nokee.platform.base.internal.ComponentIdentifier
+import dev.nokee.platform.base.internal.ProjectIdentifier
+import dev.nokee.platform.base.internal.VariantIdentifier
+import org.gradle.api.Task
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+@Subject(TaskIdentifier)
+class TaskIdentifierTest extends Specification {
+	@Unroll
+	def "can compare identifier based on task name"(owner) {
+		expect:
+		new TaskIdentifier<>('foo', DummyTask, owner) == new TaskIdentifier<>('foo', DummyTask, owner)
+		new TaskIdentifier<>('foo', DummyTask, owner) != new TaskIdentifier<>('bar', DummyTask, owner)
+
+		where:
+		owner << [new ProjectIdentifier('root'), new ComponentIdentifier('test', new ProjectIdentifier('root')), new VariantIdentifier('macosDebug', new ComponentIdentifier('test', new ProjectIdentifier('root')))]
+	}
+
+	@Unroll
+	def "can compare identifier based on task type"(owner) {
+		expect:
+		new TaskIdentifier<>('foo', DummyTask, owner) == new TaskIdentifier<>('foo', DummyTask, owner)
+		new TaskIdentifier<>('foo', DummyTask, owner) != new TaskIdentifier<>('foo', AnotherDummyTask, owner)
+
+		where:
+		owner << [new ProjectIdentifier('root'), new ComponentIdentifier('test', new ProjectIdentifier('root')), new VariantIdentifier('macosDebug', new ComponentIdentifier('test', new ProjectIdentifier('root')))]
+	}
+
+	def "can compare identifier based on owner"() {
+		given:
+		def ownerProject = new ProjectIdentifier('root')
+		def ownerComponent = new ComponentIdentifier('test', ownerProject)
+		def ownerVariant = new VariantIdentifier('macosDebug', ownerComponent)
+
+		expect:
+		new TaskIdentifier<>('foo', DummyTask, ownerProject) == new TaskIdentifier<>('foo', DummyTask, ownerProject)
+		new TaskIdentifier<>('foo', DummyTask, ownerProject) != new TaskIdentifier<>('foo', DummyTask, ownerComponent)
+		new TaskIdentifier<>('foo', DummyTask, ownerProject) != new TaskIdentifier<>('foo', DummyTask, ownerVariant)
+
+		and:
+		new TaskIdentifier<>('foo', DummyTask, ownerComponent) == new TaskIdentifier<>('foo', DummyTask, ownerComponent)
+		new TaskIdentifier<>('foo', DummyTask, ownerComponent) != new TaskIdentifier<>('foo', DummyTask, ownerProject)
+		new TaskIdentifier<>('foo', DummyTask, ownerComponent) != new TaskIdentifier<>('foo', DummyTask, ownerVariant)
+
+		and:
+		new TaskIdentifier<>('foo', DummyTask, ownerVariant) == new TaskIdentifier<>('foo', DummyTask, ownerVariant)
+		new TaskIdentifier<>('foo', DummyTask, ownerVariant) != new TaskIdentifier<>('foo', DummyTask, ownerProject)
+		new TaskIdentifier<>('foo', DummyTask, ownerVariant) != new TaskIdentifier<>('foo', DummyTask, ownerComponent)
+	}
+
+	interface DummyTask extends Task {}
+	interface AnotherDummyTask extends Task {}
+}

--- a/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/tasks/TaskNameTest.groovy
+++ b/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/tasks/TaskNameTest.groovy
@@ -1,0 +1,85 @@
+package dev.nokee.platform.base.internal.tasks
+
+import spock.lang.Specification
+import spock.lang.Subject
+
+@Subject(TaskName)
+class TaskNameTest extends Specification {
+	def "ensures task name is uncapitalized"() {
+		when:
+		TaskName.of('foo')
+		then:
+		noExceptionThrown()
+
+		when:
+		TaskName.of('Foo')
+		then:
+		thrown(AssertionError)
+	}
+
+	def "ensures verb and object is uncapitalized"() {
+		when:
+		TaskName.of('foo', 'bar')
+		then:
+		noExceptionThrown()
+
+		when:
+		TaskName.of('Foo', 'bar')
+		then:
+		thrown(AssertionError)
+
+		when:
+		TaskName.of('Foo', 'Bar')
+		then:
+		thrown(AssertionError)
+
+		when:
+		TaskName.of('foo', 'Bar')
+		then:
+		thrown(AssertionError)
+	}
+
+	def "name segments are not null"() {
+		when:
+		TaskName.of(null)
+		then:
+		thrown(AssertionError)
+
+		when:
+		TaskName.of(null, 'bar')
+		then:
+		thrown(AssertionError)
+
+		when:
+		TaskName.of('foo', null)
+		then:
+		thrown(AssertionError)
+
+		when:
+		TaskName.of(null, null)
+		then:
+		thrown(AssertionError)
+	}
+
+	def "name segments are not empty"() {
+		when:
+		TaskName.of('')
+		then:
+		thrown(AssertionError)
+
+		when:
+		TaskName.of('', 'bar')
+		then:
+		thrown(AssertionError)
+
+		when:
+		TaskName.of('foo', '')
+		then:
+		thrown(AssertionError)
+
+		when:
+		TaskName.of('', '')
+		then:
+		thrown(AssertionError)
+	}
+}

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/BaseIosExtension.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/BaseIosExtension.java
@@ -1,14 +1,9 @@
 package dev.nokee.platform.ios.internal;
 
-import com.google.common.collect.ImmutableList;
 import dev.nokee.platform.base.Binary;
 import dev.nokee.platform.base.BinaryView;
-import dev.nokee.platform.base.internal.BuildVariantInternal;
-import dev.nokee.platform.base.internal.DefaultBuildVariant;
+import dev.nokee.platform.ios.internal.rules.IosBuildVariantConvention;
 import dev.nokee.platform.nativebase.internal.BaseNativeComponent;
-import dev.nokee.platform.nativebase.internal.DefaultBinaryLinkage;
-import dev.nokee.runtime.nativebase.internal.DefaultMachineArchitecture;
-import dev.nokee.runtime.nativebase.internal.DefaultOperatingSystemFamily;
 import lombok.AccessLevel;
 import lombok.Getter;
 import org.gradle.api.model.ObjectFactory;
@@ -24,15 +19,11 @@ public class BaseIosExtension<T extends BaseNativeComponent<?>> {
 		this.objects = objects;
 		this.providers = providers;
 
-		component.getBuildVariants().convention(getProviders().provider(this::createBuildVariants));
+		component.getBuildVariants().convention(getProviders().provider(new IosBuildVariantConvention()));
 		component.getBuildVariants().finalizeValueOnRead();
 		component.getBuildVariants().disallowChanges(); // Let's disallow changing them for now.
 
 		component.getDimensions().disallowChanges(); // Let's disallow changing them for now.
-	}
-
-	protected Iterable<BuildVariantInternal> createBuildVariants() {
-		return ImmutableList.of(DefaultBuildVariant.of(DefaultOperatingSystemFamily.forName("ios"), DefaultMachineArchitecture.X86_64, DefaultBinaryLinkage.EXECUTABLE));
 	}
 
 	public T getComponent() {

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/rules/IosBuildVariantConvention.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/rules/IosBuildVariantConvention.java
@@ -1,0 +1,17 @@
+package dev.nokee.platform.ios.internal.rules;
+
+import com.google.common.collect.ImmutableList;
+import dev.nokee.platform.base.internal.BuildVariantInternal;
+import dev.nokee.platform.base.internal.DefaultBuildVariant;
+import dev.nokee.platform.nativebase.internal.DefaultBinaryLinkage;
+import dev.nokee.runtime.nativebase.internal.DefaultMachineArchitecture;
+import dev.nokee.runtime.nativebase.internal.DefaultOperatingSystemFamily;
+
+import java.util.concurrent.Callable;
+
+public class IosBuildVariantConvention implements Callable<Iterable<BuildVariantInternal>> {
+	@Override
+	public Iterable<BuildVariantInternal> call() throws Exception {
+		return ImmutableList.of(DefaultBuildVariant.of(DefaultOperatingSystemFamily.forName("ios"), DefaultMachineArchitecture.X86_64, DefaultBinaryLinkage.EXECUTABLE));
+	}
+}

--- a/subprojects/platform-native/platform-native.gradle
+++ b/subprojects/platform-native/platform-native.gradle
@@ -23,6 +23,9 @@ dependencies {
 	compileOnly "org.projectlombok:lombok:${lombokVersion}"
 	annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 
+	compileOnly 'com.google.auto.factory:auto-factory:latest.release'
+	annotationProcessor 'com.google.auto.factory:auto-factory:latest.release'
+
 	api 'com.google.dagger:dagger:latest.release'
 	annotationProcessor 'com.google.dagger:dagger-compiler:latest.release'
 	implementation project(':coreGradle')

--- a/subprojects/platform-native/platform-native.gradle
+++ b/subprojects/platform-native/platform-native.gradle
@@ -23,6 +23,10 @@ dependencies {
 	compileOnly "org.projectlombok:lombok:${lombokVersion}"
 	annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 
+	api 'com.google.dagger:dagger:latest.release'
+	annotationProcessor 'com.google.dagger:dagger-compiler:latest.release'
+	implementation project(':coreGradle')
+
 	testFixturesImplementation project(':runtimeNative')
 	testFixturesImplementation platform("org.spockframework:spock-bom:${spockVersion}")
 	testFixturesImplementation 'org.spockframework:spock-core'

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/DefaultCApplicationExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/DefaultCApplicationExtension.java
@@ -1,5 +1,7 @@
 package dev.nokee.platform.c.internal;
 
+import com.google.auto.factory.AutoFactory;
+import com.google.auto.factory.Provided;
 import dev.nokee.language.c.internal.CHeaderSet;
 import dev.nokee.language.c.internal.CSourceSet;
 import dev.nokee.platform.base.VariantView;
@@ -8,10 +10,7 @@ import dev.nokee.platform.nativebase.NativeApplication;
 import dev.nokee.platform.nativebase.NativeApplicationComponentDependencies;
 import dev.nokee.platform.nativebase.TargetBuildTypeFactory;
 import dev.nokee.platform.nativebase.TargetMachineFactory;
-import dev.nokee.platform.nativebase.internal.BaseNativeExtension;
-import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
-import dev.nokee.platform.nativebase.internal.DefaultTargetBuildTypeFactory;
-import dev.nokee.platform.nativebase.internal.DefaultTargetMachineFactory;
+import dev.nokee.platform.nativebase.internal.*;
 import dev.nokee.runtime.nativebase.TargetBuildType;
 import dev.nokee.runtime.nativebase.TargetMachine;
 import lombok.Getter;
@@ -25,6 +24,7 @@ import org.gradle.api.provider.SetProperty;
 
 import javax.inject.Inject;
 
+@AutoFactory(allowSubclasses = true, extending = DecoratingFactory.class, className = "AutoDefaultCApplicationExtensionFactory")
 public class DefaultCApplicationExtension extends BaseNativeExtension<DefaultNativeApplicationComponent> implements CApplicationExtension {
 	@Getter private final ConfigurableFileCollection sources;
 	@Getter private final ConfigurableFileCollection privateHeaders;
@@ -32,7 +32,7 @@ public class DefaultCApplicationExtension extends BaseNativeExtension<DefaultNat
 	@Getter private final SetProperty<TargetBuildType> targetBuildTypes;
 
 	@Inject
-	public DefaultCApplicationExtension(DefaultNativeApplicationComponent component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
+	public DefaultCApplicationExtension(@Provided DefaultNativeApplicationComponent component, @Provided ObjectFactory objects, @Provided ProviderFactory providers, @Provided ProjectLayout layout) {
 		super(component, objects, providers, layout);
 		this.sources = objects.fileCollection();
 		this.privateHeaders = objects.fileCollection();

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/DefaultCApplicationExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/DefaultCApplicationExtension.java
@@ -6,8 +6,12 @@ import dev.nokee.platform.base.VariantView;
 import dev.nokee.platform.c.CApplicationExtension;
 import dev.nokee.platform.nativebase.NativeApplication;
 import dev.nokee.platform.nativebase.NativeApplicationComponentDependencies;
+import dev.nokee.platform.nativebase.TargetBuildTypeFactory;
+import dev.nokee.platform.nativebase.TargetMachineFactory;
 import dev.nokee.platform.nativebase.internal.BaseNativeExtension;
 import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
+import dev.nokee.platform.nativebase.internal.DefaultTargetBuildTypeFactory;
+import dev.nokee.platform.nativebase.internal.DefaultTargetMachineFactory;
 import dev.nokee.runtime.nativebase.TargetBuildType;
 import dev.nokee.runtime.nativebase.TargetMachine;
 import lombok.Getter;
@@ -55,5 +59,15 @@ public class DefaultCApplicationExtension extends BaseNativeExtension<DefaultNat
 	@Override
 	public VariantView<NativeApplication> getVariants() {
 		return getComponent().getVariantCollection().getAsView(NativeApplication.class);
+	}
+
+	@Override
+	public TargetMachineFactory getMachines() {
+		return DefaultTargetMachineFactory.INSTANCE;
+	}
+
+	@Override
+	public TargetBuildTypeFactory getBuildTypes() {
+		return DefaultTargetBuildTypeFactory.INSTANCE;
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/DefaultCApplicationExtensionFactory.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/DefaultCApplicationExtensionFactory.java
@@ -1,0 +1,34 @@
+package dev.nokee.platform.c.internal;
+
+import dagger.MembersInjector;
+import dev.nokee.platform.nativebase.internal.DecoratingFactory;
+import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+/** @see DecoratingFactory */
+public final class DefaultCApplicationExtensionFactory extends AutoDefaultCApplicationExtensionFactory {
+	private final Provider<DefaultNativeApplicationComponent> componentProvider;
+	private final Provider<ObjectFactory> objectsProvider;
+	private final Provider<ProviderFactory> providersProvider;
+	private final Provider<ProjectLayout> layoutProvider;
+
+	@Inject
+	public DefaultCApplicationExtensionFactory(Provider<DefaultNativeApplicationComponent> componentProvider, Provider<ObjectFactory> objectsProvider, Provider<ProviderFactory> providersProvider, Provider<ProjectLayout> layoutProvider, MembersInjector<DecoratingFactory> injector) {
+		super(componentProvider, objectsProvider, providersProvider, layoutProvider);
+		this.componentProvider = componentProvider;
+		this.objectsProvider = objectsProvider;
+		this.providersProvider = providersProvider;
+		this.layoutProvider = layoutProvider;
+		injector.injectMembers(this);
+	}
+
+	@Override
+	public DefaultCApplicationExtension create() {
+		return newInstance(componentProvider.get(), objectsProvider.get(), providersProvider.get(), layoutProvider.get());
+	}
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/DefaultCLibraryExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/DefaultCLibraryExtension.java
@@ -4,10 +4,8 @@ import dev.nokee.language.c.internal.CHeaderSet;
 import dev.nokee.language.c.internal.CSourceSet;
 import dev.nokee.platform.base.VariantView;
 import dev.nokee.platform.c.CLibraryExtension;
-import dev.nokee.platform.nativebase.NativeLibrary;
-import dev.nokee.platform.nativebase.NativeLibraryComponentDependencies;
-import dev.nokee.platform.nativebase.internal.BaseNativeExtension;
-import dev.nokee.platform.nativebase.internal.DefaultNativeLibraryComponent;
+import dev.nokee.platform.nativebase.*;
+import dev.nokee.platform.nativebase.internal.*;
 import dev.nokee.runtime.nativebase.TargetBuildType;
 import dev.nokee.runtime.nativebase.TargetLinkage;
 import dev.nokee.runtime.nativebase.TargetMachine;
@@ -62,5 +60,20 @@ public class DefaultCLibraryExtension extends BaseNativeExtension<DefaultNativeL
 	@Override
 	public VariantView<NativeLibrary> getVariants() {
 		return getComponent().getVariantCollection().getAsView(NativeLibrary.class);
+	}
+
+	@Override
+	public TargetMachineFactory getMachines() {
+		return DefaultTargetMachineFactory.INSTANCE;
+	}
+
+	@Override
+	public TargetLinkageFactory getLinkages() {
+		return DefaultTargetLinkageFactory.INSTANCE;
+	}
+
+	@Override
+	public TargetBuildTypeFactory getBuildTypes() {
+		return DefaultTargetBuildTypeFactory.INSTANCE;
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/DefaultCLibraryExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/DefaultCLibraryExtension.java
@@ -1,5 +1,7 @@
 package dev.nokee.platform.c.internal;
 
+import com.google.auto.factory.AutoFactory;
+import com.google.auto.factory.Provided;
 import dev.nokee.language.c.internal.CHeaderSet;
 import dev.nokee.language.c.internal.CSourceSet;
 import dev.nokee.platform.base.VariantView;
@@ -20,6 +22,7 @@ import org.gradle.api.provider.SetProperty;
 
 import javax.inject.Inject;
 
+@AutoFactory(allowSubclasses = true, extending = DecoratingFactory.class, className = "AutoDefaultCLibraryExtensionFactory")
 public class DefaultCLibraryExtension extends BaseNativeExtension<DefaultNativeLibraryComponent> implements CLibraryExtension {
 	@Getter private final ConfigurableFileCollection sources;
 	@Getter private final ConfigurableFileCollection privateHeaders;
@@ -29,7 +32,7 @@ public class DefaultCLibraryExtension extends BaseNativeExtension<DefaultNativeL
 	@Getter private final SetProperty<TargetBuildType> targetBuildTypes;
 
 	@Inject
-	public DefaultCLibraryExtension(DefaultNativeLibraryComponent component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
+	public DefaultCLibraryExtension(@Provided DefaultNativeLibraryComponent component, @Provided ObjectFactory objects, @Provided ProviderFactory providers, @Provided ProjectLayout layout) {
 		super(component, objects, providers, layout);
 		this.sources = objects.fileCollection();
 		this.privateHeaders = objects.fileCollection();

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/DefaultCLibraryExtensionFactory.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/DefaultCLibraryExtensionFactory.java
@@ -1,0 +1,34 @@
+package dev.nokee.platform.c.internal;
+
+import dagger.MembersInjector;
+import dev.nokee.platform.nativebase.internal.DecoratingFactory;
+import dev.nokee.platform.nativebase.internal.DefaultNativeLibraryComponent;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+/** @see DecoratingFactory */
+public final class DefaultCLibraryExtensionFactory extends AutoDefaultCLibraryExtensionFactory {
+	private final Provider<DefaultNativeLibraryComponent> componentProvider;
+	private final Provider<ObjectFactory> objectsProvider;
+	private final Provider<ProviderFactory> providersProvider;
+	private final Provider<ProjectLayout> layoutProvider;
+
+	@Inject
+	public DefaultCLibraryExtensionFactory(Provider<DefaultNativeLibraryComponent> componentProvider, Provider<ObjectFactory> objectsProvider, Provider<ProviderFactory> providersProvider, Provider<ProjectLayout> layoutProvider, MembersInjector<DecoratingFactory> injector) {
+		super(componentProvider, objectsProvider, providersProvider, layoutProvider);
+		this.componentProvider = componentProvider;
+		this.objectsProvider = objectsProvider;
+		this.providersProvider = providersProvider;
+		this.layoutProvider = layoutProvider;
+		injector.injectMembers(this);
+	}
+
+	@Override
+	public DefaultCLibraryExtension create() {
+		return newInstance(componentProvider.get(), objectsProvider.get(), providersProvider.get(), layoutProvider.get());
+	}
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/plugins/CApplicationPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/plugins/CApplicationPlugin.java
@@ -1,7 +1,6 @@
 package dev.nokee.platform.c.internal.plugins;
 
-import dagger.BindsInstance;
-import dagger.Component;
+import dagger.*;
 import dev.nokee.gradle.internal.GradleModule;
 import dev.nokee.platform.base.DomainObjectElement;
 import dev.nokee.platform.base.internal.DomainObjectIdentity;
@@ -9,10 +8,8 @@ import dev.nokee.platform.base.internal.DomainObjectStore;
 import dev.nokee.platform.base.internal.plugins.ProjectStorePlugin;
 import dev.nokee.platform.c.CApplicationExtension;
 import dev.nokee.platform.c.internal.DefaultCApplicationExtension;
-import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
-import dev.nokee.platform.nativebase.internal.NativeComponentModule;
-import dev.nokee.platform.nativebase.internal.TargetBuildTypeRule;
-import dev.nokee.platform.nativebase.internal.TargetMachineRule;
+import dev.nokee.platform.c.internal.DefaultCApplicationExtensionFactory;
+import dev.nokee.platform.nativebase.internal.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.val;
@@ -65,7 +62,15 @@ public class CApplicationPlugin implements Plugin<Project> {
 		project.getExtensions().add(CApplicationExtension.class, EXTENSION_NAME, extension);
 	}
 
-	@Component(modules = {GradleModule.class, NativeComponentModule.class})
+	@Module
+	interface CModule {
+		@Provides
+		static DefaultCApplicationExtension theExtension(DefaultCApplicationExtensionFactory factory) {
+			return factory.create();
+		}
+	}
+
+	@Component(modules = {GradleModule.class, NativeComponentModule.class, CModule.class})
 	interface CApplicationComponent {
 		DefaultCApplicationExtension cApplicationComponent();
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/plugins/CApplicationPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/plugins/CApplicationPlugin.java
@@ -1,11 +1,16 @@
 package dev.nokee.platform.c.internal.plugins;
 
+import dagger.BindsInstance;
+import dagger.Component;
+import dev.nokee.gradle.internal.GradleModule;
+import dev.nokee.platform.base.DomainObjectElement;
+import dev.nokee.platform.base.internal.DomainObjectIdentity;
 import dev.nokee.platform.base.internal.DomainObjectStore;
-import dev.nokee.platform.base.internal.NamingSchemeFactory;
 import dev.nokee.platform.base.internal.plugins.ProjectStorePlugin;
 import dev.nokee.platform.c.CApplicationExtension;
 import dev.nokee.platform.c.internal.DefaultCApplicationExtension;
 import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
+import dev.nokee.platform.nativebase.internal.NativeComponentModule;
 import dev.nokee.platform.nativebase.internal.TargetBuildTypeRule;
 import dev.nokee.platform.nativebase.internal.TargetMachineRule;
 import lombok.AccessLevel;
@@ -33,14 +38,40 @@ public class CApplicationPlugin implements Plugin<Project> {
 		project.getPluginManager().apply(ProjectStorePlugin.class);
 
 		val store = project.getExtensions().getByType(DomainObjectStore.class);
-		val component = store.register(DefaultNativeApplicationComponent.newMain(getObjects(), new NamingSchemeFactory(project.getName())));
+		val extension = DaggerCApplicationPlugin_CApplicationComponent.factory().create(project).cApplicationComponent();
+		val component = store.add(new DomainObjectElement<DefaultNativeApplicationComponent>() {
+			@Override
+			public DefaultNativeApplicationComponent get() {
+				return extension.getComponent();
+			}
+
+			@Override
+			public Class<DefaultNativeApplicationComponent> getType() {
+				return DefaultNativeApplicationComponent.class;
+			}
+
+			@Override
+			public DomainObjectIdentity getIdentity() {
+				return DomainObjectIdentity.named("main");
+			}
+		});
 		component.configure(it -> it.getBaseName().convention(project.getName()));
-		DefaultCApplicationExtension extension = getObjects().newInstance(DefaultCApplicationExtension.class, component.get());
+		component.get(); // force realize... for now.
 
 		project.afterEvaluate(getObjects().newInstance(TargetMachineRule.class, extension.getTargetMachines(), EXTENSION_NAME));
 		project.afterEvaluate(getObjects().newInstance(TargetBuildTypeRule.class, extension.getTargetBuildTypes(), EXTENSION_NAME));
 		project.afterEvaluate(extension::finalizeExtension);
 
 		project.getExtensions().add(CApplicationExtension.class, EXTENSION_NAME, extension);
+	}
+
+	@Component(modules = {GradleModule.class, NativeComponentModule.class})
+	interface CApplicationComponent {
+		DefaultCApplicationExtension cApplicationComponent();
+
+		@Component.Factory
+		interface Factory {
+			CApplicationComponent create(@BindsInstance Project project);
+		}
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/plugins/CLibraryPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/plugins/CLibraryPlugin.java
@@ -2,6 +2,8 @@ package dev.nokee.platform.c.internal.plugins;
 
 import dagger.BindsInstance;
 import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
 import dev.nokee.gradle.internal.GradleModule;
 import dev.nokee.platform.base.DomainObjectElement;
 import dev.nokee.platform.base.internal.DomainObjectIdentity;
@@ -9,6 +11,7 @@ import dev.nokee.platform.base.internal.DomainObjectStore;
 import dev.nokee.platform.base.internal.plugins.ProjectStorePlugin;
 import dev.nokee.platform.c.CLibraryExtension;
 import dev.nokee.platform.c.internal.DefaultCLibraryExtension;
+import dev.nokee.platform.c.internal.DefaultCLibraryExtensionFactory;
 import dev.nokee.platform.nativebase.internal.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -63,7 +66,15 @@ public class CLibraryPlugin implements Plugin<Project> {
 		project.getExtensions().add(CLibraryExtension.class, EXTENSION_NAME, extension);
 	}
 
-	@Component(modules = {GradleModule.class, NativeComponentModule.class})
+	@Module
+	interface CModule {
+		@Provides
+		static DefaultCLibraryExtension theExtension(DefaultCLibraryExtensionFactory factory) {
+			return factory.create();
+		}
+	}
+
+	@Component(modules = {GradleModule.class, NativeComponentModule.class, CModule.class})
 	interface CLibraryComponent {
 		DefaultCLibraryExtension cLibraryComponent();
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/plugins/CLibraryPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/plugins/CLibraryPlugin.java
@@ -1,14 +1,15 @@
 package dev.nokee.platform.c.internal.plugins;
 
+import dagger.BindsInstance;
+import dagger.Component;
+import dev.nokee.gradle.internal.GradleModule;
+import dev.nokee.platform.base.DomainObjectElement;
+import dev.nokee.platform.base.internal.DomainObjectIdentity;
 import dev.nokee.platform.base.internal.DomainObjectStore;
-import dev.nokee.platform.base.internal.NamingSchemeFactory;
 import dev.nokee.platform.base.internal.plugins.ProjectStorePlugin;
 import dev.nokee.platform.c.CLibraryExtension;
 import dev.nokee.platform.c.internal.DefaultCLibraryExtension;
-import dev.nokee.platform.nativebase.internal.DefaultNativeLibraryComponent;
-import dev.nokee.platform.nativebase.internal.TargetBuildTypeRule;
-import dev.nokee.platform.nativebase.internal.TargetLinkageRule;
-import dev.nokee.platform.nativebase.internal.TargetMachineRule;
+import dev.nokee.platform.nativebase.internal.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.val;
@@ -34,9 +35,25 @@ public class CLibraryPlugin implements Plugin<Project> {
 		project.getPluginManager().apply(ProjectStorePlugin.class);
 
 		val store = project.getExtensions().getByType(DomainObjectStore.class);
-		val component = store.register(DefaultNativeLibraryComponent.newMain(getObjects(), new NamingSchemeFactory(project.getName())));
+		val extension = DaggerCLibraryPlugin_CLibraryComponent.factory().create(project).cLibraryComponent();
+		val component = store.add(new DomainObjectElement<DefaultNativeLibraryComponent>() {
+			@Override
+			public DefaultNativeLibraryComponent get() {
+				return extension.getComponent();
+			}
+
+			@Override
+			public Class<DefaultNativeLibraryComponent> getType() {
+				return DefaultNativeLibraryComponent.class;
+			}
+
+			@Override
+			public DomainObjectIdentity getIdentity() {
+				return DomainObjectIdentity.named("main");
+			}
+		});
 		component.configure(it -> it.getBaseName().convention(project.getName()));
-		DefaultCLibraryExtension extension = getObjects().newInstance(DefaultCLibraryExtension.class, component.get());
+		component.get(); // force realize... for now.
 
 		project.afterEvaluate(getObjects().newInstance(TargetMachineRule.class, extension.getTargetMachines(), EXTENSION_NAME));
 		project.afterEvaluate(getObjects().newInstance(TargetLinkageRule.class, extension.getTargetLinkages(), EXTENSION_NAME));
@@ -44,5 +61,15 @@ public class CLibraryPlugin implements Plugin<Project> {
 		project.afterEvaluate(extension::finalizeExtension);
 
 		project.getExtensions().add(CLibraryExtension.class, EXTENSION_NAME, extension);
+	}
+
+	@Component(modules = {GradleModule.class, NativeComponentModule.class})
+	interface CLibraryComponent {
+		DefaultCLibraryExtension cLibraryComponent();
+
+		@Component.Factory
+		interface Factory {
+			CLibraryComponent create(@BindsInstance Project project);
+		}
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/DefaultCppApplicationExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/DefaultCppApplicationExtension.java
@@ -6,8 +6,12 @@ import dev.nokee.platform.base.VariantView;
 import dev.nokee.platform.cpp.CppApplicationExtension;
 import dev.nokee.platform.nativebase.NativeApplication;
 import dev.nokee.platform.nativebase.NativeApplicationComponentDependencies;
+import dev.nokee.platform.nativebase.TargetBuildTypeFactory;
+import dev.nokee.platform.nativebase.TargetMachineFactory;
 import dev.nokee.platform.nativebase.internal.BaseNativeExtension;
 import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
+import dev.nokee.platform.nativebase.internal.DefaultTargetBuildTypeFactory;
+import dev.nokee.platform.nativebase.internal.DefaultTargetMachineFactory;
 import dev.nokee.runtime.nativebase.TargetBuildType;
 import dev.nokee.runtime.nativebase.TargetMachine;
 import lombok.Getter;
@@ -56,5 +60,15 @@ public class DefaultCppApplicationExtension extends BaseNativeExtension<DefaultN
 	@Override
 	public VariantView<NativeApplication> getVariants() {
 		return getComponent().getVariantCollection().getAsView(NativeApplication.class);
+	}
+
+	@Override
+	public TargetMachineFactory getMachines() {
+		return DefaultTargetMachineFactory.INSTANCE;
+	}
+
+	@Override
+	public TargetBuildTypeFactory getBuildTypes() {
+		return DefaultTargetBuildTypeFactory.INSTANCE;
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/DefaultCppApplicationExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/DefaultCppApplicationExtension.java
@@ -1,5 +1,7 @@
 package dev.nokee.platform.cpp.internal;
 
+import com.google.auto.factory.AutoFactory;
+import com.google.auto.factory.Provided;
 import dev.nokee.language.cpp.internal.CppHeaderSet;
 import dev.nokee.language.cpp.internal.CppSourceSet;
 import dev.nokee.platform.base.VariantView;
@@ -8,10 +10,7 @@ import dev.nokee.platform.nativebase.NativeApplication;
 import dev.nokee.platform.nativebase.NativeApplicationComponentDependencies;
 import dev.nokee.platform.nativebase.TargetBuildTypeFactory;
 import dev.nokee.platform.nativebase.TargetMachineFactory;
-import dev.nokee.platform.nativebase.internal.BaseNativeExtension;
-import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
-import dev.nokee.platform.nativebase.internal.DefaultTargetBuildTypeFactory;
-import dev.nokee.platform.nativebase.internal.DefaultTargetMachineFactory;
+import dev.nokee.platform.nativebase.internal.*;
 import dev.nokee.runtime.nativebase.TargetBuildType;
 import dev.nokee.runtime.nativebase.TargetMachine;
 import lombok.Getter;
@@ -25,6 +24,7 @@ import org.gradle.api.provider.SetProperty;
 
 import javax.inject.Inject;
 
+@AutoFactory(allowSubclasses = true, extending = DecoratingFactory.class, className = "AutoDefaultCppApplicationExtensionFactory")
 public class DefaultCppApplicationExtension extends BaseNativeExtension<DefaultNativeApplicationComponent> implements CppApplicationExtension {
 	@Getter private final ConfigurableFileCollection sources;
 	@Getter private final ConfigurableFileCollection privateHeaders;
@@ -32,7 +32,7 @@ public class DefaultCppApplicationExtension extends BaseNativeExtension<DefaultN
 	@Getter private final SetProperty<TargetBuildType> targetBuildTypes;
 
 	@Inject
-	public DefaultCppApplicationExtension(DefaultNativeApplicationComponent component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
+	public DefaultCppApplicationExtension(@Provided DefaultNativeApplicationComponent component, @Provided ObjectFactory objects, @Provided ProviderFactory providers, @Provided ProjectLayout layout) {
 		super(component, objects, providers, layout);
 		this.sources = objects.fileCollection();
 		this.privateHeaders = objects.fileCollection();

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/DefaultCppApplicationExtensionFactory.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/DefaultCppApplicationExtensionFactory.java
@@ -1,0 +1,34 @@
+package dev.nokee.platform.cpp.internal;
+
+import dagger.MembersInjector;
+import dev.nokee.platform.nativebase.internal.DecoratingFactory;
+import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+/** @see DecoratingFactory */
+public final class DefaultCppApplicationExtensionFactory extends AutoDefaultCppApplicationExtensionFactory {
+	private final Provider<DefaultNativeApplicationComponent> componentProvider;
+	private final Provider<ObjectFactory> objectsProvider;
+	private final Provider<ProviderFactory> providersProvider;
+	private final Provider<ProjectLayout> layoutProvider;
+
+	@Inject
+	public DefaultCppApplicationExtensionFactory(Provider<DefaultNativeApplicationComponent> componentProvider, Provider<ObjectFactory> objectsProvider, Provider<ProviderFactory> providersProvider, Provider<ProjectLayout> layoutProvider, MembersInjector<DecoratingFactory> injector) {
+		super(componentProvider, objectsProvider, providersProvider, layoutProvider);
+		this.componentProvider = componentProvider;
+		this.objectsProvider = objectsProvider;
+		this.providersProvider = providersProvider;
+		this.layoutProvider = layoutProvider;
+		injector.injectMembers(this);
+	}
+
+	@Override
+	public DefaultCppApplicationExtension create() {
+		return newInstance(componentProvider.get(), objectsProvider.get(), providersProvider.get(), layoutProvider.get());
+	}
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/DefaultCppLibraryExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/DefaultCppLibraryExtension.java
@@ -1,5 +1,7 @@
 package dev.nokee.platform.cpp.internal;
 
+import com.google.auto.factory.AutoFactory;
+import com.google.auto.factory.Provided;
 import dev.nokee.language.cpp.internal.CppHeaderSet;
 import dev.nokee.language.cpp.internal.CppSourceSet;
 import dev.nokee.platform.base.VariantView;
@@ -20,6 +22,7 @@ import org.gradle.api.provider.SetProperty;
 
 import javax.inject.Inject;
 
+@AutoFactory(allowSubclasses = true, extending = DecoratingFactory.class, className = "AutoDefaultCppLibraryExtensionFactory")
 public class DefaultCppLibraryExtension extends BaseNativeExtension<DefaultNativeLibraryComponent> implements CppLibraryExtension {
 	@Getter private final ConfigurableFileCollection sources;
 	@Getter private final ConfigurableFileCollection privateHeaders;
@@ -29,7 +32,7 @@ public class DefaultCppLibraryExtension extends BaseNativeExtension<DefaultNativ
 	@Getter private final SetProperty<TargetBuildType> targetBuildTypes;
 
 	@Inject
-	public DefaultCppLibraryExtension(DefaultNativeLibraryComponent component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
+	public DefaultCppLibraryExtension(@Provided DefaultNativeLibraryComponent component, @Provided ObjectFactory objects, @Provided ProviderFactory providers, @Provided ProjectLayout layout) {
 		super(component, objects, providers, layout);
 		this.sources = objects.fileCollection();
 		this.privateHeaders = objects.fileCollection();

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/DefaultCppLibraryExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/DefaultCppLibraryExtension.java
@@ -4,10 +4,8 @@ import dev.nokee.language.cpp.internal.CppHeaderSet;
 import dev.nokee.language.cpp.internal.CppSourceSet;
 import dev.nokee.platform.base.VariantView;
 import dev.nokee.platform.cpp.CppLibraryExtension;
-import dev.nokee.platform.nativebase.NativeLibrary;
-import dev.nokee.platform.nativebase.NativeLibraryComponentDependencies;
-import dev.nokee.platform.nativebase.internal.BaseNativeExtension;
-import dev.nokee.platform.nativebase.internal.DefaultNativeLibraryComponent;
+import dev.nokee.platform.nativebase.*;
+import dev.nokee.platform.nativebase.internal.*;
 import dev.nokee.runtime.nativebase.TargetBuildType;
 import dev.nokee.runtime.nativebase.TargetLinkage;
 import dev.nokee.runtime.nativebase.TargetMachine;
@@ -62,5 +60,20 @@ public class DefaultCppLibraryExtension extends BaseNativeExtension<DefaultNativ
 	@Override
 	public VariantView<NativeLibrary> getVariants() {
 		return getComponent().getVariantCollection().getAsView(NativeLibrary.class);
+	}
+
+	@Override
+	public TargetMachineFactory getMachines() {
+		return DefaultTargetMachineFactory.INSTANCE;
+	}
+
+	@Override
+	public TargetLinkageFactory getLinkages() {
+		return DefaultTargetLinkageFactory.INSTANCE;
+	}
+
+	@Override
+	public TargetBuildTypeFactory getBuildTypes() {
+		return DefaultTargetBuildTypeFactory.INSTANCE;
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/DefaultCppLibraryExtensionFactory.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/DefaultCppLibraryExtensionFactory.java
@@ -1,0 +1,34 @@
+package dev.nokee.platform.cpp.internal;
+
+import dagger.MembersInjector;
+import dev.nokee.platform.nativebase.internal.DecoratingFactory;
+import dev.nokee.platform.nativebase.internal.DefaultNativeLibraryComponent;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+/** @see DecoratingFactory */
+public final class DefaultCppLibraryExtensionFactory extends AutoDefaultCppLibraryExtensionFactory {
+	private final Provider<DefaultNativeLibraryComponent> componentProvider;
+	private final Provider<ObjectFactory> objectsProvider;
+	private final Provider<ProviderFactory> providersProvider;
+	private final Provider<ProjectLayout> layoutProvider;
+
+	@Inject
+	public DefaultCppLibraryExtensionFactory(Provider<DefaultNativeLibraryComponent> componentProvider, Provider<ObjectFactory> objectsProvider, Provider<ProviderFactory> providersProvider, Provider<ProjectLayout> layoutProvider, MembersInjector<DecoratingFactory> injector) {
+		super(componentProvider, objectsProvider, providersProvider, layoutProvider);
+		this.componentProvider = componentProvider;
+		this.objectsProvider = objectsProvider;
+		this.providersProvider = providersProvider;
+		this.layoutProvider = layoutProvider;
+		injector.injectMembers(this);
+	}
+
+	@Override
+	public DefaultCppLibraryExtension create() {
+		return newInstance(componentProvider.get(), objectsProvider.get(), providersProvider.get(), layoutProvider.get());
+	}
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppApplicationPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppApplicationPlugin.java
@@ -2,6 +2,8 @@ package dev.nokee.platform.cpp.internal.plugins;
 
 import dagger.BindsInstance;
 import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
 import dev.nokee.gradle.internal.GradleModule;
 import dev.nokee.platform.base.DomainObjectElement;
 import dev.nokee.platform.base.internal.DomainObjectIdentity;
@@ -9,6 +11,7 @@ import dev.nokee.platform.base.internal.DomainObjectStore;
 import dev.nokee.platform.base.internal.plugins.ProjectStorePlugin;
 import dev.nokee.platform.cpp.CppApplicationExtension;
 import dev.nokee.platform.cpp.internal.DefaultCppApplicationExtension;
+import dev.nokee.platform.cpp.internal.DefaultCppApplicationExtensionFactory;
 import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
 import dev.nokee.platform.nativebase.internal.NativeComponentModule;
 import dev.nokee.platform.nativebase.internal.TargetBuildTypeRule;
@@ -65,7 +68,15 @@ public class CppApplicationPlugin implements Plugin<Project> {
 		project.getExtensions().add(CppApplicationExtension.class, EXTENSION_NAME, extension);
 	}
 
-	@Component(modules = {GradleModule.class, NativeComponentModule.class})
+	@Module
+	interface CppModule {
+		@Provides
+		static DefaultCppApplicationExtension theExtension(DefaultCppApplicationExtensionFactory factory) {
+			return factory.create();
+		}
+	}
+
+	@Component(modules = {GradleModule.class, NativeComponentModule.class, CppModule.class})
 	interface CppApplicationComponent {
 		DefaultCppApplicationExtension cppApplicationComponent();
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppApplicationPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppApplicationPlugin.java
@@ -1,11 +1,16 @@
 package dev.nokee.platform.cpp.internal.plugins;
 
+import dagger.BindsInstance;
+import dagger.Component;
+import dev.nokee.gradle.internal.GradleModule;
+import dev.nokee.platform.base.DomainObjectElement;
+import dev.nokee.platform.base.internal.DomainObjectIdentity;
 import dev.nokee.platform.base.internal.DomainObjectStore;
-import dev.nokee.platform.base.internal.NamingSchemeFactory;
 import dev.nokee.platform.base.internal.plugins.ProjectStorePlugin;
 import dev.nokee.platform.cpp.CppApplicationExtension;
 import dev.nokee.platform.cpp.internal.DefaultCppApplicationExtension;
 import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
+import dev.nokee.platform.nativebase.internal.NativeComponentModule;
 import dev.nokee.platform.nativebase.internal.TargetBuildTypeRule;
 import dev.nokee.platform.nativebase.internal.TargetMachineRule;
 import lombok.AccessLevel;
@@ -33,14 +38,40 @@ public class CppApplicationPlugin implements Plugin<Project> {
 		project.getPluginManager().apply(ProjectStorePlugin.class);
 
 		val store = project.getExtensions().getByType(DomainObjectStore.class);
-		val component = store.register(DefaultNativeApplicationComponent.newMain(getObjects(), new NamingSchemeFactory(project.getName())));
+		val extension = DaggerCppApplicationPlugin_CppApplicationComponent.factory().create(project).cppApplicationComponent();
+		val component = store.add(new DomainObjectElement<DefaultNativeApplicationComponent>() {
+			@Override
+			public DefaultNativeApplicationComponent get() {
+				return extension.getComponent();
+			}
+
+			@Override
+			public Class<DefaultNativeApplicationComponent> getType() {
+				return DefaultNativeApplicationComponent.class;
+			}
+
+			@Override
+			public DomainObjectIdentity getIdentity() {
+				return DomainObjectIdentity.named("main");
+			}
+		});
 		component.configure(it -> it.getBaseName().convention(project.getName()));
-		DefaultCppApplicationExtension extension = getObjects().newInstance(DefaultCppApplicationExtension.class, component.get());
+		component.get(); // force realize... for now.
 
 		project.afterEvaluate(getObjects().newInstance(TargetMachineRule.class, extension.getTargetMachines(), EXTENSION_NAME));
 		project.afterEvaluate(getObjects().newInstance(TargetBuildTypeRule.class, extension.getTargetBuildTypes(), EXTENSION_NAME));
 		project.afterEvaluate(extension::finalizeExtension);
 
 		project.getExtensions().add(CppApplicationExtension.class, EXTENSION_NAME, extension);
+	}
+
+	@Component(modules = {GradleModule.class, NativeComponentModule.class})
+	interface CppApplicationComponent {
+		DefaultCppApplicationExtension cppApplicationComponent();
+
+		@Component.Factory
+		interface Factory {
+			CppApplicationComponent create(@BindsInstance Project project);
+		}
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppLibraryPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppLibraryPlugin.java
@@ -2,6 +2,8 @@ package dev.nokee.platform.cpp.internal.plugins;
 
 import dagger.BindsInstance;
 import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
 import dev.nokee.gradle.internal.GradleModule;
 import dev.nokee.platform.base.DomainObjectElement;
 import dev.nokee.platform.base.internal.DomainObjectIdentity;
@@ -9,6 +11,7 @@ import dev.nokee.platform.base.internal.DomainObjectStore;
 import dev.nokee.platform.base.internal.plugins.ProjectStorePlugin;
 import dev.nokee.platform.cpp.CppLibraryExtension;
 import dev.nokee.platform.cpp.internal.DefaultCppLibraryExtension;
+import dev.nokee.platform.cpp.internal.DefaultCppLibraryExtensionFactory;
 import dev.nokee.platform.nativebase.internal.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -63,7 +66,15 @@ public class CppLibraryPlugin implements Plugin<Project> {
 		project.getExtensions().add(CppLibraryExtension.class, EXTENSION_NAME, extension);
 	}
 
-	@Component(modules = {GradleModule.class, NativeComponentModule.class})
+	@Module
+	interface CppModule {
+		@Provides
+		static DefaultCppLibraryExtension theExtension(DefaultCppLibraryExtensionFactory factory) {
+			return factory.create();
+		}
+	}
+
+	@Component(modules = {GradleModule.class, NativeComponentModule.class, CppModule.class})
 	interface CppLibraryComponent {
 		DefaultCppLibraryExtension cppLibraryComponent();
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppLibraryPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppLibraryPlugin.java
@@ -1,14 +1,15 @@
 package dev.nokee.platform.cpp.internal.plugins;
 
+import dagger.BindsInstance;
+import dagger.Component;
+import dev.nokee.gradle.internal.GradleModule;
+import dev.nokee.platform.base.DomainObjectElement;
+import dev.nokee.platform.base.internal.DomainObjectIdentity;
 import dev.nokee.platform.base.internal.DomainObjectStore;
-import dev.nokee.platform.base.internal.NamingSchemeFactory;
 import dev.nokee.platform.base.internal.plugins.ProjectStorePlugin;
 import dev.nokee.platform.cpp.CppLibraryExtension;
 import dev.nokee.platform.cpp.internal.DefaultCppLibraryExtension;
-import dev.nokee.platform.nativebase.internal.DefaultNativeLibraryComponent;
-import dev.nokee.platform.nativebase.internal.TargetBuildTypeRule;
-import dev.nokee.platform.nativebase.internal.TargetLinkageRule;
-import dev.nokee.platform.nativebase.internal.TargetMachineRule;
+import dev.nokee.platform.nativebase.internal.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.val;
@@ -34,9 +35,25 @@ public class CppLibraryPlugin implements Plugin<Project> {
 		project.getPluginManager().apply(ProjectStorePlugin.class);
 
 		val store = project.getExtensions().getByType(DomainObjectStore.class);
-		val component = store.register(DefaultNativeLibraryComponent.newMain(getObjects(), new NamingSchemeFactory(project.getName())));
+		val extension = DaggerCppLibraryPlugin_CppLibraryComponent.factory().create(project).cppLibraryComponent();
+		val component = store.add(new DomainObjectElement<DefaultNativeLibraryComponent>() {
+			@Override
+			public DefaultNativeLibraryComponent get() {
+				return extension.getComponent();
+			}
+
+			@Override
+			public Class<DefaultNativeLibraryComponent> getType() {
+				return DefaultNativeLibraryComponent.class;
+			}
+
+			@Override
+			public DomainObjectIdentity getIdentity() {
+				return DomainObjectIdentity.named("main");
+			}
+		});
 		component.configure(it -> it.getBaseName().convention(project.getName()));
-		DefaultCppLibraryExtension extension = getObjects().newInstance(DefaultCppLibraryExtension.class, component.get());
+		component.get(); // force realize... for now.
 
 		project.afterEvaluate(getObjects().newInstance(TargetMachineRule.class, extension.getTargetMachines(), EXTENSION_NAME));
 		project.afterEvaluate(getObjects().newInstance(TargetLinkageRule.class, extension.getTargetLinkages(), EXTENSION_NAME));
@@ -44,5 +61,15 @@ public class CppLibraryPlugin implements Plugin<Project> {
 		project.afterEvaluate(extension::finalizeExtension);
 
 		project.getExtensions().add(CppLibraryExtension.class, EXTENSION_NAME, extension);
+	}
+
+	@Component(modules = {GradleModule.class, NativeComponentModule.class})
+	interface CppLibraryComponent {
+		DefaultCppLibraryExtension cppLibraryComponent();
+
+		@Component.Factory
+		interface Factory {
+			CppLibraryComponent create(@BindsInstance Project project);
+		}
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeComponent.java
@@ -94,28 +94,25 @@ public abstract class BaseNativeComponent<T extends VariantInternal> extends Bas
 				if (buildVariant.hasAxisValue(DefaultBinaryLinkage.DIMENSION_TYPE)) {
 					DefaultBinaryLinkage linkage = buildVariant.getAxisValue(DefaultBinaryLinkage.DIMENSION_TYPE);
 					if (linkage.equals(DefaultBinaryLinkage.EXECUTABLE)) {
-						TaskProvider<LinkExecutableTask> linkTask = getTasks().register(names.getTaskName("link"), LinkExecutableTask.class);
-						ExecutableBinaryInternal binary = getObjects().newInstance(ExecutableBinaryInternal.class, names, objectSourceSets, targetMachineInternal, linkTask, dependencies.getIncoming());
+						val factory = new ExecutableBinaryFactoryImpl(getTasks(), getObjects(), dependencies);
+						val binary = factory.create(names, targetMachineInternal, objectSourceSets);
 						variantInternal.getBinaryCollection().add(binary);
-						binary.getBaseName().convention(getBaseName());
+						((BaseNativeBinary)binary).getBaseName().convention(getBaseName());
 					} else if (linkage.equals(DefaultBinaryLinkage.SHARED)) {
-						TaskProvider<LinkSharedLibraryTask> linkTask = getTasks().register(names.getTaskName("link"), LinkSharedLibraryTask.class);
-
-						SharedLibraryBinaryInternal binary = getObjects().newInstance(SharedLibraryBinaryInternal.class, names, getObjects().domainObjectSet(LanguageSourceSetInternal.class), targetMachineInternal, objectSourceSets, linkTask, dependencies.getIncoming());
+						val factory = new SharedLibraryBinaryFactoryImpl(getTasks(), getObjects(), dependencies);
+						val binary = factory.create(names, targetMachineInternal, objectSourceSets);
 						variantInternal.getBinaryCollection().add(binary);
-						binary.getBaseName().convention(getBaseName());
+						((BaseNativeBinary)binary).getBaseName().convention(getBaseName());
 					} else if (linkage.equals(DefaultBinaryLinkage.BUNDLE)) {
-						TaskProvider<LinkBundleTask> linkTask = getTasks().register(names.getTaskName("link"), LinkBundleTask.class);
-
-						BundleBinaryInternal binary = getObjects().newInstance(BundleBinaryInternal.class, names, targetMachineInternal, objectSourceSets, linkTask, dependencies.getIncoming());
+						val factory = new BundleBinaryFactoryImpl(getTasks(), getObjects(), dependencies);
+						val binary = factory.create(names, targetMachineInternal, objectSourceSets);
 						variantInternal.getBinaryCollection().add(binary);
-						binary.getBaseName().convention(getBaseName());
+						((BaseNativeBinary)binary).getBaseName().convention(getBaseName());
 					} else if (linkage.equals(DefaultBinaryLinkage.STATIC)) {
-						TaskProvider<CreateStaticLibraryTask> createTask = getTasks().register(names.getTaskName("create"), CreateStaticLibraryTask.class);
-
-						val binary = getObjects().newInstance(StaticLibraryBinaryInternal.class, names, objectSourceSets, targetMachineInternal, createTask, dependencies.getIncoming());
+						val factory = new StaticLibraryBinaryFactoryImpl(getTasks(), getObjects(), dependencies);
+						val binary = factory.create(names, targetMachineInternal, objectSourceSets);
 						variantInternal.getBinaryCollection().add(binary);
-						binary.getBaseName().convention(getBaseName());
+						((BaseNativeBinary)binary).getBaseName().convention(getBaseName());
 					}
 				}
 				it.getBinaries().configureEach(NativeBinary.class, binary -> {

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeExtension.java
@@ -59,18 +59,6 @@ public class BaseNativeExtension<T extends BaseNativeComponent<?>> {
 		};
 	}
 
-	public DefaultTargetMachineFactory getMachines() {
-		return DefaultTargetMachineFactory.INSTANCE;
-	}
-
-	public DefaultTargetLinkageFactory getLinkages() {
-		return DefaultTargetLinkageFactory.INSTANCE;
-	}
-
-	public DefaultTargetBuildTypeFactory getBuildTypes() {
-		return DefaultTargetBuildTypeFactory.INSTANCE;
-	}
-
 	public BinaryView<Binary> getBinaries() {
 		return component.getBinaries();
 	}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BundleBinaryFactory.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BundleBinaryFactory.java
@@ -1,0 +1,11 @@
+package dev.nokee.platform.nativebase.internal;
+
+import dev.nokee.language.base.internal.GeneratedSourceSet;
+import dev.nokee.platform.base.internal.NamingScheme;
+import dev.nokee.platform.nativebase.BundleBinary;
+import dev.nokee.runtime.nativebase.internal.DefaultTargetMachine;
+import org.gradle.api.DomainObjectSet;
+
+public interface BundleBinaryFactory {
+	BundleBinary create(NamingScheme names, DefaultTargetMachine targetMachine, DomainObjectSet<GeneratedSourceSet> objectSourceSets);
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BundleBinaryFactoryImpl.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BundleBinaryFactoryImpl.java
@@ -1,0 +1,32 @@
+package dev.nokee.platform.nativebase.internal;
+
+import dev.nokee.language.base.internal.GeneratedSourceSet;
+import dev.nokee.platform.base.internal.NamingScheme;
+import dev.nokee.platform.base.internal.tasks.ComponentTasksInternal;
+import dev.nokee.platform.base.internal.tasks.TaskName;
+import dev.nokee.platform.nativebase.BundleBinary;
+import dev.nokee.platform.nativebase.internal.dependencies.VariantComponentDependencies;
+import dev.nokee.platform.nativebase.tasks.internal.LinkBundleTask;
+import dev.nokee.runtime.nativebase.internal.DefaultTargetMachine;
+import lombok.val;
+import org.gradle.api.DomainObjectSet;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.tasks.TaskContainer;
+
+public class BundleBinaryFactoryImpl implements BundleBinaryFactory {
+	private final TaskContainer tasks;
+	private final ObjectFactory objectFactory;
+	private final VariantComponentDependencies<?> dependencies;
+
+	public BundleBinaryFactoryImpl(TaskContainer tasks, ObjectFactory objectFactory, VariantComponentDependencies<?> dependencies) {
+		this.tasks = tasks;
+		this.objectFactory = objectFactory;
+		this.dependencies = dependencies;
+	}
+
+	@Override
+	public BundleBinary create(NamingScheme names, DefaultTargetMachine targetMachine, DomainObjectSet<GeneratedSourceSet> objectSourceSets) {
+		val linkTask = tasks.register(names.getTaskName("link"), LinkBundleTask.class);
+		return objectFactory.newInstance(BundleBinaryInternal.class, names, targetMachine, objectSourceSets, linkTask, dependencies.getIncoming());
+	}
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DecoratingFactory.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DecoratingFactory.java
@@ -1,0 +1,30 @@
+package dev.nokee.platform.nativebase.internal;
+
+import org.gradle.api.model.ObjectFactory;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import java.lang.reflect.Method;
+
+/**
+ * The decorating factory act as an extension to AutoFactory by using an custom instantiator instead of using the classic new keyword.
+ * The goal is to use Gradle's ObjectFactory with Dagger while having compile time checks by generating static factories.
+ * This is a temporary solution until 1) we get rid of the ObjectFactory requirement for decoration or 2) a solution is provided to https://github.com/google/auto/issues/872.
+ */
+public class DecoratingFactory {
+	@Inject
+	protected Provider<ObjectFactory> objectFactoryProvider;
+
+	private <T> Class<T> getType() {
+		for (Method method : this.getClass().getMethods()) {
+			if (method.getName().equals("create")) {
+				return (Class<T>)method.getReturnType();
+			}
+		}
+		throw new IllegalStateException();
+	}
+
+	protected final <T> T newInstance(Object... args) {
+		return objectFactoryProvider.get().newInstance(getType(), args);
+	}
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationComponent.java
@@ -32,11 +32,10 @@ public class DefaultNativeApplicationComponent extends BaseNativeComponent<Defau
 	@Getter(AccessLevel.PROTECTED) private final DependencyHandler dependencyHandler;
 
 	@Inject
-	public DefaultNativeApplicationComponent(NamingScheme names, ObjectFactory objects, ProviderFactory providers, TaskContainer tasks, ProjectLayout layout, ConfigurationContainer configurations, DependencyHandler dependencyHandler) {
+	public DefaultNativeApplicationComponent(NamingScheme names, ObjectFactory objects, ProviderFactory providers, TaskContainer tasks, ProjectLayout layout, ConfigurationContainer configurations, DependencyHandler dependencyHandler, DefaultNativeApplicationComponentDependencies dependencies) {
 		super(names, DefaultNativeApplicationVariant.class, objects, providers, tasks, layout, configurations);
 		this.dependencyHandler = dependencyHandler;
-		val dependencyContainer = objects.newInstance(DefaultComponentDependencies.class, names.getComponentDisplayName(), new FrameworkAwareDependencyBucketFactory(new DefaultDependencyBucketFactory(new ConfigurationFactories.Prefixing(new ConfigurationFactories.Creating(getConfigurations()), names::getConfigurationName), new DefaultDependencyFactory(getDependencyHandler()))));
-		this.dependencies = objects.newInstance(DefaultNativeApplicationComponentDependencies.class, dependencyContainer);
+		this.dependencies = dependencies;
 		getDimensions().convention(ImmutableSet.of(DefaultBinaryLinkage.DIMENSION_TYPE, BaseTargetBuildType.DIMENSION_TYPE, DefaultOperatingSystemFamily.DIMENSION_TYPE, DefaultMachineArchitecture.DIMENSION_TYPE));
 	}
 
@@ -83,30 +82,5 @@ public class DefaultNativeApplicationComponent extends BaseNativeComponent<Defau
 
 		DefaultNativeApplicationVariant result = getObjects().newInstance(DefaultNativeApplicationVariant.class, name, names, buildVariant, variantDependencies);
 		return result;
-	}
-
-	public static DomainObjectFactory<DefaultNativeApplicationComponent> newMain(ObjectFactory objects, NamingSchemeFactory namingSchemeFactory) {
-		return new DomainObjectFactory<DefaultNativeApplicationComponent>() {
-			@Override
-			public DefaultNativeApplicationComponent create() {
-				NamingScheme names = namingSchemeFactory.forMainComponent().withComponentDisplayName("main native component");
-				return objects.newInstance(DefaultNativeApplicationComponent.class, names);
-			}
-
-			@Override
-			public Class<DefaultNativeApplicationComponent> getType() {
-				return DefaultNativeApplicationComponent.class;
-			}
-
-			@Override
-			public Class<? extends DefaultNativeApplicationComponent> getImplementationType() {
-				return DefaultNativeApplicationComponent.class;
-			}
-
-			@Override
-			public DomainObjectIdentity getIdentity() {
-				return DomainObjectIdentity.named("main");
-			}
-		};
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryComponent.java
@@ -32,11 +32,10 @@ public class DefaultNativeLibraryComponent extends BaseNativeComponent<DefaultNa
 	@Getter(AccessLevel.PROTECTED) private final DependencyHandler dependencyHandler;
 
 	@Inject
-	public DefaultNativeLibraryComponent(NamingScheme names, ObjectFactory objects, ProviderFactory providers, TaskContainer tasks, ProjectLayout layout, ConfigurationContainer configurations, DependencyHandler dependencyHandler) {
+	public DefaultNativeLibraryComponent(NamingScheme names, ObjectFactory objects, ProviderFactory providers, TaskContainer tasks, ProjectLayout layout, ConfigurationContainer configurations, DependencyHandler dependencyHandler, DefaultNativeLibraryComponentDependencies dependencies) {
 		super(names, DefaultNativeLibraryVariant.class, objects, providers, tasks, layout, configurations);
 		this.dependencyHandler = dependencyHandler;
-		val dependencyContainer = objects.newInstance(DefaultComponentDependencies.class, names.getComponentDisplayName(), new FrameworkAwareDependencyBucketFactory(new DefaultDependencyBucketFactory(new ConfigurationFactories.Prefixing(new ConfigurationFactories.Creating(getConfigurations()), names::getConfigurationName), new DefaultDependencyFactory(getDependencyHandler()))));
-		this.dependencies = objects.newInstance(DefaultNativeLibraryComponentDependencies.class, dependencyContainer);
+		this.dependencies = dependencies;
 		getDimensions().convention(ImmutableSet.of(DefaultBinaryLinkage.DIMENSION_TYPE, BaseTargetBuildType.DIMENSION_TYPE, DefaultOperatingSystemFamily.DIMENSION_TYPE, DefaultMachineArchitecture.DIMENSION_TYPE));
 	}
 
@@ -88,30 +87,5 @@ public class DefaultNativeLibraryComponent extends BaseNativeComponent<DefaultNa
 
 		DefaultNativeLibraryVariant result = getObjects().newInstance(DefaultNativeLibraryVariant.class, name, names, buildVariant, variantDependencies);
 		return result;
-	}
-
-	public static DomainObjectFactory<DefaultNativeLibraryComponent> newMain(ObjectFactory objects, NamingSchemeFactory namingSchemeFactory) {
-		return new DomainObjectFactory<DefaultNativeLibraryComponent>() {
-			@Override
-			public DefaultNativeLibraryComponent create() {
-				NamingScheme names = namingSchemeFactory.forMainComponent().withComponentDisplayName("main native component");
-				return objects.newInstance(DefaultNativeLibraryComponent.class, names);
-			}
-
-			@Override
-			public Class<DefaultNativeLibraryComponent> getType() {
-				return DefaultNativeLibraryComponent.class;
-			}
-
-			@Override
-			public Class<? extends DefaultNativeLibraryComponent> getImplementationType() {
-				return DefaultNativeLibraryComponent.class;
-			}
-
-			@Override
-			public DomainObjectIdentity getIdentity() {
-				return DomainObjectIdentity.named("main");
-			}
-		};
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/ExecutableBinaryFactory.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/ExecutableBinaryFactory.java
@@ -1,0 +1,11 @@
+package dev.nokee.platform.nativebase.internal;
+
+import dev.nokee.language.base.internal.GeneratedSourceSet;
+import dev.nokee.platform.base.internal.NamingScheme;
+import dev.nokee.platform.nativebase.ExecutableBinary;
+import dev.nokee.runtime.nativebase.internal.DefaultTargetMachine;
+import org.gradle.api.DomainObjectSet;
+
+public interface ExecutableBinaryFactory {
+	ExecutableBinary create(NamingScheme names, DefaultTargetMachine targetMachine, DomainObjectSet<GeneratedSourceSet> objectSourceSets);
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/ExecutableBinaryFactoryImpl.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/ExecutableBinaryFactoryImpl.java
@@ -1,0 +1,32 @@
+package dev.nokee.platform.nativebase.internal;
+
+import dev.nokee.language.base.internal.GeneratedSourceSet;
+import dev.nokee.platform.base.internal.NamingScheme;
+import dev.nokee.platform.base.internal.tasks.ComponentTasksInternal;
+import dev.nokee.platform.base.internal.tasks.TaskName;
+import dev.nokee.platform.nativebase.ExecutableBinary;
+import dev.nokee.platform.nativebase.internal.dependencies.VariantComponentDependencies;
+import dev.nokee.platform.nativebase.tasks.internal.LinkExecutableTask;
+import dev.nokee.runtime.nativebase.internal.DefaultTargetMachine;
+import lombok.val;
+import org.gradle.api.DomainObjectSet;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.tasks.TaskContainer;
+
+public class ExecutableBinaryFactoryImpl implements ExecutableBinaryFactory {
+	private TaskContainer tasks;
+	private ObjectFactory objectFactory;
+	private final VariantComponentDependencies<?> dependencies;
+
+	public ExecutableBinaryFactoryImpl(TaskContainer tasks, ObjectFactory objectFactory, VariantComponentDependencies<?> dependencies) {
+		this.tasks = tasks;
+		this.objectFactory = objectFactory;
+		this.dependencies = dependencies;
+	}
+
+	@Override
+	public ExecutableBinary create(NamingScheme names, DefaultTargetMachine targetMachine, DomainObjectSet<GeneratedSourceSet> objectSourceSets) {
+		val linkTask = tasks.register(names.getTaskName("link"), LinkExecutableTask.class);
+		return objectFactory.newInstance(ExecutableBinaryInternal.class, names, objectSourceSets, targetMachine, linkTask, dependencies.getIncoming());
+	}
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/NativeComponentModule.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/NativeComponentModule.java
@@ -1,0 +1,42 @@
+package dev.nokee.platform.nativebase.internal;
+
+import dagger.Module;
+import dagger.Provides;
+import dev.nokee.platform.base.internal.NamingScheme;
+import dev.nokee.platform.base.internal.NamingSchemeFactory;
+import dev.nokee.platform.base.internal.dependencies.*;
+import dev.nokee.platform.nativebase.internal.dependencies.DefaultNativeApplicationComponentDependencies;
+import dev.nokee.platform.nativebase.internal.dependencies.DefaultNativeLibraryComponentDependencies;
+import dev.nokee.platform.nativebase.internal.dependencies.FrameworkAwareDependencyBucketFactory;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.model.ObjectFactory;
+
+@Module
+public interface NativeComponentModule {
+	@Provides
+	static NamingSchemeFactory aNamingSchemeFactory(Project project) {
+		return new NamingSchemeFactory(project.getName());
+	}
+
+	@Provides
+	static NamingScheme aNamingScheme(NamingSchemeFactory factory) {
+		return factory.forMainComponent().withComponentDisplayName("main native component");
+	}
+
+	@Provides
+	static ComponentDependenciesInternal aComponentDependencies(NamingScheme names, ConfigurationContainer configurations, DependencyHandler dependencyHandler, ObjectFactory objectFactory) {
+		return objectFactory.newInstance(DefaultComponentDependencies.class, names.getComponentDisplayName(), new FrameworkAwareDependencyBucketFactory(new DefaultDependencyBucketFactory(new ConfigurationFactories.Prefixing(new ConfigurationFactories.Creating(configurations), names::getConfigurationName), new DefaultDependencyFactory(dependencyHandler))));
+	}
+
+	@Provides
+	static DefaultNativeApplicationComponentDependencies aApplicationComponentDependencies(ComponentDependenciesInternal dependencies, ObjectFactory objectFactory) {
+		return objectFactory.newInstance(DefaultNativeApplicationComponentDependencies.class, dependencies);
+	}
+
+	@Provides
+	static DefaultNativeLibraryComponentDependencies aLibraryComponentDependencies(ComponentDependenciesInternal dependencies, ObjectFactory objectFactory) {
+		return objectFactory.newInstance(DefaultNativeLibraryComponentDependencies.class, dependencies);
+	}
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/SharedLibraryBinaryFactory.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/SharedLibraryBinaryFactory.java
@@ -1,0 +1,11 @@
+package dev.nokee.platform.nativebase.internal;
+
+import dev.nokee.language.base.internal.GeneratedSourceSet;
+import dev.nokee.platform.base.internal.NamingScheme;
+import dev.nokee.platform.nativebase.SharedLibraryBinary;
+import dev.nokee.runtime.nativebase.internal.DefaultTargetMachine;
+import org.gradle.api.DomainObjectSet;
+
+public interface SharedLibraryBinaryFactory {
+	SharedLibraryBinary create(NamingScheme names, DefaultTargetMachine targetMachine, DomainObjectSet<GeneratedSourceSet> objectSourceSets);
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/SharedLibraryBinaryFactoryImpl.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/SharedLibraryBinaryFactoryImpl.java
@@ -1,0 +1,35 @@
+package dev.nokee.platform.nativebase.internal;
+
+import dev.nokee.language.base.internal.GeneratedSourceSet;
+import dev.nokee.language.base.internal.LanguageSourceSetInternal;
+import dev.nokee.platform.base.internal.NamingScheme;
+import dev.nokee.platform.nativebase.SharedLibraryBinary;
+import dev.nokee.platform.nativebase.internal.dependencies.VariantComponentDependencies;
+import dev.nokee.platform.nativebase.tasks.internal.LinkSharedLibraryTask;
+import dev.nokee.runtime.nativebase.internal.DefaultTargetMachine;
+import lombok.val;
+import org.gradle.api.DomainObjectSet;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.tasks.TaskContainer;
+
+import javax.inject.Inject;
+
+public class SharedLibraryBinaryFactoryImpl implements SharedLibraryBinaryFactory {
+	private final TaskContainer tasks;
+	private final ObjectFactory objectFactory;
+	private final VariantComponentDependencies<?> dependencies;
+
+	@Inject
+	public SharedLibraryBinaryFactoryImpl(TaskContainer tasks, ObjectFactory objectFactory, VariantComponentDependencies<?> dependencies) {
+		this.tasks = tasks;
+		this.objectFactory = objectFactory;
+		this.dependencies = dependencies;
+	}
+
+	@Override
+	public SharedLibraryBinary create(NamingScheme names, DefaultTargetMachine targetMachine, DomainObjectSet<GeneratedSourceSet> objectSourceSets) {
+		val linkTask = tasks.register(names.getTaskName("link"), LinkSharedLibraryTask.class);
+
+		return objectFactory.newInstance(SharedLibraryBinaryInternal.class, names, objectFactory.domainObjectSet(LanguageSourceSetInternal.class), targetMachine, objectSourceSets, linkTask, dependencies.getIncoming());
+	}
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/StaticLibraryBinaryFactory.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/StaticLibraryBinaryFactory.java
@@ -1,0 +1,11 @@
+package dev.nokee.platform.nativebase.internal;
+
+import dev.nokee.language.base.internal.GeneratedSourceSet;
+import dev.nokee.platform.base.internal.NamingScheme;
+import dev.nokee.platform.nativebase.StaticLibraryBinary;
+import dev.nokee.runtime.nativebase.internal.DefaultTargetMachine;
+import org.gradle.api.DomainObjectSet;
+
+public interface StaticLibraryBinaryFactory {
+	StaticLibraryBinary create(NamingScheme names, DefaultTargetMachine targetMachine, DomainObjectSet<GeneratedSourceSet> objectSourceSets);
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/StaticLibraryBinaryFactoryImpl.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/StaticLibraryBinaryFactoryImpl.java
@@ -1,0 +1,35 @@
+package dev.nokee.platform.nativebase.internal;
+
+import dev.nokee.language.base.internal.GeneratedSourceSet;
+import dev.nokee.platform.base.internal.NamingScheme;
+import dev.nokee.platform.base.internal.tasks.ComponentTasksInternal;
+import dev.nokee.platform.base.internal.tasks.TaskName;
+import dev.nokee.platform.nativebase.StaticLibraryBinary;
+import dev.nokee.platform.nativebase.internal.dependencies.VariantComponentDependencies;
+import dev.nokee.platform.nativebase.tasks.internal.CreateStaticLibraryTask;
+import dev.nokee.runtime.nativebase.internal.DefaultTargetMachine;
+import lombok.val;
+import org.gradle.api.DomainObjectSet;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.tasks.TaskContainer;
+
+import javax.inject.Inject;
+
+public class StaticLibraryBinaryFactoryImpl implements StaticLibraryBinaryFactory {
+	private final TaskContainer tasks;
+	private final ObjectFactory objectFactory;
+	private final VariantComponentDependencies<?> dependencies;
+
+	@Inject
+	public StaticLibraryBinaryFactoryImpl(TaskContainer tasks, ObjectFactory objectFactory, VariantComponentDependencies<?> dependencies) {
+		this.tasks = tasks;
+		this.objectFactory = objectFactory;
+		this.dependencies = dependencies;
+	}
+
+	@Override
+	public StaticLibraryBinary create(NamingScheme names, DefaultTargetMachine targetMachine, DomainObjectSet<GeneratedSourceSet> objectSourceSets) {
+		val createTask = tasks.register(names.getTaskName("create"), CreateStaticLibraryTask.class);
+		return objectFactory.newInstance(StaticLibraryBinaryInternal.class, names, objectSourceSets, targetMachine, createTask, dependencies.getIncoming());
+	}
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/rules/BuildVariantConvention.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/rules/BuildVariantConvention.java
@@ -1,0 +1,100 @@
+package dev.nokee.platform.nativebase.internal.rules;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import dev.nokee.platform.base.internal.BuildVariantInternal;
+import dev.nokee.platform.base.internal.DefaultBuildVariant;
+import dev.nokee.platform.nativebase.TargetBuildTypeAwareComponent;
+import dev.nokee.platform.nativebase.TargetLinkageAwareComponent;
+import dev.nokee.platform.nativebase.TargetMachineAwareComponent;
+import dev.nokee.platform.nativebase.internal.*;
+import dev.nokee.runtime.base.internal.DefaultDimensionType;
+import dev.nokee.runtime.base.internal.Dimension;
+import dev.nokee.runtime.base.internal.DimensionType;
+import dev.nokee.runtime.nativebase.TargetBuildType;
+import dev.nokee.runtime.nativebase.TargetLinkage;
+import dev.nokee.runtime.nativebase.internal.DefaultTargetMachine;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+public class BuildVariantConvention implements Callable<Iterable<BuildVariantInternal>> {
+	private final Object extension;
+	private final Object component;
+	private final Supplier<Set<DimensionType>> dimensionSupplier;
+
+	public BuildVariantConvention(Object extension, Object component, Supplier<Set<DimensionType>> dimensionSupplier) {
+		this.extension = extension;
+		this.component = component;
+		this.dimensionSupplier = dimensionSupplier;
+	}
+
+	@Override
+	public Iterable<BuildVariantInternal> call() throws Exception {
+		val buildVariantBuilder = ImmutableList.<BuildVariantInternal>builder();
+
+		val builder = ImmutableList.<Set<Dimension>>builder();
+
+		// Handle operating system family and machine architecture dimension
+		if (extension instanceof TargetMachineAwareComponent) {
+			builder.add(((TargetMachineAwareComponent) extension).getTargetMachines().get().stream().map(it -> new TargetMachineDimension((DefaultTargetMachine)it)).collect(ImmutableSet.toImmutableSet()));
+		}
+
+		// Handle linkage dimension
+		if (extension instanceof TargetLinkageAwareComponent) {
+			Set<TargetLinkage> targetLinkages = ((TargetLinkageAwareComponent) extension).getTargetLinkages().get();
+			builder.add(targetLinkages.stream().map(DefaultBinaryLinkage.class::cast).collect(Collectors.toSet()));
+		} else if (component instanceof DefaultNativeApplicationComponent) {
+			builder.add(ImmutableSet.of(DefaultBinaryLinkage.EXECUTABLE));
+		} else if (component instanceof DefaultNativeLibraryComponent) {
+			builder.add(ImmutableSet.of(DefaultBinaryLinkage.SHARED));
+		}
+
+		// Handle build type dimension
+		if (extension instanceof TargetBuildTypeAwareComponent) {
+			Set<TargetBuildType> targetBuildTypes = ((TargetBuildTypeAwareComponent) extension).getTargetBuildTypes().get();
+			builder.add(targetBuildTypes.stream().map(BaseTargetBuildType.class::cast).collect(ImmutableSet.toImmutableSet()));
+		} else {
+			builder.add(ImmutableSet.of(DefaultTargetBuildTypeFactory.DEFAULT));
+		}
+
+		Sets.cartesianProduct(builder.build()).forEach(dimensions -> {
+			ImmutableList.Builder<Dimension> dimensionBuilder = ImmutableList.builder();
+			dimensions.forEach(dimension -> {
+				if (dimension instanceof TargetMachineDimension) {
+					dimensionBuilder.add(((TargetMachineDimension) dimension).targetMachine.getOperatingSystemFamily());
+					dimensionBuilder.add(((TargetMachineDimension) dimension).targetMachine.getArchitecture());
+				} else {
+					dimensionBuilder.add(dimension);
+				}
+			});
+			buildVariantBuilder.add(DefaultBuildVariant.of(sort(dimensionBuilder.build())));
+		});
+		return buildVariantBuilder.build();
+	}
+
+	private Iterable<Dimension> sort(Collection<Dimension> dimensionsToOrder) {
+		val result = ImmutableList.<Dimension>builder();
+		for (val type : dimensionSupplier.get()) {
+			result.add(dimensionsToOrder.stream().filter(it -> it.getType().equals(type)).findFirst().orElseThrow(() -> new IllegalArgumentException("Missing dimension " + type)));
+		}
+		return result.build();
+	}
+
+	@RequiredArgsConstructor
+	private static final class TargetMachineDimension implements Dimension {
+		private static final DimensionType<?> DIMENSION_TYPE = new DefaultDimensionType<>(TargetMachineDimension.class);
+		public final DefaultTargetMachine targetMachine;
+
+		@Override
+		public DimensionType getType() {
+			return DIMENSION_TYPE;
+		}
+	}
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/DefaultObjectiveCApplicationExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/DefaultObjectiveCApplicationExtension.java
@@ -1,5 +1,7 @@
 package dev.nokee.platform.objectivec.internal;
 
+import com.google.auto.factory.AutoFactory;
+import com.google.auto.factory.Provided;
 import dev.nokee.language.c.internal.CHeaderSet;
 import dev.nokee.language.objectivec.internal.ObjectiveCSourceSet;
 import dev.nokee.platform.base.VariantView;
@@ -7,10 +9,7 @@ import dev.nokee.platform.nativebase.NativeApplication;
 import dev.nokee.platform.nativebase.NativeApplicationComponentDependencies;
 import dev.nokee.platform.nativebase.TargetBuildTypeFactory;
 import dev.nokee.platform.nativebase.TargetMachineFactory;
-import dev.nokee.platform.nativebase.internal.BaseNativeExtension;
-import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
-import dev.nokee.platform.nativebase.internal.DefaultTargetBuildTypeFactory;
-import dev.nokee.platform.nativebase.internal.DefaultTargetMachineFactory;
+import dev.nokee.platform.nativebase.internal.*;
 import dev.nokee.platform.objectivec.ObjectiveCApplicationExtension;
 import dev.nokee.runtime.nativebase.TargetBuildType;
 import dev.nokee.runtime.nativebase.TargetMachine;
@@ -25,6 +24,7 @@ import org.gradle.api.provider.SetProperty;
 
 import javax.inject.Inject;
 
+@AutoFactory(allowSubclasses = true, extending = DecoratingFactory.class, className = "AutoDefaultObjectiveCApplicationExtensionFactory")
 public class DefaultObjectiveCApplicationExtension extends BaseNativeExtension<DefaultNativeApplicationComponent> implements ObjectiveCApplicationExtension {
 	@Getter private final ConfigurableFileCollection sources;
 	@Getter private final ConfigurableFileCollection privateHeaders;
@@ -32,7 +32,7 @@ public class DefaultObjectiveCApplicationExtension extends BaseNativeExtension<D
 	@Getter private final SetProperty<TargetBuildType> targetBuildTypes;
 
 	@Inject
-	public DefaultObjectiveCApplicationExtension(DefaultNativeApplicationComponent component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
+	public DefaultObjectiveCApplicationExtension(@Provided DefaultNativeApplicationComponent component, @Provided ObjectFactory objects, @Provided ProviderFactory providers, @Provided ProjectLayout layout) {
 		super(component, objects, providers, layout);
 		this.sources = objects.fileCollection();
 		this.privateHeaders = objects.fileCollection();

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/DefaultObjectiveCApplicationExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/DefaultObjectiveCApplicationExtension.java
@@ -5,8 +5,12 @@ import dev.nokee.language.objectivec.internal.ObjectiveCSourceSet;
 import dev.nokee.platform.base.VariantView;
 import dev.nokee.platform.nativebase.NativeApplication;
 import dev.nokee.platform.nativebase.NativeApplicationComponentDependencies;
+import dev.nokee.platform.nativebase.TargetBuildTypeFactory;
+import dev.nokee.platform.nativebase.TargetMachineFactory;
 import dev.nokee.platform.nativebase.internal.BaseNativeExtension;
 import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
+import dev.nokee.platform.nativebase.internal.DefaultTargetBuildTypeFactory;
+import dev.nokee.platform.nativebase.internal.DefaultTargetMachineFactory;
 import dev.nokee.platform.objectivec.ObjectiveCApplicationExtension;
 import dev.nokee.runtime.nativebase.TargetBuildType;
 import dev.nokee.runtime.nativebase.TargetMachine;
@@ -56,5 +60,15 @@ public class DefaultObjectiveCApplicationExtension extends BaseNativeExtension<D
 	@Override
 	public VariantView<NativeApplication> getVariants() {
 		return getComponent().getVariantCollection().getAsView(NativeApplication.class);
+	}
+
+	@Override
+	public TargetMachineFactory getMachines() {
+		return DefaultTargetMachineFactory.INSTANCE;
+	}
+
+	@Override
+	public TargetBuildTypeFactory getBuildTypes() {
+		return DefaultTargetBuildTypeFactory.INSTANCE;
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/DefaultObjectiveCApplicationExtensionFactory.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/DefaultObjectiveCApplicationExtensionFactory.java
@@ -1,0 +1,34 @@
+package dev.nokee.platform.objectivec.internal;
+
+import dagger.MembersInjector;
+import dev.nokee.platform.nativebase.internal.DecoratingFactory;
+import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+/** @see DecoratingFactory */
+public final class DefaultObjectiveCApplicationExtensionFactory extends AutoDefaultObjectiveCApplicationExtensionFactory {
+	private final Provider<DefaultNativeApplicationComponent> componentProvider;
+	private final Provider<ObjectFactory> objectsProvider;
+	private final Provider<ProviderFactory> providersProvider;
+	private final Provider<ProjectLayout> layoutProvider;
+
+	@Inject
+	public DefaultObjectiveCApplicationExtensionFactory(Provider<DefaultNativeApplicationComponent> componentProvider, Provider<ObjectFactory> objectsProvider, Provider<ProviderFactory> providersProvider, Provider<ProjectLayout> layoutProvider, MembersInjector<DecoratingFactory> injector) {
+		super(componentProvider, objectsProvider, providersProvider, layoutProvider);
+		this.componentProvider = componentProvider;
+		this.objectsProvider = objectsProvider;
+		this.providersProvider = providersProvider;
+		this.layoutProvider = layoutProvider;
+		injector.injectMembers(this);
+	}
+
+	@Override
+	public DefaultObjectiveCApplicationExtension create() {
+		return newInstance(componentProvider.get(), objectsProvider.get(), providersProvider.get(), layoutProvider.get());
+	}
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/DefaultObjectiveCLibraryExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/DefaultObjectiveCLibraryExtension.java
@@ -1,5 +1,7 @@
 package dev.nokee.platform.objectivec.internal;
 
+import com.google.auto.factory.AutoFactory;
+import com.google.auto.factory.Provided;
 import dev.nokee.language.c.internal.CHeaderSet;
 import dev.nokee.language.objectivec.internal.ObjectiveCSourceSet;
 import dev.nokee.platform.base.VariantView;
@@ -20,6 +22,7 @@ import org.gradle.api.provider.SetProperty;
 
 import javax.inject.Inject;
 
+@AutoFactory(allowSubclasses = true, extending = DecoratingFactory.class, className = "AutoDefaultObjectiveCLibraryExtensionFactory")
 public class DefaultObjectiveCLibraryExtension extends BaseNativeExtension<DefaultNativeLibraryComponent> implements ObjectiveCLibraryExtension {
 	@Getter private final ConfigurableFileCollection sources;
 	@Getter private final ConfigurableFileCollection privateHeaders;
@@ -29,7 +32,7 @@ public class DefaultObjectiveCLibraryExtension extends BaseNativeExtension<Defau
 	@Getter private final SetProperty<TargetBuildType> targetBuildTypes;
 
 	@Inject
-	public DefaultObjectiveCLibraryExtension(DefaultNativeLibraryComponent component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
+	public DefaultObjectiveCLibraryExtension(@Provided DefaultNativeLibraryComponent component, @Provided ObjectFactory objects, @Provided ProviderFactory providers, @Provided ProjectLayout layout) {
 		super(component, objects, providers, layout);
 		this.sources = objects.fileCollection();
 		this.privateHeaders = objects.fileCollection();

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/DefaultObjectiveCLibraryExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/DefaultObjectiveCLibraryExtension.java
@@ -3,10 +3,8 @@ package dev.nokee.platform.objectivec.internal;
 import dev.nokee.language.c.internal.CHeaderSet;
 import dev.nokee.language.objectivec.internal.ObjectiveCSourceSet;
 import dev.nokee.platform.base.VariantView;
-import dev.nokee.platform.nativebase.NativeLibrary;
-import dev.nokee.platform.nativebase.NativeLibraryComponentDependencies;
-import dev.nokee.platform.nativebase.internal.BaseNativeExtension;
-import dev.nokee.platform.nativebase.internal.DefaultNativeLibraryComponent;
+import dev.nokee.platform.nativebase.*;
+import dev.nokee.platform.nativebase.internal.*;
 import dev.nokee.platform.objectivec.ObjectiveCLibraryExtension;
 import dev.nokee.runtime.nativebase.TargetBuildType;
 import dev.nokee.runtime.nativebase.TargetLinkage;
@@ -62,5 +60,20 @@ public class DefaultObjectiveCLibraryExtension extends BaseNativeExtension<Defau
 	@Override
 	public VariantView<NativeLibrary> getVariants() {
 		return getComponent().getVariantCollection().getAsView(NativeLibrary.class);
+	}
+
+	@Override
+	public TargetMachineFactory getMachines() {
+		return DefaultTargetMachineFactory.INSTANCE;
+	}
+
+	@Override
+	public TargetLinkageFactory getLinkages() {
+		return DefaultTargetLinkageFactory.INSTANCE;
+	}
+
+	@Override
+	public TargetBuildTypeFactory getBuildTypes() {
+		return DefaultTargetBuildTypeFactory.INSTANCE;
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/DefaultObjectiveCLibraryExtensionFactory.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/DefaultObjectiveCLibraryExtensionFactory.java
@@ -1,0 +1,34 @@
+package dev.nokee.platform.objectivec.internal;
+
+import dagger.MembersInjector;
+import dev.nokee.platform.nativebase.internal.DecoratingFactory;
+import dev.nokee.platform.nativebase.internal.DefaultNativeLibraryComponent;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+/** @see DecoratingFactory */
+public final class DefaultObjectiveCLibraryExtensionFactory extends AutoDefaultObjectiveCLibraryExtensionFactory {
+	private final Provider<DefaultNativeLibraryComponent> componentProvider;
+	private final Provider<ObjectFactory> objectsProvider;
+	private final Provider<ProviderFactory> providersProvider;
+	private final Provider<ProjectLayout> layoutProvider;
+
+	@Inject
+	public DefaultObjectiveCLibraryExtensionFactory(Provider<DefaultNativeLibraryComponent> componentProvider, Provider<ObjectFactory> objectsProvider, Provider<ProviderFactory> providersProvider, Provider<ProjectLayout> layoutProvider, MembersInjector<DecoratingFactory> injector) {
+		super(componentProvider, objectsProvider, providersProvider, layoutProvider);
+		this.componentProvider = componentProvider;
+		this.objectsProvider = objectsProvider;
+		this.providersProvider = providersProvider;
+		this.layoutProvider = layoutProvider;
+		injector.injectMembers(this);
+	}
+
+	@Override
+	public DefaultObjectiveCLibraryExtension create() {
+		return newInstance(componentProvider.get(), objectsProvider.get(), providersProvider.get(), layoutProvider.get());
+	}
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCApplicationPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCApplicationPlugin.java
@@ -2,17 +2,24 @@ package dev.nokee.platform.objectivec.internal.plugins;
 
 import dagger.BindsInstance;
 import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
 import dev.nokee.gradle.internal.GradleModule;
 import dev.nokee.platform.base.DomainObjectElement;
 import dev.nokee.platform.base.internal.DomainObjectIdentity;
 import dev.nokee.platform.base.internal.DomainObjectStore;
 import dev.nokee.platform.base.internal.plugins.ProjectStorePlugin;
+import dev.nokee.platform.c.internal.DefaultCApplicationExtension;
+import dev.nokee.platform.c.internal.DefaultCApplicationExtensionFactory;
+import dev.nokee.platform.cpp.internal.DefaultCppApplicationExtension;
+import dev.nokee.platform.cpp.internal.DefaultCppApplicationExtensionFactory;
 import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
 import dev.nokee.platform.nativebase.internal.NativeComponentModule;
 import dev.nokee.platform.nativebase.internal.TargetBuildTypeRule;
 import dev.nokee.platform.nativebase.internal.TargetMachineRule;
 import dev.nokee.platform.objectivec.ObjectiveCApplicationExtension;
 import dev.nokee.platform.objectivec.internal.DefaultObjectiveCApplicationExtension;
+import dev.nokee.platform.objectivec.internal.DefaultObjectiveCApplicationExtensionFactory;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.val;
@@ -65,7 +72,15 @@ public class ObjectiveCApplicationPlugin implements Plugin<Project> {
 		project.getExtensions().add(ObjectiveCApplicationExtension.class, EXTENSION_NAME, extension);
 	}
 
-	@Component(modules = {GradleModule.class, NativeComponentModule.class})
+	@Module
+	interface ObjectiveCModule {
+		@Provides
+		static DefaultObjectiveCApplicationExtension theExtension(DefaultObjectiveCApplicationExtensionFactory factory) {
+			return factory.create();
+		}
+	}
+
+	@Component(modules = {GradleModule.class, NativeComponentModule.class, ObjectiveCModule.class})
 	interface ObjectiveCApplicationComponent {
 		DefaultObjectiveCApplicationExtension objectiveCApplicationComponent();
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCApplicationPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCApplicationPlugin.java
@@ -1,9 +1,14 @@
 package dev.nokee.platform.objectivec.internal.plugins;
 
+import dagger.BindsInstance;
+import dagger.Component;
+import dev.nokee.gradle.internal.GradleModule;
+import dev.nokee.platform.base.DomainObjectElement;
+import dev.nokee.platform.base.internal.DomainObjectIdentity;
 import dev.nokee.platform.base.internal.DomainObjectStore;
-import dev.nokee.platform.base.internal.NamingSchemeFactory;
 import dev.nokee.platform.base.internal.plugins.ProjectStorePlugin;
 import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
+import dev.nokee.platform.nativebase.internal.NativeComponentModule;
 import dev.nokee.platform.nativebase.internal.TargetBuildTypeRule;
 import dev.nokee.platform.nativebase.internal.TargetMachineRule;
 import dev.nokee.platform.objectivec.ObjectiveCApplicationExtension;
@@ -33,14 +38,40 @@ public class ObjectiveCApplicationPlugin implements Plugin<Project> {
 		project.getPluginManager().apply(ProjectStorePlugin.class);
 
 		val store = project.getExtensions().getByType(DomainObjectStore.class);
-		val component = store.register(DefaultNativeApplicationComponent.newMain(getObjects(), new NamingSchemeFactory(project.getName())));
+		val extension = DaggerObjectiveCApplicationPlugin_ObjectiveCApplicationComponent.factory().create(project).objectiveCApplicationComponent();
+		val component = store.add(new DomainObjectElement<DefaultNativeApplicationComponent>() {
+			@Override
+			public DefaultNativeApplicationComponent get() {
+				return extension.getComponent();
+			}
+
+			@Override
+			public Class<DefaultNativeApplicationComponent> getType() {
+				return DefaultNativeApplicationComponent.class;
+			}
+
+			@Override
+			public DomainObjectIdentity getIdentity() {
+				return DomainObjectIdentity.named("main");
+			}
+		});
 		component.configure(it -> it.getBaseName().convention(project.getName()));
-		DefaultObjectiveCApplicationExtension extension = getObjects().newInstance(DefaultObjectiveCApplicationExtension.class, component.get());
+		component.get(); // force realize... for now.
 
 		project.afterEvaluate(getObjects().newInstance(TargetMachineRule.class, extension.getTargetMachines(), EXTENSION_NAME));
 		project.afterEvaluate(getObjects().newInstance(TargetBuildTypeRule.class, extension.getTargetBuildTypes(), EXTENSION_NAME));
 		project.afterEvaluate(extension::finalizeExtension);
 
 		project.getExtensions().add(ObjectiveCApplicationExtension.class, EXTENSION_NAME, extension);
+	}
+
+	@Component(modules = {GradleModule.class, NativeComponentModule.class})
+	interface ObjectiveCApplicationComponent {
+		DefaultObjectiveCApplicationExtension objectiveCApplicationComponent();
+
+		@Component.Factory
+		interface Factory {
+			ObjectiveCApplicationComponent create(@BindsInstance Project project);
+		}
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCLibraryPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCLibraryPlugin.java
@@ -1,12 +1,13 @@
 package dev.nokee.platform.objectivec.internal.plugins;
 
+import dagger.BindsInstance;
+import dagger.Component;
+import dev.nokee.gradle.internal.GradleModule;
+import dev.nokee.platform.base.DomainObjectElement;
+import dev.nokee.platform.base.internal.DomainObjectIdentity;
 import dev.nokee.platform.base.internal.DomainObjectStore;
-import dev.nokee.platform.base.internal.NamingSchemeFactory;
 import dev.nokee.platform.base.internal.plugins.ProjectStorePlugin;
-import dev.nokee.platform.nativebase.internal.DefaultNativeLibraryComponent;
-import dev.nokee.platform.nativebase.internal.TargetBuildTypeRule;
-import dev.nokee.platform.nativebase.internal.TargetLinkageRule;
-import dev.nokee.platform.nativebase.internal.TargetMachineRule;
+import dev.nokee.platform.nativebase.internal.*;
 import dev.nokee.platform.objectivec.ObjectiveCLibraryExtension;
 import dev.nokee.platform.objectivec.internal.DefaultObjectiveCLibraryExtension;
 import lombok.AccessLevel;
@@ -34,9 +35,25 @@ public class ObjectiveCLibraryPlugin implements Plugin<Project> {
 		project.getPluginManager().apply(ProjectStorePlugin.class);
 
 		val store = project.getExtensions().getByType(DomainObjectStore.class);
-		val component = store.register(DefaultNativeLibraryComponent.newMain(getObjects(), new NamingSchemeFactory(project.getName())));
+		val extension = DaggerObjectiveCLibraryPlugin_ObjectiveCLibraryComponent.factory().create(project).objectiveCLibraryComponent();
+		val component = store.add(new DomainObjectElement<DefaultNativeLibraryComponent>() {
+			@Override
+			public DefaultNativeLibraryComponent get() {
+				return extension.getComponent();
+			}
+
+			@Override
+			public Class<DefaultNativeLibraryComponent> getType() {
+				return DefaultNativeLibraryComponent.class;
+			}
+
+			@Override
+			public DomainObjectIdentity getIdentity() {
+				return DomainObjectIdentity.named("main");
+			}
+		});
 		component.configure(it -> it.getBaseName().convention(project.getName()));
-		DefaultObjectiveCLibraryExtension extension = getObjects().newInstance(DefaultObjectiveCLibraryExtension.class, component.get());
+		component.get(); // force realize... for now.
 
 		project.afterEvaluate(getObjects().newInstance(TargetMachineRule.class, extension.getTargetMachines(), EXTENSION_NAME));
 		project.afterEvaluate(getObjects().newInstance(TargetLinkageRule.class, extension.getTargetLinkages(), EXTENSION_NAME));
@@ -44,5 +61,15 @@ public class ObjectiveCLibraryPlugin implements Plugin<Project> {
 		project.afterEvaluate(extension::finalizeExtension);
 
 		project.getExtensions().add(ObjectiveCLibraryExtension.class, EXTENSION_NAME, extension);
+	}
+
+	@Component(modules = {GradleModule.class, NativeComponentModule.class})
+	interface ObjectiveCLibraryComponent {
+		DefaultObjectiveCLibraryExtension objectiveCLibraryComponent();
+
+		@Component.Factory
+		interface Factory {
+			ObjectiveCLibraryComponent create(@BindsInstance Project project);
+		}
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCLibraryPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCLibraryPlugin.java
@@ -2,6 +2,8 @@ package dev.nokee.platform.objectivec.internal.plugins;
 
 import dagger.BindsInstance;
 import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
 import dev.nokee.gradle.internal.GradleModule;
 import dev.nokee.platform.base.DomainObjectElement;
 import dev.nokee.platform.base.internal.DomainObjectIdentity;
@@ -9,7 +11,10 @@ import dev.nokee.platform.base.internal.DomainObjectStore;
 import dev.nokee.platform.base.internal.plugins.ProjectStorePlugin;
 import dev.nokee.platform.nativebase.internal.*;
 import dev.nokee.platform.objectivec.ObjectiveCLibraryExtension;
+import dev.nokee.platform.objectivec.internal.DefaultObjectiveCApplicationExtension;
+import dev.nokee.platform.objectivec.internal.DefaultObjectiveCApplicationExtensionFactory;
 import dev.nokee.platform.objectivec.internal.DefaultObjectiveCLibraryExtension;
+import dev.nokee.platform.objectivec.internal.DefaultObjectiveCLibraryExtensionFactory;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.val;
@@ -63,7 +68,15 @@ public class ObjectiveCLibraryPlugin implements Plugin<Project> {
 		project.getExtensions().add(ObjectiveCLibraryExtension.class, EXTENSION_NAME, extension);
 	}
 
-	@Component(modules = {GradleModule.class, NativeComponentModule.class})
+	@Module
+	interface ObjectiveCModule {
+		@Provides
+		static DefaultObjectiveCLibraryExtension theExtension(DefaultObjectiveCLibraryExtensionFactory factory) {
+			return factory.create();
+		}
+	}
+
+	@Component(modules = {GradleModule.class, NativeComponentModule.class, ObjectiveCModule.class})
 	interface ObjectiveCLibraryComponent {
 		DefaultObjectiveCLibraryExtension objectiveCLibraryComponent();
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/DefaultObjectiveCppApplicationExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/DefaultObjectiveCppApplicationExtension.java
@@ -1,5 +1,7 @@
 package dev.nokee.platform.objectivecpp.internal;
 
+import com.google.auto.factory.AutoFactory;
+import com.google.auto.factory.Provided;
 import dev.nokee.language.cpp.internal.CppHeaderSet;
 import dev.nokee.language.objectivecpp.internal.ObjectiveCppSourceSet;
 import dev.nokee.platform.base.VariantView;
@@ -7,10 +9,7 @@ import dev.nokee.platform.nativebase.NativeApplication;
 import dev.nokee.platform.nativebase.NativeApplicationComponentDependencies;
 import dev.nokee.platform.nativebase.TargetBuildTypeFactory;
 import dev.nokee.platform.nativebase.TargetMachineFactory;
-import dev.nokee.platform.nativebase.internal.BaseNativeExtension;
-import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
-import dev.nokee.platform.nativebase.internal.DefaultTargetBuildTypeFactory;
-import dev.nokee.platform.nativebase.internal.DefaultTargetMachineFactory;
+import dev.nokee.platform.nativebase.internal.*;
 import dev.nokee.platform.objectivecpp.ObjectiveCppApplicationExtension;
 import dev.nokee.runtime.nativebase.TargetBuildType;
 import dev.nokee.runtime.nativebase.TargetMachine;
@@ -25,6 +24,7 @@ import org.gradle.api.provider.SetProperty;
 
 import javax.inject.Inject;
 
+@AutoFactory(allowSubclasses = true, extending = DecoratingFactory.class, className = "AutoDefaultObjectiveCppApplicationExtensionFactory")
 public class DefaultObjectiveCppApplicationExtension extends BaseNativeExtension<DefaultNativeApplicationComponent> implements ObjectiveCppApplicationExtension {
 	@Getter private final ConfigurableFileCollection sources;
 	@Getter private final ConfigurableFileCollection privateHeaders;
@@ -32,7 +32,7 @@ public class DefaultObjectiveCppApplicationExtension extends BaseNativeExtension
 	@Getter private final SetProperty<TargetBuildType> targetBuildTypes;
 
 	@Inject
-	public DefaultObjectiveCppApplicationExtension(DefaultNativeApplicationComponent component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
+	public DefaultObjectiveCppApplicationExtension(@Provided DefaultNativeApplicationComponent component, @Provided ObjectFactory objects, @Provided ProviderFactory providers, @Provided ProjectLayout layout) {
 		super(component, objects, providers, layout);
 		this.sources = objects.fileCollection();
 		this.privateHeaders = objects.fileCollection();

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/DefaultObjectiveCppApplicationExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/DefaultObjectiveCppApplicationExtension.java
@@ -5,8 +5,12 @@ import dev.nokee.language.objectivecpp.internal.ObjectiveCppSourceSet;
 import dev.nokee.platform.base.VariantView;
 import dev.nokee.platform.nativebase.NativeApplication;
 import dev.nokee.platform.nativebase.NativeApplicationComponentDependencies;
+import dev.nokee.platform.nativebase.TargetBuildTypeFactory;
+import dev.nokee.platform.nativebase.TargetMachineFactory;
 import dev.nokee.platform.nativebase.internal.BaseNativeExtension;
 import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
+import dev.nokee.platform.nativebase.internal.DefaultTargetBuildTypeFactory;
+import dev.nokee.platform.nativebase.internal.DefaultTargetMachineFactory;
 import dev.nokee.platform.objectivecpp.ObjectiveCppApplicationExtension;
 import dev.nokee.runtime.nativebase.TargetBuildType;
 import dev.nokee.runtime.nativebase.TargetMachine;
@@ -56,5 +60,15 @@ public class DefaultObjectiveCppApplicationExtension extends BaseNativeExtension
 	@Override
 	public VariantView<NativeApplication> getVariants() {
 		return getComponent().getVariantCollection().getAsView(NativeApplication.class);
+	}
+
+	@Override
+	public TargetMachineFactory getMachines() {
+		return DefaultTargetMachineFactory.INSTANCE;
+	}
+
+	@Override
+	public TargetBuildTypeFactory getBuildTypes() {
+		return DefaultTargetBuildTypeFactory.INSTANCE;
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/DefaultObjectiveCppApplicationExtensionFactory.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/DefaultObjectiveCppApplicationExtensionFactory.java
@@ -1,0 +1,34 @@
+package dev.nokee.platform.objectivecpp.internal;
+
+import dagger.MembersInjector;
+import dev.nokee.platform.nativebase.internal.DecoratingFactory;
+import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+/** @see DecoratingFactory */
+public final class DefaultObjectiveCppApplicationExtensionFactory extends AutoDefaultObjectiveCppApplicationExtensionFactory {
+	private final Provider<DefaultNativeApplicationComponent> componentProvider;
+	private final Provider<ObjectFactory> objectsProvider;
+	private final Provider<ProviderFactory> providersProvider;
+	private final Provider<ProjectLayout> layoutProvider;
+
+	@Inject
+	public DefaultObjectiveCppApplicationExtensionFactory(Provider<DefaultNativeApplicationComponent> componentProvider, Provider<ObjectFactory> objectsProvider, Provider<ProviderFactory> providersProvider, Provider<ProjectLayout> layoutProvider, MembersInjector<DecoratingFactory> injector) {
+		super(componentProvider, objectsProvider, providersProvider, layoutProvider);
+		this.componentProvider = componentProvider;
+		this.objectsProvider = objectsProvider;
+		this.providersProvider = providersProvider;
+		this.layoutProvider = layoutProvider;
+		injector.injectMembers(this);
+	}
+
+	@Override
+	public DefaultObjectiveCppApplicationExtension create() {
+		return newInstance(componentProvider.get(), objectsProvider.get(), providersProvider.get(), layoutProvider.get());
+	}
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/DefaultObjectiveCppLibraryExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/DefaultObjectiveCppLibraryExtension.java
@@ -3,10 +3,8 @@ package dev.nokee.platform.objectivecpp.internal;
 import dev.nokee.language.cpp.internal.CppHeaderSet;
 import dev.nokee.language.objectivecpp.internal.ObjectiveCppSourceSet;
 import dev.nokee.platform.base.VariantView;
-import dev.nokee.platform.nativebase.NativeLibrary;
-import dev.nokee.platform.nativebase.NativeLibraryComponentDependencies;
-import dev.nokee.platform.nativebase.internal.BaseNativeExtension;
-import dev.nokee.platform.nativebase.internal.DefaultNativeLibraryComponent;
+import dev.nokee.platform.nativebase.*;
+import dev.nokee.platform.nativebase.internal.*;
 import dev.nokee.platform.objectivecpp.ObjectiveCppLibraryExtension;
 import dev.nokee.runtime.nativebase.TargetBuildType;
 import dev.nokee.runtime.nativebase.TargetLinkage;
@@ -62,5 +60,20 @@ public class DefaultObjectiveCppLibraryExtension extends BaseNativeExtension<Def
 	@Override
 	public VariantView<NativeLibrary> getVariants() {
 		return getComponent().getVariantCollection().getAsView(NativeLibrary.class);
+	}
+
+	@Override
+	public TargetMachineFactory getMachines() {
+		return DefaultTargetMachineFactory.INSTANCE;
+	}
+
+	@Override
+	public TargetLinkageFactory getLinkages() {
+		return DefaultTargetLinkageFactory.INSTANCE;
+	}
+
+	@Override
+	public TargetBuildTypeFactory getBuildTypes() {
+		return DefaultTargetBuildTypeFactory.INSTANCE;
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/DefaultObjectiveCppLibraryExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/DefaultObjectiveCppLibraryExtension.java
@@ -1,5 +1,7 @@
 package dev.nokee.platform.objectivecpp.internal;
 
+import com.google.auto.factory.AutoFactory;
+import com.google.auto.factory.Provided;
 import dev.nokee.language.cpp.internal.CppHeaderSet;
 import dev.nokee.language.objectivecpp.internal.ObjectiveCppSourceSet;
 import dev.nokee.platform.base.VariantView;
@@ -20,6 +22,7 @@ import org.gradle.api.provider.SetProperty;
 
 import javax.inject.Inject;
 
+@AutoFactory(allowSubclasses = true, extending = DecoratingFactory.class, className = "AutoDefaultObjectiveCppLibraryExtensionFactory")
 public class DefaultObjectiveCppLibraryExtension extends BaseNativeExtension<DefaultNativeLibraryComponent> implements ObjectiveCppLibraryExtension {
 	@Getter private final ConfigurableFileCollection sources;
 	@Getter private final ConfigurableFileCollection privateHeaders;
@@ -29,7 +32,7 @@ public class DefaultObjectiveCppLibraryExtension extends BaseNativeExtension<Def
 	@Getter private final SetProperty<TargetBuildType> targetBuildTypes;
 
 	@Inject
-	public DefaultObjectiveCppLibraryExtension(DefaultNativeLibraryComponent component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
+	public DefaultObjectiveCppLibraryExtension(@Provided DefaultNativeLibraryComponent component, @Provided ObjectFactory objects, @Provided ProviderFactory providers, @Provided ProjectLayout layout) {
 		super(component, objects, providers, layout);
 		this.sources = objects.fileCollection();
 		this.privateHeaders = objects.fileCollection();

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/DefaultObjectiveCppLibraryExtensionFactory.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/DefaultObjectiveCppLibraryExtensionFactory.java
@@ -1,0 +1,34 @@
+package dev.nokee.platform.objectivecpp.internal;
+
+import dagger.MembersInjector;
+import dev.nokee.platform.nativebase.internal.DecoratingFactory;
+import dev.nokee.platform.nativebase.internal.DefaultNativeLibraryComponent;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+/** @see DecoratingFactory */
+public final class DefaultObjectiveCppLibraryExtensionFactory extends AutoDefaultObjectiveCppLibraryExtensionFactory {
+	private final Provider<DefaultNativeLibraryComponent> componentProvider;
+	private final Provider<ObjectFactory> objectsProvider;
+	private final Provider<ProviderFactory> providersProvider;
+	private final Provider<ProjectLayout> layoutProvider;
+
+	@Inject
+	public DefaultObjectiveCppLibraryExtensionFactory(Provider<DefaultNativeLibraryComponent> componentProvider, Provider<ObjectFactory> objectsProvider, Provider<ProviderFactory> providersProvider, Provider<ProjectLayout> layoutProvider, MembersInjector<DecoratingFactory> injector) {
+		super(componentProvider, objectsProvider, providersProvider, layoutProvider);
+		this.componentProvider = componentProvider;
+		this.objectsProvider = objectsProvider;
+		this.providersProvider = providersProvider;
+		this.layoutProvider = layoutProvider;
+		injector.injectMembers(this);
+	}
+
+	@Override
+	public DefaultObjectiveCppLibraryExtension create() {
+		return newInstance(componentProvider.get(), objectsProvider.get(), providersProvider.get(), layoutProvider.get());
+	}
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/plugins/ObjectiveCppApplicationPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/plugins/ObjectiveCppApplicationPlugin.java
@@ -1,9 +1,14 @@
 package dev.nokee.platform.objectivecpp.internal.plugins;
 
+import dagger.BindsInstance;
+import dagger.Component;
+import dev.nokee.gradle.internal.GradleModule;
+import dev.nokee.platform.base.DomainObjectElement;
+import dev.nokee.platform.base.internal.DomainObjectIdentity;
 import dev.nokee.platform.base.internal.DomainObjectStore;
-import dev.nokee.platform.base.internal.NamingSchemeFactory;
 import dev.nokee.platform.base.internal.plugins.ProjectStorePlugin;
 import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
+import dev.nokee.platform.nativebase.internal.NativeComponentModule;
 import dev.nokee.platform.nativebase.internal.TargetBuildTypeRule;
 import dev.nokee.platform.nativebase.internal.TargetMachineRule;
 import dev.nokee.platform.objectivecpp.ObjectiveCppApplicationExtension;
@@ -33,14 +38,41 @@ public class ObjectiveCppApplicationPlugin implements Plugin<Project> {
 		project.getPluginManager().apply(ProjectStorePlugin.class);
 
 		val store = project.getExtensions().getByType(DomainObjectStore.class);
-		val component = store.register(DefaultNativeApplicationComponent.newMain(getObjects(), new NamingSchemeFactory(project.getName())));
+		val extension = DaggerObjectiveCppApplicationPlugin_ObjectiveCppApplicationComponent.factory().create(project).objectiveCppApplicationComponent();
+		val component = store.add(new DomainObjectElement<DefaultNativeApplicationComponent>() {
+			@Override
+			public DefaultNativeApplicationComponent get() {
+				return extension.getComponent();
+			}
+
+			@Override
+			public Class<DefaultNativeApplicationComponent> getType() {
+				return DefaultNativeApplicationComponent.class;
+			}
+
+			@Override
+			public DomainObjectIdentity getIdentity() {
+				return DomainObjectIdentity.named("main");
+			}
+		});
 		component.configure(it -> it.getBaseName().convention(project.getName()));
-		DefaultObjectiveCppApplicationExtension extension = getObjects().newInstance(DefaultObjectiveCppApplicationExtension.class, component.get());
+		component.get(); // force realize... for now.
 
 		project.afterEvaluate(getObjects().newInstance(TargetMachineRule.class, extension.getTargetMachines(), EXTENSION_NAME));
 		project.afterEvaluate(getObjects().newInstance(TargetBuildTypeRule.class, extension.getTargetBuildTypes(), EXTENSION_NAME));
 		project.afterEvaluate(extension::finalizeExtension);
 
 		project.getExtensions().add(ObjectiveCppApplicationExtension.class, EXTENSION_NAME, extension);
+	}
+
+
+	@Component(modules = {GradleModule.class, NativeComponentModule.class})
+	interface ObjectiveCppApplicationComponent {
+		DefaultObjectiveCppApplicationExtension objectiveCppApplicationComponent();
+
+		@Component.Factory
+		interface Factory {
+			ObjectiveCppApplicationComponent create(@BindsInstance Project project);
+		}
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/plugins/ObjectiveCppApplicationPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/plugins/ObjectiveCppApplicationPlugin.java
@@ -2,6 +2,8 @@ package dev.nokee.platform.objectivecpp.internal.plugins;
 
 import dagger.BindsInstance;
 import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
 import dev.nokee.gradle.internal.GradleModule;
 import dev.nokee.platform.base.DomainObjectElement;
 import dev.nokee.platform.base.internal.DomainObjectIdentity;
@@ -13,6 +15,7 @@ import dev.nokee.platform.nativebase.internal.TargetBuildTypeRule;
 import dev.nokee.platform.nativebase.internal.TargetMachineRule;
 import dev.nokee.platform.objectivecpp.ObjectiveCppApplicationExtension;
 import dev.nokee.platform.objectivecpp.internal.DefaultObjectiveCppApplicationExtension;
+import dev.nokee.platform.objectivecpp.internal.DefaultObjectiveCppApplicationExtensionFactory;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.val;
@@ -65,8 +68,15 @@ public class ObjectiveCppApplicationPlugin implements Plugin<Project> {
 		project.getExtensions().add(ObjectiveCppApplicationExtension.class, EXTENSION_NAME, extension);
 	}
 
+	@Module
+	interface ObjectiveCppModule {
+		@Provides
+		static DefaultObjectiveCppApplicationExtension theExtension(DefaultObjectiveCppApplicationExtensionFactory factory) {
+			return factory.create();
+		}
+	}
 
-	@Component(modules = {GradleModule.class, NativeComponentModule.class})
+	@Component(modules = {GradleModule.class, NativeComponentModule.class, ObjectiveCppModule.class})
 	interface ObjectiveCppApplicationComponent {
 		DefaultObjectiveCppApplicationExtension objectiveCppApplicationComponent();
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/plugins/ObjectiveCppLibraryPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/plugins/ObjectiveCppLibraryPlugin.java
@@ -2,6 +2,8 @@ package dev.nokee.platform.objectivecpp.internal.plugins;
 
 import dagger.BindsInstance;
 import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
 import dev.nokee.gradle.internal.GradleModule;
 import dev.nokee.platform.base.DomainObjectElement;
 import dev.nokee.platform.base.internal.DomainObjectIdentity;
@@ -10,6 +12,7 @@ import dev.nokee.platform.base.internal.plugins.ProjectStorePlugin;
 import dev.nokee.platform.nativebase.internal.*;
 import dev.nokee.platform.objectivecpp.ObjectiveCppLibraryExtension;
 import dev.nokee.platform.objectivecpp.internal.DefaultObjectiveCppLibraryExtension;
+import dev.nokee.platform.objectivecpp.internal.DefaultObjectiveCppLibraryExtensionFactory;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.val;
@@ -63,7 +66,15 @@ public class ObjectiveCppLibraryPlugin implements Plugin<Project> {
 		project.getExtensions().add(ObjectiveCppLibraryExtension.class, EXTENSION_NAME, extension);
 	}
 
-	@Component(modules = {GradleModule.class, NativeComponentModule.class})
+	@Module
+	interface ObjectiveCppModule {
+		@Provides
+		static DefaultObjectiveCppLibraryExtension theExtension(DefaultObjectiveCppLibraryExtensionFactory factory) {
+			return factory.create();
+		}
+	}
+
+	@Component(modules = {GradleModule.class, NativeComponentModule.class, ObjectiveCppModule.class})
 	interface ObjectiveCppLibraryComponent {
 		DefaultObjectiveCppLibraryExtension objectiveCppLibraryComponent();
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/DefaultSwiftApplicationExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/DefaultSwiftApplicationExtension.java
@@ -4,8 +4,12 @@ import dev.nokee.language.swift.internal.SwiftSourceSet;
 import dev.nokee.platform.base.VariantView;
 import dev.nokee.platform.nativebase.NativeApplication;
 import dev.nokee.platform.nativebase.NativeApplicationComponentDependencies;
+import dev.nokee.platform.nativebase.TargetBuildTypeFactory;
+import dev.nokee.platform.nativebase.TargetMachineFactory;
 import dev.nokee.platform.nativebase.internal.BaseNativeExtension;
 import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
+import dev.nokee.platform.nativebase.internal.DefaultTargetBuildTypeFactory;
+import dev.nokee.platform.nativebase.internal.DefaultTargetMachineFactory;
 import dev.nokee.platform.swift.SwiftApplicationExtension;
 import dev.nokee.runtime.nativebase.TargetBuildType;
 import dev.nokee.runtime.nativebase.TargetMachine;
@@ -52,5 +56,15 @@ public class DefaultSwiftApplicationExtension extends BaseNativeExtension<Defaul
 	@Override
 	public VariantView<NativeApplication> getVariants() {
 		return getComponent().getVariantCollection().getAsView(NativeApplication.class);
+	}
+
+	@Override
+	public TargetMachineFactory getMachines() {
+		return DefaultTargetMachineFactory.INSTANCE;
+	}
+
+	@Override
+	public TargetBuildTypeFactory getBuildTypes() {
+		return DefaultTargetBuildTypeFactory.INSTANCE;
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/DefaultSwiftApplicationExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/DefaultSwiftApplicationExtension.java
@@ -1,15 +1,14 @@
 package dev.nokee.platform.swift.internal;
 
+import com.google.auto.factory.AutoFactory;
+import com.google.auto.factory.Provided;
 import dev.nokee.language.swift.internal.SwiftSourceSet;
 import dev.nokee.platform.base.VariantView;
 import dev.nokee.platform.nativebase.NativeApplication;
 import dev.nokee.platform.nativebase.NativeApplicationComponentDependencies;
 import dev.nokee.platform.nativebase.TargetBuildTypeFactory;
 import dev.nokee.platform.nativebase.TargetMachineFactory;
-import dev.nokee.platform.nativebase.internal.BaseNativeExtension;
-import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
-import dev.nokee.platform.nativebase.internal.DefaultTargetBuildTypeFactory;
-import dev.nokee.platform.nativebase.internal.DefaultTargetMachineFactory;
+import dev.nokee.platform.nativebase.internal.*;
 import dev.nokee.platform.swift.SwiftApplicationExtension;
 import dev.nokee.runtime.nativebase.TargetBuildType;
 import dev.nokee.runtime.nativebase.TargetMachine;
@@ -24,13 +23,14 @@ import org.gradle.api.provider.SetProperty;
 
 import javax.inject.Inject;
 
+@AutoFactory(allowSubclasses = true, extending = DecoratingFactory.class, className = "AutoDefaultSwiftApplicationExtensionFactory")
 public class DefaultSwiftApplicationExtension extends BaseNativeExtension<DefaultNativeApplicationComponent> implements SwiftApplicationExtension {
 	@Getter private final ConfigurableFileCollection sources;
 	@Getter private final SetProperty<TargetMachine> targetMachines;
 	@Getter private final SetProperty<TargetBuildType> targetBuildTypes;
 
 	@Inject
-	public DefaultSwiftApplicationExtension(DefaultNativeApplicationComponent component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
+	public DefaultSwiftApplicationExtension(@Provided DefaultNativeApplicationComponent component, @Provided ObjectFactory objects, @Provided ProviderFactory providers, @Provided ProjectLayout layout) {
 		super(component, objects, providers, layout);
 		this.sources = objects.fileCollection();
 		this.targetMachines = objects.setProperty(TargetMachine.class);

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/DefaultSwiftApplicationExtensionFactory.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/DefaultSwiftApplicationExtensionFactory.java
@@ -1,0 +1,34 @@
+package dev.nokee.platform.swift.internal;
+
+import dagger.MembersInjector;
+import dev.nokee.platform.nativebase.internal.DecoratingFactory;
+import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+/** @see DecoratingFactory */
+public final class DefaultSwiftApplicationExtensionFactory extends AutoDefaultSwiftApplicationExtensionFactory {
+	private final Provider<DefaultNativeApplicationComponent> componentProvider;
+	private final Provider<ObjectFactory> objectsProvider;
+	private final Provider<ProviderFactory> providersProvider;
+	private final Provider<ProjectLayout> layoutProvider;
+
+	@Inject
+	public DefaultSwiftApplicationExtensionFactory(Provider<DefaultNativeApplicationComponent> componentProvider, Provider<ObjectFactory> objectsProvider, Provider<ProviderFactory> providersProvider, Provider<ProjectLayout> layoutProvider, MembersInjector<DecoratingFactory> injector) {
+		super(componentProvider, objectsProvider, providersProvider, layoutProvider);
+		this.componentProvider = componentProvider;
+		this.objectsProvider = objectsProvider;
+		this.providersProvider = providersProvider;
+		this.layoutProvider = layoutProvider;
+		injector.injectMembers(this);
+	}
+
+	@Override
+	public DefaultSwiftApplicationExtension create() {
+		return newInstance(componentProvider.get(), objectsProvider.get(), providersProvider.get(), layoutProvider.get());
+	}
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/DefaultSwiftLibraryExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/DefaultSwiftLibraryExtension.java
@@ -1,5 +1,7 @@
 package dev.nokee.platform.swift.internal;
 
+import com.google.auto.factory.AutoFactory;
+import com.google.auto.factory.Provided;
 import dev.nokee.language.swift.internal.SwiftSourceSet;
 import dev.nokee.platform.base.VariantView;
 import dev.nokee.platform.nativebase.*;
@@ -19,6 +21,7 @@ import org.gradle.api.provider.SetProperty;
 
 import javax.inject.Inject;
 
+@AutoFactory(allowSubclasses = true, extending = DecoratingFactory.class, className = "AutoDefaultSwiftLibraryExtensionFactory")
 public class DefaultSwiftLibraryExtension extends BaseNativeExtension<DefaultNativeLibraryComponent> implements SwiftLibraryExtension {
 	@Getter private final ConfigurableFileCollection sources;
 	@Getter private final SetProperty<TargetLinkage> targetLinkages;
@@ -26,7 +29,7 @@ public class DefaultSwiftLibraryExtension extends BaseNativeExtension<DefaultNat
 	@Getter private final SetProperty<TargetBuildType> targetBuildTypes;
 
 	@Inject
-	public DefaultSwiftLibraryExtension(DefaultNativeLibraryComponent component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
+	public DefaultSwiftLibraryExtension(@Provided DefaultNativeLibraryComponent component, @Provided ObjectFactory objects, @Provided ProviderFactory providers, @Provided ProjectLayout layout) {
 		super(component, objects, providers, layout);
 		this.sources = objects.fileCollection();
 		this.targetLinkages = objects.setProperty(TargetLinkage.class);

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/DefaultSwiftLibraryExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/DefaultSwiftLibraryExtension.java
@@ -2,10 +2,8 @@ package dev.nokee.platform.swift.internal;
 
 import dev.nokee.language.swift.internal.SwiftSourceSet;
 import dev.nokee.platform.base.VariantView;
-import dev.nokee.platform.nativebase.NativeLibrary;
-import dev.nokee.platform.nativebase.NativeLibraryComponentDependencies;
-import dev.nokee.platform.nativebase.internal.BaseNativeExtension;
-import dev.nokee.platform.nativebase.internal.DefaultNativeLibraryComponent;
+import dev.nokee.platform.nativebase.*;
+import dev.nokee.platform.nativebase.internal.*;
 import dev.nokee.platform.swift.SwiftLibraryExtension;
 import dev.nokee.runtime.nativebase.TargetBuildType;
 import dev.nokee.runtime.nativebase.TargetLinkage;
@@ -55,5 +53,20 @@ public class DefaultSwiftLibraryExtension extends BaseNativeExtension<DefaultNat
 	@Override
 	public VariantView<NativeLibrary> getVariants() {
 		return getComponent().getVariantCollection().getAsView(NativeLibrary.class);
+	}
+
+	@Override
+	public TargetMachineFactory getMachines() {
+		return DefaultTargetMachineFactory.INSTANCE;
+	}
+
+	@Override
+	public TargetLinkageFactory getLinkages() {
+		return DefaultTargetLinkageFactory.INSTANCE;
+	}
+
+	@Override
+	public TargetBuildTypeFactory getBuildTypes() {
+		return DefaultTargetBuildTypeFactory.INSTANCE;
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/DefaultSwiftLibraryExtensionFactory.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/DefaultSwiftLibraryExtensionFactory.java
@@ -1,0 +1,34 @@
+package dev.nokee.platform.swift.internal;
+
+import dagger.MembersInjector;
+import dev.nokee.platform.nativebase.internal.DecoratingFactory;
+import dev.nokee.platform.nativebase.internal.DefaultNativeLibraryComponent;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+/** @see DecoratingFactory */
+public final class DefaultSwiftLibraryExtensionFactory extends AutoDefaultSwiftLibraryExtensionFactory {
+	private final Provider<DefaultNativeLibraryComponent> componentProvider;
+	private final Provider<ObjectFactory> objectsProvider;
+	private final Provider<ProviderFactory> providersProvider;
+	private final Provider<ProjectLayout> layoutProvider;
+
+	@Inject
+	public DefaultSwiftLibraryExtensionFactory(Provider<DefaultNativeLibraryComponent> componentProvider, Provider<ObjectFactory> objectsProvider, Provider<ProviderFactory> providersProvider, Provider<ProjectLayout> layoutProvider, MembersInjector<DecoratingFactory> injector) {
+		super(componentProvider, objectsProvider, providersProvider, layoutProvider);
+		this.componentProvider = componentProvider;
+		this.objectsProvider = objectsProvider;
+		this.providersProvider = providersProvider;
+		this.layoutProvider = layoutProvider;
+		injector.injectMembers(this);
+	}
+
+	@Override
+	public DefaultSwiftLibraryExtension create() {
+		return newInstance(componentProvider.get(), objectsProvider.get(), providersProvider.get(), layoutProvider.get());
+	}
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftApplicationPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftApplicationPlugin.java
@@ -2,6 +2,8 @@ package dev.nokee.platform.swift.internal.plugins;
 
 import dagger.BindsInstance;
 import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
 import dev.nokee.gradle.internal.GradleModule;
 import dev.nokee.platform.base.DomainObjectElement;
 import dev.nokee.platform.base.internal.DomainObjectIdentity;
@@ -13,6 +15,7 @@ import dev.nokee.platform.nativebase.internal.TargetBuildTypeRule;
 import dev.nokee.platform.nativebase.internal.TargetMachineRule;
 import dev.nokee.platform.swift.SwiftApplicationExtension;
 import dev.nokee.platform.swift.internal.DefaultSwiftApplicationExtension;
+import dev.nokee.platform.swift.internal.DefaultSwiftApplicationExtensionFactory;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.val;
@@ -65,8 +68,15 @@ public class SwiftApplicationPlugin implements Plugin<Project> {
 		project.getExtensions().add(SwiftApplicationExtension.class, EXTENSION_NAME, extension);
 	}
 
+	@Module
+	interface SwiftModule {
+		@Provides
+		static DefaultSwiftApplicationExtension theExtension(DefaultSwiftApplicationExtensionFactory factory) {
+			return factory.create();
+		}
+	}
 
-	@Component(modules = {GradleModule.class, NativeComponentModule.class})
+	@Component(modules = {GradleModule.class, NativeComponentModule.class, SwiftModule.class})
 	interface SwiftApplicationComponent {
 		DefaultSwiftApplicationExtension swiftApplicationComponent();
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftApplicationPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftApplicationPlugin.java
@@ -1,9 +1,14 @@
 package dev.nokee.platform.swift.internal.plugins;
 
+import dagger.BindsInstance;
+import dagger.Component;
+import dev.nokee.gradle.internal.GradleModule;
+import dev.nokee.platform.base.DomainObjectElement;
+import dev.nokee.platform.base.internal.DomainObjectIdentity;
 import dev.nokee.platform.base.internal.DomainObjectStore;
-import dev.nokee.platform.base.internal.NamingSchemeFactory;
 import dev.nokee.platform.base.internal.plugins.ProjectStorePlugin;
 import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
+import dev.nokee.platform.nativebase.internal.NativeComponentModule;
 import dev.nokee.platform.nativebase.internal.TargetBuildTypeRule;
 import dev.nokee.platform.nativebase.internal.TargetMachineRule;
 import dev.nokee.platform.swift.SwiftApplicationExtension;
@@ -15,7 +20,6 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.nativeplatform.toolchain.plugins.SwiftCompilerPlugin;
-import org.gradle.util.GUtil;
 
 import javax.inject.Inject;
 
@@ -34,14 +38,41 @@ public class SwiftApplicationPlugin implements Plugin<Project> {
 		project.getPluginManager().apply(ProjectStorePlugin.class);
 
 		val store = project.getExtensions().getByType(DomainObjectStore.class);
-		val component = store.register(DefaultNativeApplicationComponent.newMain(getObjects(), new NamingSchemeFactory(project.getName())));
-		component.configure(it -> it.getBaseName().convention(GUtil.toCamelCase(project.getName())));
-		DefaultSwiftApplicationExtension extension = getObjects().newInstance(DefaultSwiftApplicationExtension.class, component.get());
+		val extension = DaggerSwiftApplicationPlugin_SwiftApplicationComponent.factory().create(project).swiftApplicationComponent();
+		val component = store.add(new DomainObjectElement<DefaultNativeApplicationComponent>() {
+			@Override
+			public DefaultNativeApplicationComponent get() {
+				return extension.getComponent();
+			}
+
+			@Override
+			public Class<DefaultNativeApplicationComponent> getType() {
+				return DefaultNativeApplicationComponent.class;
+			}
+
+			@Override
+			public DomainObjectIdentity getIdentity() {
+				return DomainObjectIdentity.named("main");
+			}
+		});
+		component.configure(it -> it.getBaseName().convention(project.getName()));
+		component.get(); // force realize... for now.
 
 		project.afterEvaluate(getObjects().newInstance(TargetMachineRule.class, extension.getTargetMachines(), EXTENSION_NAME));
 		project.afterEvaluate(getObjects().newInstance(TargetBuildTypeRule.class, extension.getTargetBuildTypes(), EXTENSION_NAME));
 		project.afterEvaluate(extension::finalizeExtension);
 
 		project.getExtensions().add(SwiftApplicationExtension.class, EXTENSION_NAME, extension);
+	}
+
+
+	@Component(modules = {GradleModule.class, NativeComponentModule.class})
+	interface SwiftApplicationComponent {
+		DefaultSwiftApplicationExtension swiftApplicationComponent();
+
+		@Component.Factory
+		interface Factory {
+			SwiftApplicationComponent create(@BindsInstance Project project);
+		}
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftLibraryPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftLibraryPlugin.java
@@ -1,12 +1,13 @@
 package dev.nokee.platform.swift.internal.plugins;
 
+import dagger.BindsInstance;
+import dagger.Component;
+import dev.nokee.gradle.internal.GradleModule;
+import dev.nokee.platform.base.DomainObjectElement;
+import dev.nokee.platform.base.internal.DomainObjectIdentity;
 import dev.nokee.platform.base.internal.DomainObjectStore;
-import dev.nokee.platform.base.internal.NamingSchemeFactory;
 import dev.nokee.platform.base.internal.plugins.ProjectStorePlugin;
-import dev.nokee.platform.nativebase.internal.DefaultNativeLibraryComponent;
-import dev.nokee.platform.nativebase.internal.TargetBuildTypeRule;
-import dev.nokee.platform.nativebase.internal.TargetLinkageRule;
-import dev.nokee.platform.nativebase.internal.TargetMachineRule;
+import dev.nokee.platform.nativebase.internal.*;
 import dev.nokee.platform.swift.SwiftLibraryExtension;
 import dev.nokee.platform.swift.internal.DefaultSwiftLibraryExtension;
 import lombok.AccessLevel;
@@ -16,7 +17,6 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.nativeplatform.toolchain.plugins.SwiftCompilerPlugin;
-import org.gradle.util.GUtil;
 
 import javax.inject.Inject;
 
@@ -35,9 +35,25 @@ public class SwiftLibraryPlugin implements Plugin<Project> {
 		project.getPluginManager().apply(ProjectStorePlugin.class);
 
 		val store = project.getExtensions().getByType(DomainObjectStore.class);
-		val component = store.register(DefaultNativeLibraryComponent.newMain(getObjects(), new NamingSchemeFactory(project.getName())));
-		component.configure(it -> it.getBaseName().convention(GUtil.toCamelCase(project.getName())));
-		DefaultSwiftLibraryExtension extension = getObjects().newInstance(DefaultSwiftLibraryExtension.class, component.get());
+		val extension = DaggerSwiftLibraryPlugin_SwiftLibraryComponent.factory().create(project).swiftLibraryComponent();
+		val component = store.add(new DomainObjectElement<DefaultNativeLibraryComponent>() {
+			@Override
+			public DefaultNativeLibraryComponent get() {
+				return extension.getComponent();
+			}
+
+			@Override
+			public Class<DefaultNativeLibraryComponent> getType() {
+				return DefaultNativeLibraryComponent.class;
+			}
+
+			@Override
+			public DomainObjectIdentity getIdentity() {
+				return DomainObjectIdentity.named("main");
+			}
+		});
+		component.configure(it -> it.getBaseName().convention(project.getName()));
+		component.get(); // force realize... for now.
 
 		project.afterEvaluate(getObjects().newInstance(TargetMachineRule.class, extension.getTargetMachines(), EXTENSION_NAME));
 		project.afterEvaluate(getObjects().newInstance(TargetLinkageRule.class, extension.getTargetLinkages(), EXTENSION_NAME));
@@ -45,5 +61,15 @@ public class SwiftLibraryPlugin implements Plugin<Project> {
 		project.afterEvaluate(extension::finalizeExtension);
 
 		project.getExtensions().add(SwiftLibraryExtension.class, EXTENSION_NAME, extension);
+	}
+
+	@Component(modules = {GradleModule.class, NativeComponentModule.class})
+	interface SwiftLibraryComponent {
+		DefaultSwiftLibraryExtension swiftLibraryComponent();
+
+		@Component.Factory
+		interface Factory {
+			SwiftLibraryComponent create(@BindsInstance Project project);
+		}
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftLibraryPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftLibraryPlugin.java
@@ -2,6 +2,8 @@ package dev.nokee.platform.swift.internal.plugins;
 
 import dagger.BindsInstance;
 import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
 import dev.nokee.gradle.internal.GradleModule;
 import dev.nokee.platform.base.DomainObjectElement;
 import dev.nokee.platform.base.internal.DomainObjectIdentity;
@@ -10,6 +12,7 @@ import dev.nokee.platform.base.internal.plugins.ProjectStorePlugin;
 import dev.nokee.platform.nativebase.internal.*;
 import dev.nokee.platform.swift.SwiftLibraryExtension;
 import dev.nokee.platform.swift.internal.DefaultSwiftLibraryExtension;
+import dev.nokee.platform.swift.internal.DefaultSwiftLibraryExtensionFactory;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.val;
@@ -63,7 +66,15 @@ public class SwiftLibraryPlugin implements Plugin<Project> {
 		project.getExtensions().add(SwiftLibraryExtension.class, EXTENSION_NAME, extension);
 	}
 
-	@Component(modules = {GradleModule.class, NativeComponentModule.class})
+	@Module
+	interface SwiftModule {
+		@Provides
+		static DefaultSwiftLibraryExtension theExtension(DefaultSwiftLibraryExtensionFactory factory) {
+			return factory.create();
+		}
+	}
+
+	@Component(modules = {GradleModule.class, NativeComponentModule.class, SwiftModule.class})
 	interface SwiftLibraryComponent {
 		DefaultSwiftLibraryExtension swiftLibraryComponent();
 


### PR DESCRIPTION
Having a master base component for all components is not a good idea. Instead, we are moving toward breaking this relationship down so each component is free standing. This will allow reusing the component concept in various other places such as in the build adapters. It will also help keep the business logic closer to the domain model.

This PR also includes an experiment around tracking component tasks. Each component can have its own set of tasks as well as each variant. It allows mixing-in the naming of tasks as a self-aware hierarchy. This will enable things like configuring tasks per component and per variant. The same concept will be applied to dependencies, sources, variants and binaries. A similar implementation exists for dependencies but it is still lacking some of the hierarchy and the class decomposition is a bit sketchy particularly when it comes to incoming vs outgoing dependency buckets.