### PR TITLE
Ungradlefy the Groovy DSL mixin of public types

### DIFF
--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/ApplicationComponentDependencies.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/ApplicationComponentDependencies.java
@@ -1,9 +1,12 @@
 package dev.nokee.platform.base;
 
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ProjectDependency;
+import org.gradle.util.ConfigureUtil;
 
 /**
  * The dependency buckets for an application component.
@@ -27,6 +30,17 @@ public interface ApplicationComponentDependencies extends ComponentDependencies 
 	 * @param action The action to run to configure the dependency (project dependencies are {@link ProjectDependency} and external dependencies are {@link ExternalModuleDependency}).
 	 */
 	void implementation(Object notation, Action<? super ModuleDependency> action);
+
+	/**
+	 * Adds an implementation dependency to this component.
+	 * An implementation dependency is not visible to consumers that are compiled against this component.
+	 *
+	 * @param notation The dependency notation, as per {@link org.gradle.api.artifacts.dsl.DependencyHandler#create(Object)}.
+	 * @param closure The closure to run to configure the dependency (project dependencies are {@link ProjectDependency} and external dependencies are {@link ExternalModuleDependency}).
+	 */
+	default void implementation(Object notation, @DelegatesTo(value = ModuleDependency.class, strategy = Closure.DELEGATE_FIRST) Closure<Void> closure) {
+		implementation(notation, ConfigureUtil.configureUsing(closure));
+	}
 
 	/**
 	 * Returns the implementation bucket of dependencies for this component.

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/DependencyAwareComponent.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/DependencyAwareComponent.java
@@ -1,6 +1,9 @@
 package dev.nokee.platform.base;
 
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
+import org.gradle.util.ConfigureUtil;
 
 /**
  * A component with dependency buckets.
@@ -23,6 +26,15 @@ public interface DependencyAwareComponent<T extends ComponentDependencies> {
 	 */
 	default void dependencies(Action<? super T> action) {
 		action.execute(getDependencies());
+	}
+
+	/**
+	 * Configure the dependencies of this component.
+	 *
+	 * @param closure configuration closure for {@link ComponentDependencies}.
+	 */
+	default void dependencies(@DelegatesTo(type = "T", strategy = Closure.DELEGATE_FIRST) Closure<Void> closure) {
+		dependencies(ConfigureUtil.configureUsing(closure));
 	}
 }
 

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/LibraryComponentDependencies.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/LibraryComponentDependencies.java
@@ -1,9 +1,12 @@
 package dev.nokee.platform.base;
 
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ProjectDependency;
+import org.gradle.util.ConfigureUtil;
 
 /**
  * The dependency buckets for a library component.
@@ -27,6 +30,16 @@ public interface LibraryComponentDependencies extends ComponentDependencies {
 	void api(Object notation, Action<? super ModuleDependency> action);
 
 	/**
+	 * Adds an API dependency to this library. An API dependency is made visible to consumers that are compiled against this component.
+	 *
+	 * @param notation The dependency notation, as per {@link org.gradle.api.artifacts.dsl.DependencyHandler#create(Object)}.
+	 * @param closure The closure to run to configure the dependency (project dependencies are {@link ProjectDependency} and external dependencies are {@link ExternalModuleDependency}).
+	 */
+	default void api(Object notation, @DelegatesTo(value = ModuleDependency.class, strategy = Closure.DELEGATE_FIRST) Closure<Void> closure) {
+		api(notation, ConfigureUtil.configureUsing(closure));
+	}
+
+	/**
 	 * Adds an implementation dependency to this component.
 	 * An implementation dependency is not visible to consumers that are compiled against this component.
 	 *
@@ -42,6 +55,17 @@ public interface LibraryComponentDependencies extends ComponentDependencies {
 	 * @param action The action to run to configure the dependency (project dependencies are {@link ProjectDependency} and external dependencies are {@link ExternalModuleDependency}).
 	 */
 	void implementation(Object notation, Action<? super ModuleDependency> action);
+
+	/**
+	 * Adds an implementation dependency to this component.
+	 * An implementation dependency is not visible to consumers that are compiled against this component.
+	 *
+	 * @param notation The dependency notation, as per {@link org.gradle.api.artifacts.dsl.DependencyHandler#create(Object)}.
+	 * @param closure The closure to run to configure the dependency (project dependencies are {@link ProjectDependency} and external dependencies are {@link ExternalModuleDependency}).
+	 */
+	default void implementation(Object notation, @DelegatesTo(value = ModuleDependency.class, strategy = Closure.DELEGATE_FIRST) Closure<Void> closure) {
+		implementation(notation, ConfigureUtil.configureUsing(closure));
+	}
 
 	/**
 	 * Returns the implementation bucket of dependencies for this component.

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/View.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/View.java
@@ -1,9 +1,12 @@
 package dev.nokee.platform.base;
 
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.specs.Spec;
+import org.gradle.util.ConfigureUtil;
 
 import java.util.List;
 import java.util.Set;
@@ -25,6 +28,17 @@ public interface View<T> {
 	void configureEach(Action<? super T> action);
 
 	/**
+	 * Registers a closure to execute to configure each element in the view.
+	 * The action is only executed for those elements that are required.
+	 * Fails if any element has already been finalized.
+	 *
+	 * @param closure The closure to execute on each element for configuration.
+	 */
+	default void configureEach(@DelegatesTo(type = "T", strategy = Closure.DELEGATE_FIRST) Closure<Void> closure) {
+		configureEach(ConfigureUtil.configureUsing(closure));
+	}
+
+	/**
 	 * Registers an action to execute to configure each element in the view.
 	 * The action is only executed for those elements that are required.
 	 * Fails if any matching element has already been finalized.
@@ -38,6 +52,21 @@ public interface View<T> {
 	<S extends T> void configureEach(Class<S> type, Action<? super S> action);
 
 	/**
+	 * Registers a closure to execute to configure each element in the view.
+	 * The action is only executed for those elements that are required.
+	 * Fails if any matching element has already been finalized.
+	 *
+	 * This method is equivalent to <code>view.withType(Foo).configureEach { ... }</code>.
+	 *
+	 * @param type the type of binary to select.
+	 * @param <S> the base type of the element to configure.
+	 * @param closure the closure to execute on each element for configuration.
+	 */
+	default <S extends T> void configureEach(Class<S> type, @DelegatesTo(type = "S", strategy = Closure.DELEGATE_FIRST) Closure<Void> closure) {
+		configureEach(type, ConfigureUtil.configureUsing(closure));
+	}
+
+	/**
 	 * Registers an action to execute to configure each element in the view matching the given specification.
 	 * The action is only executed for those elements that are required.
 	 * Fails if any element has already been finalized.
@@ -47,6 +76,19 @@ public interface View<T> {
 	 * @since 0.4
 	 */
 	void configureEach(Spec<? super T> spec, Action<? super T> action);
+
+	/**
+	 * Registers a closure to execute to configure each element in the view matching the given specification.
+	 * The action is only executed for those elements that are required.
+	 * Fails if any element has already been finalized.
+	 *
+	 * @param spec a specification to satisfy. The spec is applied to each binary prior to configuration.
+	 * @param closure the closure to execute on each element for configuration.
+	 * @since 0.4
+	 */
+	default void configureEach(Spec<? super T> spec, @DelegatesTo(type = "S", strategy = Closure.DELEGATE_FIRST) Closure<Void> closure) {
+		configureEach(spec, ConfigureUtil.configureUsing(closure));
+	}
 
 	/**
 	 * Returns a view containing the objects in this view of the given type.

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/JavaNativeInterfaceLibraryComponentDependencies.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/JavaNativeInterfaceLibraryComponentDependencies.java
@@ -2,10 +2,13 @@ package dev.nokee.platform.jni;
 
 import dev.nokee.platform.base.ComponentDependencies;
 import dev.nokee.platform.base.DependencyBucket;
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ProjectDependency;
+import org.gradle.util.ConfigureUtil;
 
 /**
  * Allows the API, JVM implementation and native implementation dependencies of a Java Native Interface (JNI) library to be specified.
@@ -30,6 +33,16 @@ public interface JavaNativeInterfaceLibraryComponentDependencies extends JavaNat
 	void api(Object notation, Action<? super ModuleDependency> action);
 
 	/**
+	 * Adds an JVM API dependency to this library. An API dependency is made visible to consumers that are compiled against this component.
+	 *
+	 * @param notation The dependency notation, as per {@link org.gradle.api.artifacts.dsl.DependencyHandler#create(Object)}.
+	 * @param closure The closure to run to configure the dependency (project dependencies are {@link ProjectDependency} and external dependencies are {@link ExternalModuleDependency}).
+	 */
+	default void api(Object notation, @DelegatesTo(value = ModuleDependency.class, strategy = Closure.DELEGATE_FIRST) Closure<Void> closure) {
+		api(notation, ConfigureUtil.configureUsing(closure));
+	}
+
+	/**
 	 * Adds an JVM implementation dependency to this library. An implementation dependency is not visible to consumers that are compiled against this component.
 	 *
 	 * @param notation The dependency notation, as per {@link org.gradle.api.artifacts.dsl.DependencyHandler#create(Object)}.
@@ -44,6 +57,17 @@ public interface JavaNativeInterfaceLibraryComponentDependencies extends JavaNat
 	 * @param action The action to run to configure the dependency (project dependencies are {@link ProjectDependency} and external dependencies are {@link ExternalModuleDependency}).
 	 */
 	void jvmImplementation(Object notation, Action<? super ModuleDependency> action);
+
+	/**
+	 * Adds an JVM implementation dependency to this library.
+	 * An implementation dependency is not visible to consumers that are compiled against this component.
+	 *
+	 * @param notation The dependency notation, as per {@link org.gradle.api.artifacts.dsl.DependencyHandler#create(Object)}.
+	 * @param closure The closure to run to configure the dependency (project dependencies are {@link ProjectDependency} and external dependencies are {@link ExternalModuleDependency}).
+	 */
+	default void jvmImplementation(Object notation, @DelegatesTo(value = ModuleDependency.class, strategy = Closure.DELEGATE_FIRST) Closure<Void> closure) {
+		jvmImplementation(notation, ConfigureUtil.configureUsing(closure));
+	}
 
 	/**
 	 * Adds an JVM runtime only dependency to this library.
@@ -61,6 +85,17 @@ public interface JavaNativeInterfaceLibraryComponentDependencies extends JavaNat
 	 * @param action The action to run to configure the dependency (project dependencies are {@link ProjectDependency} and external dependencies are {@link ExternalModuleDependency}).
 	 */
 	void jvmRuntimeOnly(Object notation, Action<? super ModuleDependency> action);
+
+	/**
+	 * Adds an JVM runtime only dependency to this library.
+	 * An implementation dependency is only visible to consumers that are running against this component.
+	 *
+	 * @param notation The dependency notation, as per {@link org.gradle.api.artifacts.dsl.DependencyHandler#create(Object)}.
+	 * @param closure The closure to run to configure the dependency (project dependencies are {@link ProjectDependency} and external dependencies are {@link ExternalModuleDependency}).
+	 */
+	default void jvmRuntimeOnly(Object notation, @DelegatesTo(value = ModuleDependency.class, strategy = Closure.DELEGATE_FIRST) Closure<Void> closure) {
+		jvmRuntimeOnly(notation, ConfigureUtil.configureUsing(closure));
+	}
 
 	/**
 	 * Returns the JVM runtime only bucket of dependencies for this component.

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/JavaNativeInterfaceNativeComponentDependencies.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/JavaNativeInterfaceNativeComponentDependencies.java
@@ -2,10 +2,13 @@ package dev.nokee.platform.jni;
 
 import dev.nokee.platform.base.ComponentDependencies;
 import dev.nokee.platform.base.DependencyBucket;
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ProjectDependency;
+import org.gradle.util.ConfigureUtil;
 
 /**
  * Allows the native implementation dependencies of a Java Native Interface (JNI) library to be specified.
@@ -32,6 +35,17 @@ public interface JavaNativeInterfaceNativeComponentDependencies extends Componen
 	void nativeImplementation(Object notation, Action<? super ModuleDependency> action);
 
 	/**
+	 * Adds an native implementation dependency to this component.
+	 * An implementation dependency is not visible to consumers that are compiled or linked against this component.
+	 *
+	 * @param notation The dependency notation, as per {@link org.gradle.api.artifacts.dsl.DependencyHandler#create(Object)}.
+	 * @param closure The closure to run to configure the dependency (project dependencies are {@link ProjectDependency} and external dependencies are {@link ExternalModuleDependency}).
+	 */
+	default void nativeImplementation(Object notation, @DelegatesTo(value = ModuleDependency.class, strategy = Closure.DELEGATE_FIRST) Closure<Void> closure) {
+		nativeImplementation(notation, ConfigureUtil.configureUsing(closure));
+	}
+
+	/**
 	 * Adds an native link only dependency to this component.
 	 * An link only dependency is not visible to consumers that are compiled or linked against this component.
 	 *
@@ -50,6 +64,18 @@ public interface JavaNativeInterfaceNativeComponentDependencies extends Componen
 	void nativeLinkOnly(Object notation, Action<? super ModuleDependency> action);
 
 	/**
+	 * Adds an native link only dependency to this component.
+	 * An link only dependency is not visible to consumers that are compiled or linked against this component.
+	 *
+	 * @param notation The dependency notation, as per {@link org.gradle.api.artifacts.dsl.DependencyHandler#create(Object)}.
+	 * @param closure The closure to run to configure the dependency (project dependencies are {@link ProjectDependency} and external dependencies are {@link ExternalModuleDependency}).
+	 * @since 0.4
+	 */
+	default void nativeLinkOnly(Object notation, @DelegatesTo(value = ModuleDependency.class, strategy = Closure.DELEGATE_FIRST) Closure<Void> closure) {
+		nativeLinkOnly(notation, ConfigureUtil.configureUsing(closure));
+	}
+
+	/**
 	 * Adds an native runtime only dependency to this component.
 	 * An runtime only dependency is not visible to consumers that are running against this component.
 	 *
@@ -65,6 +91,17 @@ public interface JavaNativeInterfaceNativeComponentDependencies extends Componen
 	 * @param action The action to run to configure the dependency (project dependencies are {@link ProjectDependency} and external dependencies are {@link ExternalModuleDependency}).
 	 */
 	void nativeRuntimeOnly(Object notation, Action<? super ModuleDependency> action);
+
+	/**
+	 * Adds an native runtime only dependency to this component.
+	 * An runtime only dependency is visible only to consumers that are running against this component.
+	 *
+	 * @param notation The dependency notation, as per {@link org.gradle.api.artifacts.dsl.DependencyHandler#create(Object)}.
+	 * @param closure The closure to run to configure the dependency (project dependencies are {@link ProjectDependency} and external dependencies are {@link ExternalModuleDependency}).
+	 */
+	default void nativeRuntimeOnly(Object notation, @DelegatesTo(value = ModuleDependency.class, strategy = Closure.DELEGATE_FIRST) Closure<Void> closure) {
+		nativeRuntimeOnly(notation, ConfigureUtil.configureUsing(closure));
+	}
 
 	/**
 	 * Returns the native implementation bucket of dependencies for this component.

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/JniLibrary.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/JniLibrary.java
@@ -5,9 +5,12 @@ import dev.nokee.platform.base.DependencyAwareComponent;
 import dev.nokee.platform.base.Variant;
 import dev.nokee.platform.nativebase.SharedLibraryBinary;
 import dev.nokee.runtime.nativebase.TargetMachine;
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.provider.Property;
+import org.gradle.util.ConfigureUtil;
 
 /**
  * Configuration for a specific Java Native Interface (JNI) library variant, defining the dependencies that make up the library plus other settings.
@@ -44,6 +47,16 @@ public interface JniLibrary extends Variant, DependencyAwareComponent<JavaNative
 	 * @since 0.3
 	 */
 	void sharedLibrary(Action<? super SharedLibraryBinary> action);
+
+	/**
+	 * Configure the shared library binary for this variant.
+	 *
+	 * @param closure configuration closure for {@link SharedLibraryBinary}.
+	 * @since 0.3
+	 */
+	default void sharedLibrary(@DelegatesTo(value = SharedLibraryBinary.class, strategy = Closure.DELEGATE_FIRST) Closure<Void> closure) {
+		sharedLibrary(ConfigureUtil.configureUsing(closure));
+	}
 
 	/**
 	 * Configure the native runtime files to include inside the JNI JAR at the resource path location.

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/JniLibraryExtension.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/JniLibraryExtension.java
@@ -4,7 +4,6 @@ import dev.nokee.platform.base.*;
 import dev.nokee.platform.nativebase.TargetMachineAwareComponent;
 import dev.nokee.platform.nativebase.TargetMachineFactory;
 import dev.nokee.runtime.nativebase.TargetMachine;
-import org.gradle.api.Action;
 import org.gradle.api.provider.SetProperty;
 
 /**

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/NativeApplicationComponentDependencies.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/NativeApplicationComponentDependencies.java
@@ -2,6 +2,10 @@ package dev.nokee.platform.nativebase;
 
 import dev.nokee.platform.base.ApplicationComponentDependencies;
 import dev.nokee.platform.base.ComponentDependencies;
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
+import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.util.ConfigureUtil;
 
 /**
  * Allows the implementation dependencies of a native application to be specified.
@@ -9,4 +13,11 @@ import dev.nokee.platform.base.ComponentDependencies;
  * @since 0.5
  */
 public interface NativeApplicationComponentDependencies extends ApplicationComponentDependencies, NativeComponentDependencies, ComponentDependencies {
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	default void implementation(Object notation, @DelegatesTo(value = ModuleDependency.class, strategy = Closure.DELEGATE_FIRST) Closure<Void> closure) {
+		implementation(notation, ConfigureUtil.configureUsing(closure));
+	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/NativeComponentDependencies.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/NativeComponentDependencies.java
@@ -2,10 +2,13 @@ package dev.nokee.platform.nativebase;
 
 import dev.nokee.platform.base.ComponentDependencies;
 import dev.nokee.platform.base.DependencyBucket;
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ProjectDependency;
+import org.gradle.util.ConfigureUtil;
 
 /**
  * Allows the implementation dependencies of a native component to be specified.
@@ -31,6 +34,17 @@ public interface NativeComponentDependencies extends ComponentDependencies {
 	void implementation(Object notation, Action<? super ModuleDependency> action);
 
 	/**
+	 * Adds an implementation dependency to this component.
+	 * An implementation dependency is not visible to consumers that are compiled against this component.
+	 *
+	 * @param notation The dependency notation, as per {@link org.gradle.api.artifacts.dsl.DependencyHandler#create(Object)}.
+	 * @param closure The closure to run to configure the dependency (project dependencies are {@link ProjectDependency} and external dependencies are {@link ExternalModuleDependency}).
+	 */
+	default void implementation(Object notation, @DelegatesTo(value = ModuleDependency.class, strategy = Closure.DELEGATE_FIRST) Closure<Void> closure) {
+		implementation(notation, ConfigureUtil.configureUsing(closure));
+	}
+
+	/**
 	 * Adds an native compile only dependency to this component.
 	 * An compile only dependency is not visible to consumers that are compiled or linked against this component.
 	 *
@@ -46,6 +60,17 @@ public interface NativeComponentDependencies extends ComponentDependencies {
 	 * @param action The action to run to configure the dependency (project dependencies are {@link ProjectDependency} and external dependencies are {@link ExternalModuleDependency}).
 	 */
 	void compileOnly(Object notation, Action<? super ModuleDependency> action);
+
+	/**
+	 * Adds an native compile only dependency to this component.
+	 * An compile only dependency is not visible to consumers that are compiled or linked against this component.
+	 *
+	 * @param notation The dependency notation, as per {@link org.gradle.api.artifacts.dsl.DependencyHandler#create(Object)}.
+	 * @param closure The closure to run to configure the dependency (project dependencies are {@link ProjectDependency} and external dependencies are {@link ExternalModuleDependency}).
+	 */
+	default void compileOnly(Object notation, @DelegatesTo(value = ModuleDependency.class, strategy = Closure.DELEGATE_FIRST) Closure<Void> closure) {
+		compileOnly(notation, ConfigureUtil.configureUsing(closure));
+	}
 
 	/**
 	 * Adds an native link only dependency to this component.
@@ -65,6 +90,17 @@ public interface NativeComponentDependencies extends ComponentDependencies {
 	void linkOnly(Object notation, Action<? super ModuleDependency> action);
 
 	/**
+	 * Adds an native link only dependency to this component.
+	 * An link only dependency is not visible to consumers that are compiled or linked against this component.
+	 *
+	 * @param notation The dependency notation, as per {@link org.gradle.api.artifacts.dsl.DependencyHandler#create(Object)}.
+	 * @param closure The closure to run to configure the dependency (project dependencies are {@link ProjectDependency} and external dependencies are {@link ExternalModuleDependency}).
+	 */
+	default void linkOnly(Object notation, @DelegatesTo(value = ModuleDependency.class, strategy = Closure.DELEGATE_FIRST) Closure<Void> closure) {
+		linkOnly(notation, ConfigureUtil.configureUsing(closure));
+	}
+
+	/**
 	 * Adds an native runtime only dependency to this component.
 	 * An runtime only dependency is not visible to consumers that are running against this component.
 	 *
@@ -80,6 +116,17 @@ public interface NativeComponentDependencies extends ComponentDependencies {
 	 * @param action The action to run to configure the dependency (project dependencies are {@link ProjectDependency} and external dependencies are {@link ExternalModuleDependency}).
 	 */
 	void runtimeOnly(Object notation, Action<? super ModuleDependency> action);
+
+	/**
+	 * Adds an native runtime only dependency to this component.
+	 * An runtime only dependency is visible only to consumers that are running against this component.
+	 *
+	 * @param notation The dependency notation, as per {@link org.gradle.api.artifacts.dsl.DependencyHandler#create(Object)}.
+	 * @param closure The closure to run to configure the dependency (project dependencies are {@link ProjectDependency} and external dependencies are {@link ExternalModuleDependency}).
+	 */
+	default void runtimeOnly(Object notation, @DelegatesTo(value = ModuleDependency.class, strategy = Closure.DELEGATE_FIRST) Closure<Void> closure) {
+		runtimeOnly(notation, ConfigureUtil.configureUsing(closure));
+	}
 
 	/**
 	 * Returns the implementation bucket of dependencies for this component.

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/NativeLibraryComponentDependencies.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/NativeLibraryComponentDependencies.java
@@ -2,6 +2,10 @@ package dev.nokee.platform.nativebase;
 
 import dev.nokee.platform.base.ComponentDependencies;
 import dev.nokee.platform.base.LibraryComponentDependencies;
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
+import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.util.ConfigureUtil;
 
 /**
  * Allows the API and implementation dependencies of a native library to be specified.
@@ -9,4 +13,19 @@ import dev.nokee.platform.base.LibraryComponentDependencies;
  * @since 0.5
  */
 public interface NativeLibraryComponentDependencies extends LibraryComponentDependencies, NativeComponentDependencies, ComponentDependencies, NativeLibraryDependencies {
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	default void api(Object notation, @DelegatesTo(value = ModuleDependency.class, strategy = Closure.DELEGATE_FIRST) Closure<Void> closure) {
+		api(notation, ConfigureUtil.configureUsing(closure));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	default void implementation(Object notation, @DelegatesTo(value = ModuleDependency.class, strategy = Closure.DELEGATE_FIRST) Closure<Void> closure) {
+		implementation(notation, ConfigureUtil.configureUsing(closure));
+	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/NativeLibraryDependencies.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/NativeLibraryDependencies.java
@@ -1,10 +1,13 @@
 package dev.nokee.platform.nativebase;
 
 import dev.nokee.platform.base.ComponentDependencies;
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ProjectDependency;
+import org.gradle.util.ConfigureUtil;
 
 /**
  * Allows the API and implementation dependencies of a native library to be specified.
@@ -27,4 +30,14 @@ public interface NativeLibraryDependencies extends NativeComponentDependencies, 
      * @param action The action to run to configure the dependency (project dependencies are {@link ProjectDependency} and external dependencies are {@link ExternalModuleDependency}).
      */
     void api(Object notation, Action<? super ModuleDependency> action);
+
+	/**
+	 * Adds an API dependency to this library. An API dependency is made visible to consumers that are compiled against this component.
+	 *
+	 * @param notation The dependency notation, as per {@link org.gradle.api.artifacts.dsl.DependencyHandler#create(Object)}.
+	 * @param closure The closure to run to configure the dependency (project dependencies are {@link ProjectDependency} and external dependencies are {@link ExternalModuleDependency}).
+	 */
+	default void api(Object notation, @DelegatesTo(value = ModuleDependency.class, strategy = Closure.DELEGATE_FIRST) Closure<Void> closure) {
+		api(notation, ConfigureUtil.configureUsing(closure));
+	}
 }

--- a/subprojects/testing-base/src/main/java/dev/nokee/testing/base/TestSuiteContainer.java
+++ b/subprojects/testing-base/src/main/java/dev/nokee/testing/base/TestSuiteContainer.java
@@ -2,15 +2,30 @@ package dev.nokee.testing.base;
 
 import dev.nokee.platform.base.DomainObjectProvider;
 import dev.nokee.platform.base.KnownDomainObject;
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
+import org.gradle.util.ConfigureUtil;
 
 public interface TestSuiteContainer {
 	<T extends TestSuiteComponent> DomainObjectProvider<T> register(String name, Class<T> type);
 	<T extends TestSuiteComponent> DomainObjectProvider<T> register(String name, Class<T> type, Action<? super T> action);
+	default <T extends TestSuiteComponent> DomainObjectProvider<T> register(String name, Class<T> type, @DelegatesTo(type = "T", strategy = Closure.DELEGATE_FIRST) Closure<Void> closure) {
+		return register(name, type, ConfigureUtil.configureUsing(closure));
+	}
 
 	void configureEach(Action<? super TestSuiteComponent> action);
+	default void configureEach(@DelegatesTo(value = TestSuiteComponent.class, strategy = Closure.DELEGATE_FIRST) Closure<Void> closure) {
+		configureEach(ConfigureUtil.configureUsing(closure));
+	}
 	<T extends TestSuiteComponent> void configureEach(Class<T> type, Action<? super T> action);
 
 	void whenElementKnown(Action<KnownDomainObject<? extends TestSuiteComponent>> action);
+	default void whenElementKnown(@DelegatesTo(value = KnownDomainObject.class, strategy = Closure.DELEGATE_FIRST) Closure<Void> closure) {
+		whenElementKnown(ConfigureUtil.configureUsing(closure));
+	}
 	<T extends TestSuiteComponent> void whenElementKnown(Class<T> type, Action<KnownDomainObject<? extends T>> action);
+	default <T extends TestSuiteComponent> void whenElementKnown(Class<T> type, @DelegatesTo(type = "T", strategy = Closure.DELEGATE_FIRST) Closure<Void> closure) {
+		whenElementKnown(type, ConfigureUtil.configureUsing(closure));
+	}
 }


### PR DESCRIPTION
As we are moving away from dynamic instantiation, we need to manually
mixin the Groovy DSL methods inside the public types. It can be
perceived as unecessary or going against idiomatic Gradle but is in fact
much better this way as IDEs will have better auto-complete as well as
eliminating a whole class of errors because of the dynamic
instantiation.