### PR TITLE
Move code around to unblock variant/binary handling refactoring

### DIFF
--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/KnownVariant.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/KnownVariant.java
@@ -3,12 +3,13 @@ package dev.nokee.platform.base.internal;
 import dev.nokee.model.internal.Value;
 import dev.nokee.platform.base.Variant;
 import dev.nokee.utils.TransformerUtils;
+import lombok.Getter;
 import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.provider.Provider;
 
 public final class KnownVariant<T extends Variant> {
-	private final VariantIdentifier<T> identifier;
+	@Getter private final VariantIdentifier<T> identifier;
 	private final Value<? extends T> value;
 
 	public KnownVariant(VariantIdentifier<T> identifier, Value<? extends T> value) {

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantCollection.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantCollection.java
@@ -31,7 +31,7 @@ public final class VariantCollection<T extends Variant> implements Realizable {
 	}
 
 	public VariantProvider<T> registerVariant(VariantIdentifier<T> identifier, VariantFactory<T> factory) {
-		val value = Value.supplied(elementType, () -> factory.create(identifier.getUnambiguousName(), (BuildVariantInternal) identifier.getBuildVariant()));
+		val value = Value.supplied(elementType, () -> factory.create(identifier.getFullName(), (BuildVariantInternal) identifier.getBuildVariant()));
 		store.put(identifier, value);
 		return new VariantProvider<>(identifier, value);
 	}

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantCollection.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantCollection.java
@@ -5,7 +5,6 @@ import com.google.common.collect.ImmutableSet;
 import dev.nokee.model.internal.NokeeMap;
 import dev.nokee.model.internal.NokeeMapImpl;
 import dev.nokee.model.internal.Value;
-import dev.nokee.platform.base.Component;
 import dev.nokee.platform.base.Variant;
 import dev.nokee.platform.base.VariantView;
 import dev.nokee.utils.Cast;
@@ -31,10 +30,8 @@ public final class VariantCollection<T extends Variant> implements Realizable {
 		this.elementType = elementType;
 	}
 
-	public VariantProvider<T> registerVariant(BuildVariantInternal buildVariant, VariantFactory<T> factory) {
-		val identifier = VariantIdentifier.builder().withComponentIdentifier(ComponentIdentifier.ofMain(Component.class, ProjectIdentifier.of("root"))).withUnambiguousNameFromBuildVariant(buildVariant).withType(elementType).build();
-
-		val value = Value.supplied(elementType, () -> factory.create(identifier.getUnambiguousName(), buildVariant));
+	public VariantProvider<T> registerVariant(VariantIdentifier<T> identifier, VariantFactory<T> factory) {
+		val value = Value.supplied(elementType, () -> factory.create(identifier.getUnambiguousName(), (BuildVariantInternal) identifier.getBuildVariant()));
 		store.put(identifier, value);
 		return new VariantProvider<>(identifier, value);
 	}

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantCollection.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantCollection.java
@@ -65,7 +65,7 @@ public final class VariantCollection<T extends Variant> implements Realizable {
 		return ImmutableSet.copyOf(store.values().get());
 	}
 
-	public void whenElementKnown(Action<KnownVariant<? extends T>> action) {
+	public void whenElementKnown(Action<? super KnownVariant<T>> action) {
 		store.forEach((k, v) -> {
 			action.execute(new KnownVariant<>(k, v));
 		});

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantIdentifier.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantIdentifier.java
@@ -23,21 +23,27 @@ public class VariantIdentifier<T extends Variant> implements DomainObjectIdentif
 	@Getter private final ComponentIdentifier<?> componentIdentifier;
 	private final List<String> dimensions;
 	@EqualsAndHashCode.Exclude private final BuildVariant buildVariant;
+	@EqualsAndHashCode.Exclude private final String fullName;
 
-	public VariantIdentifier(String unambiguousName, Class<T> type, ComponentIdentifier<?> componentIdentifier, List<String> dimensions, BuildVariant buildVariant) {
+	public VariantIdentifier(String unambiguousName, Class<T> type, ComponentIdentifier<?> componentIdentifier, List<String> dimensions, BuildVariant buildVariant, String fullName) {
 		this.unambiguousName = requireNonNull(unambiguousName);
 		this.type = requireNonNull(type);
 		this.componentIdentifier = requireNonNull(componentIdentifier);
 		this.dimensions = requireNonNull(dimensions);
 		this.buildVariant = buildVariant;
+		this.fullName = fullName;
 	}
 
 	public static <T extends Variant> VariantIdentifier<T> of(String unambiguousName, Class<T> type, ComponentIdentifier<?> identifier) {
-		return new VariantIdentifier<>(unambiguousName, type, identifier, Collections.emptyList(), null);
+		return new VariantIdentifier<>(unambiguousName, type, identifier, Collections.emptyList(), null, unambiguousName);
 	}
 
 	public String getName() {
 		return unambiguousName;
+	}
+
+	public String getFullName() {
+		return fullName;
 	}
 
 	public BuildVariant getBuildVariant() {
@@ -128,7 +134,11 @@ public class VariantIdentifier<T extends Variant> implements DomainObjectIdentif
 			}
 			@SuppressWarnings("unchecked")
 			val variantType = (Class<T>) type;
-			return new VariantIdentifier<>(createUnambiguousName(dimensions), variantType, componentIdentifier, allDimensions, buildVariant);
+			return new VariantIdentifier<>(createUnambiguousName(dimensions), variantType, componentIdentifier, allDimensions, buildVariant, createFullName(this.allDimensions));
+		}
+
+		private static String createFullName(List<String> allDimensions) {
+			return StringUtils.uncapitalize(allDimensions.stream().map(StringUtils::capitalize).collect(Collectors.joining()));
 		}
 
 		private static String createUnambiguousName(List<String> dimensions) {

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantIdentifier.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantIdentifier.java
@@ -112,14 +112,6 @@ public class VariantIdentifier<T extends Variant> implements DomainObjectIdentif
 			return this;
 		}
 
-		public Builder<T> withUnambiguousNameFromBuildVariant(BuildVariant buildVariant) {
-			val dimensions = ((BuildVariantInternal) buildVariant).getDimensions().stream().map(Named.class::cast).map(Named::getName).collect(Collectors.toList());
-			this.dimensions.addAll(dimensions);
-			this.allDimensions.addAll(dimensions);
-			this.buildVariant = buildVariant;
-			return this;
-		}
-
 		private Function<BuildVariantInternal, Named> extractDimensionAtIndex(int index) {
 			return buildVariant -> (Named)buildVariant.getDimensions().get(index);
 		}

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantInternal.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantInternal.java
@@ -1,8 +1,11 @@
 package dev.nokee.platform.base.internal;
 
 import dev.nokee.platform.base.Variant;
+import dev.nokee.platform.base.internal.dependencies.ResolvableComponentDependencies;
 
 public interface VariantInternal extends Variant {
 	@Override
 	BuildVariantInternal getBuildVariant();
+
+	ResolvableComponentDependencies getResolvableDependencies();
 }

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/ResolvableComponentDependencies.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/ResolvableComponentDependencies.java
@@ -1,0 +1,4 @@
+package dev.nokee.platform.base.internal.dependencies;
+
+public interface ResolvableComponentDependencies {
+}

--- a/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/VariantIdentifierTest.groovy
+++ b/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/VariantIdentifierTest.groovy
@@ -68,6 +68,28 @@ class VariantIdentifierTest extends Specification {
 		identifier.componentIdentifier == ownerIdentifier
 	}
 
+	def "can query the full identifier name"() {
+		given:
+		def ownerIdentifier = ComponentIdentifier.ofMain(TestableComponent, ProjectIdentifier.of('root'))
+
+		expect:
+		VariantIdentifier.builder().withComponentIdentifier(ownerIdentifier)
+			.withType(TestableVariant)
+			.withVariantDimension({'macos'}, [{'macos'}])
+			.withVariantDimension({'debug'}, [{'debug'}, {'release'}])
+			.build().fullName == 'macosDebug'
+
+		VariantIdentifier.builder().withComponentIdentifier(ownerIdentifier)
+			.withType(TestableVariant)
+			.withVariantDimension({'macos'}, [{'macos'}, {'windows'}])
+			.withVariantDimension({'debug'}, [{'debug'}, {'release'}])
+			.build().fullName == 'macosDebug'
+
+		VariantIdentifier.builder().withComponentIdentifier(ownerIdentifier)
+			.withType(TestableVariant)
+			.build().fullName == ''
+	}
+
 	def "can build identifier from only one unambiguous variant dimension using the builder"() {
 		given:
 		def ownerIdentifier = ComponentIdentifier.ofMain(TestableComponent, ProjectIdentifier.of('root'))

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationComponent.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationComponent.java
@@ -115,7 +115,7 @@ public class DefaultIosApplicationComponent extends BaseNativeComponent<DefaultI
 	}
 
 	@Override
-	protected void onEachVariant(VariantIdentifier<DefaultIosApplicationVariant> variantIdentifier, VariantProvider<DefaultIosApplicationVariant> variant, NamingScheme names) {
+	protected void onEachVariant(KnownVariant<DefaultIosApplicationVariant> variant) {
 		variant.configure(application -> {
 			application.getBinaries().configureEach(ExecutableBinary.class, binary -> {
 				binary.getCompileTasks().configureEach(SourceCompile.class, task -> {
@@ -156,7 +156,7 @@ public class DefaultIosApplicationComponent extends BaseNativeComponent<DefaultI
 			Provider<CommandLineTool> assetCompilerTool = getProviders().provider(() -> new VersionedCommandLineTool(new File("/usr/bin/actool"), VersionNumber.parse("11.3.1")));
 			Provider<CommandLineTool> codeSignatureTool = getProviders().provider(() -> new PathAwareCommandLineTool(new File("/usr/bin/codesign")));
 
-			String moduleName = names.getBaseName().getAsCamelCase();
+			String moduleName = getNames().getBaseName().getAsCamelCase();
 			Provider<String> identifier = getProviders().provider(() -> getGroupId().get().get().map(it -> it + "." + moduleName).orElse(moduleName));
 
 			val compileStoryboardTask = taskRegistry.register("compileStoryboard", StoryboardCompileTask.class, task -> {

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationVariant.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationVariant.java
@@ -5,12 +5,12 @@ import dev.nokee.platform.base.Binary;
 import dev.nokee.platform.base.internal.BuildVariantInternal;
 import dev.nokee.platform.base.internal.NamingScheme;
 import dev.nokee.platform.base.internal.VariantInternal;
+import dev.nokee.platform.base.internal.dependencies.ResolvableComponentDependencies;
 import dev.nokee.platform.ios.IosApplication;
-import dev.nokee.platform.nativebase.NativeComponentDependencies;
 import dev.nokee.platform.nativebase.internal.BaseNativeVariant;
 import dev.nokee.platform.nativebase.internal.dependencies.DefaultNativeComponentDependencies;
 import dev.nokee.platform.nativebase.internal.dependencies.VariantComponentDependencies;
-import org.gradle.api.Action;
+import lombok.Getter;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
@@ -21,11 +21,13 @@ import java.util.List;
 
 public class DefaultIosApplicationVariant extends BaseNativeVariant implements IosApplication, VariantInternal {
 	private final DefaultNativeComponentDependencies dependencies;
+	@Getter private final ResolvableComponentDependencies resolvableDependencies;
 
 	@Inject
 	public DefaultIosApplicationVariant(String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<DefaultNativeComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
 		super(name, names, buildVariant, objects, tasks, providers);
 		this.dependencies = dependencies.getDependencies();
+		this.resolvableDependencies = dependencies.getIncoming();
 	}
 
 	@Override

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryInternal.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryInternal.java
@@ -4,7 +4,7 @@ import dev.nokee.language.base.internal.GeneratedSourceSet;
 import dev.nokee.language.base.internal.LanguageSourceSetInternal;
 import dev.nokee.platform.base.Binary;
 import dev.nokee.platform.base.internal.*;
-import dev.nokee.platform.jni.JavaNativeInterfaceNativeComponentDependencies;
+import dev.nokee.platform.base.internal.dependencies.ResolvableComponentDependencies;
 import dev.nokee.platform.jni.JniLibrary;
 import dev.nokee.platform.nativebase.SharedLibraryBinary;
 import dev.nokee.platform.nativebase.internal.SharedLibraryBinaryInternal;
@@ -43,6 +43,7 @@ public class JniLibraryInternal extends BaseVariant implements JniLibrary, Varia
 	private SharedLibraryBinaryInternal sharedLibraryBinary;
 	@Getter private final Property<String> resourcePath;
 	@Getter private final ConfigurableFileCollection nativeRuntimeFiles;
+	@Getter private final ResolvableComponentDependencies resolvableDependencies;
 
 	@Inject
 	public JniLibraryInternal(String name, NamingScheme names, DomainObjectSet<LanguageSourceSetInternal> parentSources, BuildVariantInternal buildVariant, GroupId groupId, DomainObjectSet<Binary> parentBinaries, VariantComponentDependencies dependencies, ObjectFactory objects, ConfigurationContainer configurations, ProviderFactory providers, TaskContainer tasks) {
@@ -57,6 +58,7 @@ public class JniLibraryInternal extends BaseVariant implements JniLibrary, Varia
 		this.groupId = groupId;
 		this.resourcePath = objects.property(String.class);
 		this.nativeRuntimeFiles = objects.fileCollection();
+		this.resolvableDependencies = dependencies.getIncoming();
 
 		parentSources.all(sources::add);
 

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/plugins/JniLibraryPlugin.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/plugins/JniLibraryPlugin.java
@@ -179,9 +179,10 @@ public class JniLibraryPlugin implements Plugin<Project> {
 			extension.getBuildVariants().get().forEach(buildVariant -> {
 				final DefaultTargetMachine targetMachineInternal = new DefaultTargetMachine((DefaultOperatingSystemFamily)buildVariant.getDimensions().get(0), (DefaultMachineArchitecture)buildVariant.getDimensions().get(1));
 				final NamingScheme names = mainComponentNames.forBuildVariant(buildVariant, extension.getBuildVariants().get());
+				final VariantIdentifier<JniLibraryInternal> variantIdentifier = VariantIdentifier.builder().withUnambiguousNameFromBuildVariants(buildVariant, extension.getBuildVariants().get()).withComponentIdentifier(ComponentIdentifier.ofMain(JniLibraryComponentInternal.class, ProjectIdentifier.of(project))).withType(JniLibraryInternal.class).build();
 
 				val dependencies = newDependencies(names.withComponentDisplayName("JNI shared library"), buildVariant, extension.getComponent());
-				final VariantProvider<JniLibraryInternal> library = extension.getVariantCollection().registerVariant(buildVariant, (name, bv) -> {
+				final VariantProvider<JniLibraryInternal> library = extension.getVariantCollection().registerVariant(variantIdentifier, (name, bv) -> {
 					JniLibraryInternal it = extension.getComponent().createVariant(name, bv, dependencies);
 
 					// Build all language source set

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationVariant.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationVariant.java
@@ -3,12 +3,11 @@ package dev.nokee.platform.nativebase.internal;
 import dev.nokee.platform.base.internal.BuildVariantInternal;
 import dev.nokee.platform.base.internal.NamingScheme;
 import dev.nokee.platform.base.internal.VariantInternal;
+import dev.nokee.platform.base.internal.dependencies.ResolvableComponentDependencies;
 import dev.nokee.platform.nativebase.NativeApplication;
-import dev.nokee.platform.nativebase.NativeApplicationComponentDependencies;
 import dev.nokee.platform.nativebase.internal.dependencies.DefaultNativeApplicationComponentDependencies;
 import dev.nokee.platform.nativebase.internal.dependencies.VariantComponentDependencies;
 import lombok.Getter;
-import org.gradle.api.Action;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.TaskContainer;
@@ -17,10 +16,12 @@ import javax.inject.Inject;
 
 public class DefaultNativeApplicationVariant extends BaseNativeVariant implements NativeApplication, VariantInternal {
 	@Getter private final DefaultNativeApplicationComponentDependencies dependencies;
+	@Getter private final ResolvableComponentDependencies resolvableDependencies;
 
 	@Inject
 	public DefaultNativeApplicationVariant(String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<DefaultNativeApplicationComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
 		super(name, names, buildVariant, objects, tasks, providers);
 		this.dependencies = dependencies.getDependencies();
+		this.resolvableDependencies = dependencies.getIncoming();
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryVariant.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryVariant.java
@@ -3,13 +3,12 @@ package dev.nokee.platform.nativebase.internal;
 import dev.nokee.platform.base.internal.BuildVariantInternal;
 import dev.nokee.platform.base.internal.NamingScheme;
 import dev.nokee.platform.base.internal.VariantInternal;
+import dev.nokee.platform.base.internal.dependencies.ResolvableComponentDependencies;
 import dev.nokee.platform.nativebase.NativeLibrary;
-import dev.nokee.platform.nativebase.NativeLibraryComponentDependencies;
 import dev.nokee.platform.nativebase.internal.dependencies.DefaultNativeLibraryComponentDependencies;
 import dev.nokee.platform.nativebase.internal.dependencies.VariantComponentDependencies;
 import lombok.AccessLevel;
 import lombok.Getter;
-import org.gradle.api.Action;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ProviderFactory;
@@ -20,11 +19,13 @@ import javax.inject.Inject;
 public class DefaultNativeLibraryVariant extends BaseNativeVariant implements NativeLibrary, VariantInternal {
 	@Getter private final DefaultNativeLibraryComponentDependencies dependencies;
 	@Getter(AccessLevel.PROTECTED) private final ProjectLayout layout;
+	@Getter private final ResolvableComponentDependencies resolvableDependencies;
 
 	@Inject
 	public DefaultNativeLibraryVariant(String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<DefaultNativeLibraryComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers, ProjectLayout layout) {
 		super(name, names, buildVariant, objects, tasks, providers);
 		this.dependencies = dependencies.getDependencies();
 		this.layout = layout;
+		this.resolvableDependencies = dependencies.getIncoming();
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/dependencies/NativeIncomingDependencies.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/dependencies/NativeIncomingDependencies.java
@@ -1,8 +1,9 @@
 package dev.nokee.platform.nativebase.internal.dependencies;
 
+import dev.nokee.platform.base.internal.dependencies.ResolvableComponentDependencies;
 import org.gradle.api.file.FileCollection;
 
-public interface NativeIncomingDependencies {
+public interface NativeIncomingDependencies extends ResolvableComponentDependencies {
 	FileCollection getHeaderSearchPaths();
 	FileCollection getFrameworkSearchPaths();
 	FileCollection getSwiftModules();

--- a/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteVariant.java
+++ b/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteVariant.java
@@ -3,9 +3,11 @@ package dev.nokee.testing.nativebase.internal;
 import dev.nokee.platform.base.internal.BuildVariantInternal;
 import dev.nokee.platform.base.internal.NamingScheme;
 import dev.nokee.platform.base.internal.VariantInternal;
+import dev.nokee.platform.base.internal.dependencies.ResolvableComponentDependencies;
 import dev.nokee.platform.nativebase.internal.BaseNativeVariant;
 import dev.nokee.platform.nativebase.internal.dependencies.VariantComponentDependencies;
 import dev.nokee.testing.nativebase.NativeTestSuiteVariant;
+import lombok.Getter;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.TaskContainer;
@@ -13,8 +15,11 @@ import org.gradle.api.tasks.TaskContainer;
 import javax.inject.Inject;
 
 public class DefaultNativeTestSuiteVariant extends BaseNativeVariant implements NativeTestSuiteVariant, VariantInternal {
+	@Getter private final ResolvableComponentDependencies resolvableDependencies;
+
 	@Inject
 	public DefaultNativeTestSuiteVariant(String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<?> variantDependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
 		super(name, names, buildVariant, objects, tasks, providers);
+		this.resolvableDependencies = variantDependencies.getIncoming();
 	}
 }

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/BaseXCTestTestSuiteComponent.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/BaseXCTestTestSuiteComponent.java
@@ -112,7 +112,7 @@ public class BaseXCTestTestSuiteComponent extends BaseNativeComponent<DefaultXCT
 	}
 
 	@Override
-	protected void onEachVariant(VariantIdentifier<DefaultXCTestTestSuiteVariant> variantIdentifier, VariantProvider<DefaultXCTestTestSuiteVariant> variant, NamingScheme names) {
+	protected void onEachVariant(KnownVariant<DefaultXCTestTestSuiteVariant> variant) {
 		variant.configure(testSuite -> {
 			testSuite.getBinaries().configureEach(BundleBinary.class, binary -> {
 				Provider<String> moduleName = getTestedComponent().map(it -> it.getNames().getBaseName().getAsCamelCase());
@@ -155,6 +155,7 @@ public class BaseXCTestTestSuiteComponent extends BaseNativeComponent<DefaultXCT
 
 	@Override
 	public void finalizeExtension(Project project) {
+		// TODO: Use component binary view instead once finish cleanup, it remove one level of indirection
 		getVariants().configureEach(variant -> {
 			variant.getBinaries().configureEach(BaseNativeBinary.class, binary -> {
 				binary.getBaseName().convention(GUtil.toCamelCase(project.getName()));

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultUiTestXCTestTestSuiteComponent.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultUiTestXCTestTestSuiteComponent.java
@@ -5,10 +5,9 @@ import dev.nokee.core.exec.CommandLineTool;
 import dev.nokee.core.exec.internal.PathAwareCommandLineTool;
 import dev.nokee.model.DomainObjectFactory;
 import dev.nokee.platform.base.Component;
-import dev.nokee.platform.base.internal.NamingScheme;
-import dev.nokee.platform.base.internal.NamingSchemeFactory;
-import dev.nokee.platform.base.internal.VariantIdentifier;
-import dev.nokee.platform.base.internal.VariantProvider;
+import dev.nokee.platform.base.internal.*;
+import dev.nokee.platform.base.internal.tasks.TaskIdentifier;
+import dev.nokee.platform.base.internal.tasks.TaskName;
 import dev.nokee.platform.base.internal.tasks.TaskRegistry;
 import dev.nokee.platform.base.internal.tasks.TaskRegistryImpl;
 import dev.nokee.platform.ios.internal.SignedIosApplicationBundleInternal;
@@ -47,12 +46,13 @@ public class DefaultUiTestXCTestTestSuiteComponent extends BaseXCTestTestSuiteCo
 	}
 
 	@Override
-	protected void onEachVariant(VariantIdentifier<DefaultXCTestTestSuiteVariant> variantIdentifier, VariantProvider<DefaultXCTestTestSuiteVariant> variant, NamingScheme names) {
-		super.onEachVariant(variantIdentifier, variant, names);
+	protected void onEachVariant(KnownVariant<DefaultXCTestTestSuiteVariant> variant) {
+		super.onEachVariant(variant);
+		val variantIdentifier = variant.getIdentifier();
 
 		variant.configure(testSuite -> {
 			testSuite.getBinaries().configureEach(BundleBinary.class, binary -> {
-				((BundleBinaryInternal)binary).getBaseName().set(names.getBaseName().getAsCamelCase());
+				((BundleBinaryInternal)binary).getBaseName().set(getNames().getBaseName().getAsCamelCase());
 			});
 			String moduleName = testSuite.getNames().getBaseName().getAsCamelCase();
 
@@ -96,7 +96,7 @@ public class DefaultUiTestXCTestTestSuiteComponent extends BaseXCTestTestSuiteCo
 			testSuite.getBinaryCollection().add(getObjects().newInstance(SignedIosApplicationBundleInternal.class, signTask));
 		});
 
-		TaskProvider<Task> bundle = taskRegistry.register(names.getTaskName("bundle"), task -> {
+		TaskProvider<Task> bundle = taskRegistry.register(TaskIdentifier.of(TaskName.of("bundle"), variantIdentifier), task -> {
 			task.dependsOn(variant.map(it -> it.getBinaries().withType(SignedIosApplicationBundleInternal.class).get()));
 		});
 	}

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultUnitTestXCTestTestSuiteComponent.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultUnitTestXCTestTestSuiteComponent.java
@@ -5,10 +5,7 @@ import dev.nokee.core.exec.CommandLineTool;
 import dev.nokee.core.exec.internal.PathAwareCommandLineTool;
 import dev.nokee.model.DomainObjectFactory;
 import dev.nokee.platform.base.Component;
-import dev.nokee.platform.base.internal.NamingScheme;
-import dev.nokee.platform.base.internal.NamingSchemeFactory;
-import dev.nokee.platform.base.internal.VariantIdentifier;
-import dev.nokee.platform.base.internal.VariantProvider;
+import dev.nokee.platform.base.internal.*;
 import dev.nokee.platform.base.internal.tasks.TaskIdentifier;
 import dev.nokee.platform.base.internal.tasks.TaskName;
 import dev.nokee.platform.base.internal.tasks.TaskRegistry;
@@ -48,12 +45,13 @@ public class DefaultUnitTestXCTestTestSuiteComponent extends BaseXCTestTestSuite
 	}
 
 	@Override
-	protected void onEachVariant(VariantIdentifier<DefaultXCTestTestSuiteVariant> variantIdentifier, VariantProvider<DefaultXCTestTestSuiteVariant> variant, NamingScheme names) {
-		super.onEachVariant(variantIdentifier, variant, names);
+	protected void onEachVariant(KnownVariant<DefaultXCTestTestSuiteVariant> variant) {
+		super.onEachVariant(variant);
+		val variantIdentifier = variant.getIdentifier();
 
 		variant.configure(testSuite -> {
 			testSuite.getBinaries().configureEach(BundleBinary.class, binary -> {
-				((BundleBinaryInternal)binary).getBaseName().set(names.getBaseName().getAsCamelCase());
+				((BundleBinaryInternal)binary).getBaseName().set(getNames().getBaseName().getAsCamelCase());
 			});
 			String moduleName = testSuite.getNames().getBaseName().getAsCamelCase();
 

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultXCTestTestSuiteVariant.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultXCTestTestSuiteVariant.java
@@ -5,13 +5,13 @@ import dev.nokee.platform.base.Binary;
 import dev.nokee.platform.base.internal.BuildVariantInternal;
 import dev.nokee.platform.base.internal.NamingScheme;
 import dev.nokee.platform.base.internal.VariantInternal;
+import dev.nokee.platform.base.internal.dependencies.ResolvableComponentDependencies;
 import dev.nokee.platform.ios.IosApplication;
 import dev.nokee.platform.ios.internal.SignedIosApplicationBundleInternal;
-import dev.nokee.platform.nativebase.NativeComponentDependencies;
 import dev.nokee.platform.nativebase.internal.BaseNativeVariant;
 import dev.nokee.platform.nativebase.internal.dependencies.DefaultNativeComponentDependencies;
 import dev.nokee.platform.nativebase.internal.dependencies.VariantComponentDependencies;
-import org.gradle.api.Action;
+import lombok.Getter;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
@@ -22,11 +22,13 @@ import java.util.List;
 
 public class DefaultXCTestTestSuiteVariant extends BaseNativeVariant implements IosApplication, VariantInternal {
 	private final DefaultNativeComponentDependencies dependencies;
+	@Getter private final ResolvableComponentDependencies resolvableDependencies;
 
 	@Inject
 	public DefaultXCTestTestSuiteVariant(String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<DefaultNativeComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
 		super(name, names, buildVariant, objects, tasks, providers);
 		this.dependencies = dependencies.getDependencies();
+		this.resolvableDependencies = dependencies.getIncoming();
 	}
 
 	@Override


### PR DESCRIPTION
The idea of a massive central component is quite frankly troublesome. After some experimentation, we are going to break it apart to create more composable component able to evolve independently. The direction the next few refactoring PR will introduce more laziness, split the variant and binary concerns, and enable rule sharing between components. It will also open up for more unit testing allowing faster checks. 