### PR TITLE
Additional clean-up following the previous PR

### DIFF
--- a/subprojects/core-utils/src/main/java/dev/nokee/utils/ProviderUtils.java
+++ b/subprojects/core-utils/src/main/java/dev/nokee/utils/ProviderUtils.java
@@ -45,6 +45,16 @@ public final class ProviderUtils {
 	}
 
 	/**
+	 * Returned an undefined provider.
+	 * It will always return null, throw an exception on get and returns false when querying for presence.
+	 *
+	 * @return a {@link Provider} instance without any value.
+	 */
+	public static <T> Provider<T> notDefined() {
+		return Providers.notDefined();
+	}
+
+	/**
 	 * Returns the object type provided by the Gradle provider.
 	 *
 	 * @param self the provider to query the provided type.

--- a/subprojects/core-utils/src/test/groovy/dev/nokee/utils/ProviderUtils_NotDefinedTest.groovy
+++ b/subprojects/core-utils/src/test/groovy/dev/nokee/utils/ProviderUtils_NotDefinedTest.groovy
@@ -1,0 +1,31 @@
+package dev.nokee.utils
+
+import org.gradle.api.internal.provider.MissingValueException
+import spock.lang.Specification
+
+import static dev.nokee.utils.ProviderUtils.notDefined
+
+class ProviderUtils_NotDefinedTest extends Specification {
+	def "always returns null on getOrNull()"() {
+		expect:
+		notDefined().getOrNull() == null
+	}
+
+	def "throws exception on get()"() {
+		when:
+		notDefined().get()
+
+		then:
+		thrown(MissingValueException)
+	}
+
+	def "always returns false on isPresent()"() {
+		expect:
+		!notDefined().isPresent()
+	}
+
+	def "always return the same instance"() {
+		expect:
+		notDefined() == notDefined()
+	}
+}

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/BaseComponent.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/BaseComponent.java
@@ -3,7 +3,6 @@ package dev.nokee.platform.base.internal;
 import dev.nokee.language.base.internal.SourceSet;
 import dev.nokee.platform.base.Binary;
 import dev.nokee.platform.base.BinaryView;
-import dev.nokee.platform.base.Component;
 import dev.nokee.platform.base.Variant;
 import dev.nokee.runtime.base.internal.DimensionType;
 import dev.nokee.utils.Cast;
@@ -31,8 +30,8 @@ public class BaseComponent<T extends Variant> {
 	@Getter private final Property<T> developmentVariant;
 	@Getter private final Property<String> baseName;
 
-	protected BaseComponent(NamingScheme names, Class<T> variantType, ObjectFactory objects) {
-		this.identifier = ComponentIdentifier.builder().withName(ComponentName.of(names.getComponentName())).withType(((Component)this).getClass()).withDisplayName(names.getComponentDisplayName()).withProjectIdentifier(ProjectIdentifier.of(names.getBaseName().getAsString())).build();
+	protected BaseComponent(ComponentIdentifier<?> identifier, NamingScheme names, Class<T> variantType, ObjectFactory objects) {
+		this.identifier = identifier;
 		this.names = names;
 		this.variantCollection = new VariantCollection<>(variantType, objects);
 		this.binaries = Cast.uncheckedCastBecauseOfTypeErasure(objects.newInstance(VariantAwareBinaryView.class, new DefaultMappingView<Binary, T>(variantCollection.getAsView(variantType), Variant::getBinaries)));

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/BaseVariant.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/BaseVariant.java
@@ -15,17 +15,19 @@ public class BaseVariant implements Named {
 	@Getter private final VariantIdentifier<?> identifier;
 	@Getter private final DomainObjectSet<Binary> binaryCollection;
 	@Getter private final String name;
-	@Getter private final BuildVariantInternal buildVariant;
 	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
 	@Getter private final Property<Binary> developmentBinary;
 
-	protected BaseVariant(VariantIdentifier<?> identifier, String name, BuildVariantInternal buildVariant, ObjectFactory objects) {
+	protected BaseVariant(VariantIdentifier<?> identifier, String name, ObjectFactory objects) {
 		this.identifier = identifier;
 		this.name = name;
-		this.buildVariant = buildVariant;
 		this.objects = objects;
 		this.binaryCollection = objects.domainObjectSet(Binary.class);
 		this.developmentBinary = objects.property(Binary.class);
+	}
+
+	public BuildVariantInternal getBuildVariant() {
+		return (BuildVariantInternal) identifier.getBuildVariant();
 	}
 
 	public BinaryView<Binary> getBinaries() {

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/BaseVariant.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/BaseVariant.java
@@ -6,21 +6,17 @@ import dev.nokee.utils.Cast;
 import lombok.AccessLevel;
 import lombok.Getter;
 import org.gradle.api.DomainObjectSet;
-import org.gradle.api.Named;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 
-// CAUTION: Never rely on the name of the variant, it isn't exposed on the public type!
-public class BaseVariant implements Named {
+public class BaseVariant {
 	@Getter private final VariantIdentifier<?> identifier;
 	@Getter private final DomainObjectSet<Binary> binaryCollection;
-	@Getter private final String name;
 	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
 	@Getter private final Property<Binary> developmentBinary;
 
-	protected BaseVariant(VariantIdentifier<?> identifier, String name, ObjectFactory objects) {
+	protected BaseVariant(VariantIdentifier<?> identifier, ObjectFactory objects) {
 		this.identifier = identifier;
-		this.name = name;
 		this.objects = objects;
 		this.binaryCollection = objects.domainObjectSet(Binary.class);
 		this.developmentBinary = objects.property(Binary.class);

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/BaseVariant.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/BaseVariant.java
@@ -12,13 +12,15 @@ import org.gradle.api.provider.Property;
 
 // CAUTION: Never rely on the name of the variant, it isn't exposed on the public type!
 public class BaseVariant implements Named {
+	@Getter private final VariantIdentifier<?> identifier;
 	@Getter private final DomainObjectSet<Binary> binaryCollection;
 	@Getter private final String name;
 	@Getter private final BuildVariantInternal buildVariant;
 	@Getter(AccessLevel.PROTECTED) private final ObjectFactory objects;
 	@Getter private final Property<Binary> developmentBinary;
 
-	protected BaseVariant(String name, BuildVariantInternal buildVariant, ObjectFactory objects) {
+	protected BaseVariant(VariantIdentifier<?> identifier, String name, BuildVariantInternal buildVariant, ObjectFactory objects) {
+		this.identifier = identifier;
 		this.name = name;
 		this.buildVariant = buildVariant;
 		this.objects = objects;

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/DevelopmentBinaryUtils.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/DevelopmentBinaryUtils.java
@@ -1,0 +1,28 @@
+package dev.nokee.platform.base.internal;
+
+import com.google.common.collect.Iterables;
+import dev.nokee.platform.base.Binary;
+import dev.nokee.utils.ProviderUtils;
+import org.gradle.api.provider.Provider;
+
+import java.util.Optional;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+public class DevelopmentBinaryUtils {
+	public static Provider<? extends Binary> selectSingleBinaryByType(Class<? extends Binary> binaryTypeToSelect, Iterable<? extends Binary> binaries) {
+		return StreamSupport.stream(binaries.spliterator(), false)
+			.filter(binaryTypeToSelect::isInstance)
+			.collect(toAtMostOneElement())
+			.map(ProviderUtils::fixed)
+			.orElseGet(ProviderUtils::notDefined);
+	}
+
+	private static <T> Collector<T, ?, Optional<T>> toAtMostOneElement() {
+		return Collectors.collectingAndThen(
+			Collectors.toList(),
+			list -> Optional.of(list).map(it -> Iterables.getOnlyElement(it, null))
+		);
+	}
+}

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/KnownVariant.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/KnownVariant.java
@@ -3,12 +3,13 @@ package dev.nokee.platform.base.internal;
 import dev.nokee.model.internal.Value;
 import dev.nokee.platform.base.Variant;
 import dev.nokee.utils.TransformerUtils;
+import lombok.Getter;
 import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.provider.Provider;
 
 public final class KnownVariant<T extends Variant> {
-	private final VariantIdentifier<T> identifier;
+	@Getter private final VariantIdentifier<T> identifier;
 	private final Value<? extends T> value;
 
 	public KnownVariant(VariantIdentifier<T> identifier, Value<? extends T> value) {

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantCollection.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantCollection.java
@@ -31,7 +31,7 @@ public final class VariantCollection<T extends Variant> implements Realizable {
 	}
 
 	public VariantProvider<T> registerVariant(VariantIdentifier<T> identifier, VariantFactory<T> factory) {
-		val value = Value.supplied(elementType, () -> factory.create(identifier.getUnambiguousName(), (BuildVariantInternal) identifier.getBuildVariant()));
+		val value = Value.supplied(elementType, () -> factory.create(identifier.getFullName(), (BuildVariantInternal) identifier.getBuildVariant()));
 		store.put(identifier, value);
 		return new VariantProvider<>(identifier, value);
 	}

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantCollection.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantCollection.java
@@ -5,7 +5,6 @@ import com.google.common.collect.ImmutableSet;
 import dev.nokee.model.internal.NokeeMap;
 import dev.nokee.model.internal.NokeeMapImpl;
 import dev.nokee.model.internal.Value;
-import dev.nokee.platform.base.Component;
 import dev.nokee.platform.base.Variant;
 import dev.nokee.platform.base.VariantView;
 import dev.nokee.utils.Cast;
@@ -31,10 +30,8 @@ public final class VariantCollection<T extends Variant> implements Realizable {
 		this.elementType = elementType;
 	}
 
-	public VariantProvider<T> registerVariant(BuildVariantInternal buildVariant, VariantFactory<T> factory) {
-		val identifier = VariantIdentifier.builder().withComponentIdentifier(ComponentIdentifier.ofMain(Component.class, ProjectIdentifier.of("root"))).withUnambiguousNameFromBuildVariant(buildVariant).withType(elementType).build();
-
-		val value = Value.supplied(elementType, () -> factory.create(identifier.getUnambiguousName(), buildVariant));
+	public VariantProvider<T> registerVariant(VariantIdentifier<T> identifier, VariantFactory<T> factory) {
+		val value = Value.supplied(elementType, () -> factory.create(identifier.getUnambiguousName(), (BuildVariantInternal) identifier.getBuildVariant()));
 		store.put(identifier, value);
 		return new VariantProvider<>(identifier, value);
 	}

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantCollection.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantCollection.java
@@ -65,7 +65,7 @@ public final class VariantCollection<T extends Variant> implements Realizable {
 		return ImmutableSet.copyOf(store.values().get());
 	}
 
-	public void whenElementKnown(Action<KnownVariant<? extends T>> action) {
+	public void whenElementKnown(Action<? super KnownVariant<T>> action) {
 		store.forEach((k, v) -> {
 			action.execute(new KnownVariant<>(k, v));
 		});

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantIdentifier.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantIdentifier.java
@@ -23,21 +23,27 @@ public class VariantIdentifier<T extends Variant> implements DomainObjectIdentif
 	@Getter private final ComponentIdentifier<?> componentIdentifier;
 	private final List<String> dimensions;
 	@EqualsAndHashCode.Exclude private final BuildVariant buildVariant;
+	@EqualsAndHashCode.Exclude private final String fullName;
 
-	public VariantIdentifier(String unambiguousName, Class<T> type, ComponentIdentifier<?> componentIdentifier, List<String> dimensions, BuildVariant buildVariant) {
+	public VariantIdentifier(String unambiguousName, Class<T> type, ComponentIdentifier<?> componentIdentifier, List<String> dimensions, BuildVariant buildVariant, String fullName) {
 		this.unambiguousName = requireNonNull(unambiguousName);
 		this.type = requireNonNull(type);
 		this.componentIdentifier = requireNonNull(componentIdentifier);
 		this.dimensions = requireNonNull(dimensions);
 		this.buildVariant = buildVariant;
+		this.fullName = fullName;
 	}
 
 	public static <T extends Variant> VariantIdentifier<T> of(String unambiguousName, Class<T> type, ComponentIdentifier<?> identifier) {
-		return new VariantIdentifier<>(unambiguousName, type, identifier, Collections.emptyList(), null);
+		return new VariantIdentifier<>(unambiguousName, type, identifier, Collections.emptyList(), null, unambiguousName);
 	}
 
 	public String getName() {
 		return unambiguousName;
+	}
+
+	public String getFullName() {
+		return fullName;
 	}
 
 	public BuildVariant getBuildVariant() {
@@ -128,7 +134,11 @@ public class VariantIdentifier<T extends Variant> implements DomainObjectIdentif
 			}
 			@SuppressWarnings("unchecked")
 			val variantType = (Class<T>) type;
-			return new VariantIdentifier<>(createUnambiguousName(dimensions), variantType, componentIdentifier, allDimensions, buildVariant);
+			return new VariantIdentifier<>(createUnambiguousName(dimensions), variantType, componentIdentifier, allDimensions, buildVariant, createFullName(this.allDimensions));
+		}
+
+		private static String createFullName(List<String> allDimensions) {
+			return StringUtils.uncapitalize(allDimensions.stream().map(StringUtils::capitalize).collect(Collectors.joining()));
 		}
 
 		private static String createUnambiguousName(List<String> dimensions) {

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantIdentifier.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantIdentifier.java
@@ -112,14 +112,6 @@ public class VariantIdentifier<T extends Variant> implements DomainObjectIdentif
 			return this;
 		}
 
-		public Builder<T> withUnambiguousNameFromBuildVariant(BuildVariant buildVariant) {
-			val dimensions = ((BuildVariantInternal) buildVariant).getDimensions().stream().map(Named.class::cast).map(Named::getName).collect(Collectors.toList());
-			this.dimensions.addAll(dimensions);
-			this.allDimensions.addAll(dimensions);
-			this.buildVariant = buildVariant;
-			return this;
-		}
-
 		private Function<BuildVariantInternal, Named> extractDimensionAtIndex(int index) {
 			return buildVariant -> (Named)buildVariant.getDimensions().get(index);
 		}

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantInternal.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantInternal.java
@@ -1,8 +1,11 @@
 package dev.nokee.platform.base.internal;
 
 import dev.nokee.platform.base.Variant;
+import dev.nokee.platform.base.internal.dependencies.ResolvableComponentDependencies;
 
 public interface VariantInternal extends Variant {
 	@Override
 	BuildVariantInternal getBuildVariant();
+
+	ResolvableComponentDependencies getResolvableDependencies();
 }

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/ResolvableComponentDependencies.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/ResolvableComponentDependencies.java
@@ -1,0 +1,4 @@
+package dev.nokee.platform.base.internal.dependencies;
+
+public interface ResolvableComponentDependencies {
+}

--- a/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/DevelopmentBinaryUtils_SelectSingleBinaryByTypeTest.groovy
+++ b/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/DevelopmentBinaryUtils_SelectSingleBinaryByTypeTest.groovy
@@ -1,0 +1,57 @@
+package dev.nokee.platform.base.internal
+
+import dev.nokee.platform.base.Binary
+import dev.nokee.utils.ProviderUtils
+import spock.lang.Specification
+import spock.lang.Subject
+
+import static dev.nokee.platform.base.internal.DevelopmentBinaryUtils.selectSingleBinaryByType
+
+@Subject(DevelopmentBinaryUtils)
+class DevelopmentBinaryUtils_SelectSingleBinaryByTypeTest extends Specification {
+	def "returns undefined provider on empty list"() {
+		expect:
+		selectSingleBinaryByType(MyBinary, []) == ProviderUtils.notDefined()
+	}
+
+	def "throws exception when multiple MyBinary binaries"() {
+		when:
+		selectSingleBinaryByType(MyBinary, [Stub(MyBinary), Stub(MyBinary)])
+
+		then:
+		def ex = thrown(IllegalArgumentException)
+		ex.message == "expected one element but was: <Mock for type 'MyBinary', Mock for type 'MyBinary'>"
+	}
+
+	def "returns a provider of the single MyBinary binary list"() {
+		given:
+		def binary = Stub(MyBinary)
+
+		expect:
+		def result = selectSingleBinaryByType(MyBinary, [binary])
+		result.present
+		result.get() == binary
+	}
+
+	def "returns a provider of a multi-binary list containing one MyBinary binary"() {
+		given:
+		def binary = Stub(MyBinary)
+
+		expect:
+		def result1 = selectSingleBinaryByType(MyBinary, [binary, Stub(Binary)])
+		result1.present
+		result1.get() == binary
+
+		and:
+		def result2 = selectSingleBinaryByType(MyBinary, [Stub(Binary), binary])
+		result2.present
+		result2.get() == binary
+
+		and:
+		def result3 = selectSingleBinaryByType(MyBinary, [Stub(Binary), binary, Stub(Binary)])
+		result3.present
+		result3.get() == binary
+	}
+
+	interface MyBinary extends Binary {}
+}

--- a/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/VariantIdentifierTest.groovy
+++ b/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/VariantIdentifierTest.groovy
@@ -68,6 +68,28 @@ class VariantIdentifierTest extends Specification {
 		identifier.componentIdentifier == ownerIdentifier
 	}
 
+	def "can query the full identifier name"() {
+		given:
+		def ownerIdentifier = ComponentIdentifier.ofMain(TestableComponent, ProjectIdentifier.of('root'))
+
+		expect:
+		VariantIdentifier.builder().withComponentIdentifier(ownerIdentifier)
+			.withType(TestableVariant)
+			.withVariantDimension({'macos'}, [{'macos'}])
+			.withVariantDimension({'debug'}, [{'debug'}, {'release'}])
+			.build().fullName == 'macosDebug'
+
+		VariantIdentifier.builder().withComponentIdentifier(ownerIdentifier)
+			.withType(TestableVariant)
+			.withVariantDimension({'macos'}, [{'macos'}, {'windows'}])
+			.withVariantDimension({'debug'}, [{'debug'}, {'release'}])
+			.build().fullName == 'macosDebug'
+
+		VariantIdentifier.builder().withComponentIdentifier(ownerIdentifier)
+			.withType(TestableVariant)
+			.build().fullName == ''
+	}
+
 	def "can build identifier from only one unambiguous variant dimension using the builder"() {
 		given:
 		def ownerIdentifier = ComponentIdentifier.ofMain(TestableComponent, ProjectIdentifier.of('root'))

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationComponent.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationComponent.java
@@ -80,10 +80,11 @@ public class DefaultIosApplicationComponent extends BaseNativeComponent<DefaultI
 	}
 
 	@Override
-	protected DefaultIosApplicationVariant createVariant(VariantIdentifier<?> identifier, String name, BuildVariantInternal buildVariant, VariantComponentDependencies<?> variantDependencies) {
+	protected DefaultIosApplicationVariant createVariant(VariantIdentifier<?> identifier, String name, VariantComponentDependencies<?> variantDependencies) {
+		val buildVariant = (BuildVariantInternal) identifier.getBuildVariant();
 		NamingScheme names = getNames().forBuildVariant(buildVariant, getBuildVariants().get());
 
-		DefaultIosApplicationVariant result = getObjects().newInstance(DefaultIosApplicationVariant.class, identifier, name, names, buildVariant, variantDependencies);
+		DefaultIosApplicationVariant result = getObjects().newInstance(DefaultIosApplicationVariant.class, identifier, name, names, variantDependencies);
 		return result;
 	}
 

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationComponent.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationComponent.java
@@ -238,7 +238,7 @@ public class DefaultIosApplicationComponent extends BaseNativeComponent<DefaultI
 
 	public static DomainObjectFactory<DefaultIosApplicationComponent> newFactory(ObjectFactory objects, NamingSchemeFactory namingSchemeFactory) {
 		return identifier -> {
-			NamingScheme names = namingSchemeFactory.forMainComponent().withComponentDisplayName("main iOS application");
+			NamingScheme names = namingSchemeFactory.forMainComponent().withComponentDisplayName(((ComponentIdentifier<?>)identifier).getDisplayName());
 			return objects.newInstance(DefaultIosApplicationComponent.class, identifier, names);
 		};
 	}

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationComponent.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationComponent.java
@@ -80,11 +80,11 @@ public class DefaultIosApplicationComponent extends BaseNativeComponent<DefaultI
 	}
 
 	@Override
-	protected DefaultIosApplicationVariant createVariant(VariantIdentifier<?> identifier, String name, VariantComponentDependencies<?> variantDependencies) {
+	protected DefaultIosApplicationVariant createVariant(VariantIdentifier<?> identifier, VariantComponentDependencies<?> variantDependencies) {
 		val buildVariant = (BuildVariantInternal) identifier.getBuildVariant();
 		NamingScheme names = getNames().forBuildVariant(buildVariant, getBuildVariants().get());
 
-		DefaultIosApplicationVariant result = getObjects().newInstance(DefaultIosApplicationVariant.class, identifier, name, names, variantDependencies);
+		DefaultIosApplicationVariant result = getObjects().newInstance(DefaultIosApplicationVariant.class, identifier, names, variantDependencies);
 		return result;
 	}
 

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationComponent.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationComponent.java
@@ -63,8 +63,8 @@ public class DefaultIosApplicationComponent extends BaseNativeComponent<DefaultI
 	private final TaskRegistry taskRegistry;
 
 	@Inject
-	public DefaultIosApplicationComponent(NamingScheme names, ObjectFactory objects, ProviderFactory providers, TaskContainer tasks, ProjectLayout layout, ConfigurationContainer configurations, DependencyHandler dependencyHandler) {
-		super(names, DefaultIosApplicationVariant.class, objects, providers, tasks, layout, configurations);
+	public DefaultIosApplicationComponent(ComponentIdentifier<DefaultIosApplicationComponent> identifier, NamingScheme names, ObjectFactory objects, ProviderFactory providers, TaskContainer tasks, ProjectLayout layout, ConfigurationContainer configurations, DependencyHandler dependencyHandler) {
+		super(identifier, names, DefaultIosApplicationVariant.class, objects, providers, tasks, layout, configurations);
 		this.dependencyHandler = dependencyHandler;
 		val dependencyContainer = objects.newInstance(DefaultComponentDependencies.class, names.getComponentDisplayName(), new FrameworkAwareDependencyBucketFactory(new DefaultDependencyBucketFactory(new ConfigurationFactories.Prefixing(new ConfigurationFactories.Creating(getConfigurations()), names::getConfigurationName), new DefaultDependencyFactory(getDependencyHandler()))));
 		this.dependencies = objects.newInstance(DefaultNativeComponentDependencies.class, dependencyContainer);
@@ -239,7 +239,7 @@ public class DefaultIosApplicationComponent extends BaseNativeComponent<DefaultI
 	public static DomainObjectFactory<DefaultIosApplicationComponent> newFactory(ObjectFactory objects, NamingSchemeFactory namingSchemeFactory) {
 		return identifier -> {
 			NamingScheme names = namingSchemeFactory.forMainComponent().withComponentDisplayName("main iOS application");
-			return objects.newInstance(DefaultIosApplicationComponent.class, names);
+			return objects.newInstance(DefaultIosApplicationComponent.class, identifier, names);
 		};
 	}
 }

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationComponent.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationComponent.java
@@ -80,10 +80,10 @@ public class DefaultIosApplicationComponent extends BaseNativeComponent<DefaultI
 	}
 
 	@Override
-	protected DefaultIosApplicationVariant createVariant(String name, BuildVariantInternal buildVariant, VariantComponentDependencies<?> variantDependencies) {
+	protected DefaultIosApplicationVariant createVariant(VariantIdentifier<?> identifier, String name, BuildVariantInternal buildVariant, VariantComponentDependencies<?> variantDependencies) {
 		NamingScheme names = getNames().forBuildVariant(buildVariant, getBuildVariants().get());
 
-		DefaultIosApplicationVariant result = getObjects().newInstance(DefaultIosApplicationVariant.class, name, names, buildVariant, variantDependencies);
+		DefaultIosApplicationVariant result = getObjects().newInstance(DefaultIosApplicationVariant.class, identifier, name, names, buildVariant, variantDependencies);
 		return result;
 	}
 

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationComponent.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationComponent.java
@@ -115,7 +115,7 @@ public class DefaultIosApplicationComponent extends BaseNativeComponent<DefaultI
 	}
 
 	@Override
-	protected void onEachVariant(VariantIdentifier<DefaultIosApplicationVariant> variantIdentifier, VariantProvider<DefaultIosApplicationVariant> variant, NamingScheme names) {
+	protected void onEachVariant(KnownVariant<DefaultIosApplicationVariant> variant) {
 		variant.configure(application -> {
 			application.getBinaries().configureEach(ExecutableBinary.class, binary -> {
 				binary.getCompileTasks().configureEach(SourceCompile.class, task -> {
@@ -156,7 +156,7 @@ public class DefaultIosApplicationComponent extends BaseNativeComponent<DefaultI
 			Provider<CommandLineTool> assetCompilerTool = getProviders().provider(() -> new VersionedCommandLineTool(new File("/usr/bin/actool"), VersionNumber.parse("11.3.1")));
 			Provider<CommandLineTool> codeSignatureTool = getProviders().provider(() -> new PathAwareCommandLineTool(new File("/usr/bin/codesign")));
 
-			String moduleName = names.getBaseName().getAsCamelCase();
+			String moduleName = getNames().getBaseName().getAsCamelCase();
 			Provider<String> identifier = getProviders().provider(() -> getGroupId().get().get().map(it -> it + "." + moduleName).orElse(moduleName));
 
 			val compileStoryboardTask = taskRegistry.register("compileStoryboard", StoryboardCompileTask.class, task -> {

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationVariant.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationVariant.java
@@ -24,8 +24,8 @@ public class DefaultIosApplicationVariant extends BaseNativeVariant implements I
 	@Getter private final ResolvableComponentDependencies resolvableDependencies;
 
 	@Inject
-	public DefaultIosApplicationVariant(VariantIdentifier<DefaultIosApplicationVariant> identifier, String name, NamingScheme names, VariantComponentDependencies<DefaultNativeComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
-		super(identifier, name, names, objects, tasks, providers);
+	public DefaultIosApplicationVariant(VariantIdentifier<DefaultIosApplicationVariant> identifier, NamingScheme names, VariantComponentDependencies<DefaultNativeComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
+		super(identifier, names, objects, tasks, providers);
 		this.dependencies = dependencies.getDependencies();
 		this.resolvableDependencies = dependencies.getIncoming();
 	}

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationVariant.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationVariant.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import dev.nokee.platform.base.Binary;
 import dev.nokee.platform.base.internal.BuildVariantInternal;
 import dev.nokee.platform.base.internal.NamingScheme;
+import dev.nokee.platform.base.internal.VariantIdentifier;
 import dev.nokee.platform.base.internal.VariantInternal;
 import dev.nokee.platform.base.internal.dependencies.ResolvableComponentDependencies;
 import dev.nokee.platform.ios.IosApplication;
@@ -24,8 +25,8 @@ public class DefaultIosApplicationVariant extends BaseNativeVariant implements I
 	@Getter private final ResolvableComponentDependencies resolvableDependencies;
 
 	@Inject
-	public DefaultIosApplicationVariant(String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<DefaultNativeComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
-		super(name, names, buildVariant, objects, tasks, providers);
+	public DefaultIosApplicationVariant(VariantIdentifier<DefaultIosApplicationVariant> identifier, String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<DefaultNativeComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
+		super(identifier, name, names, buildVariant, objects, tasks, providers);
 		this.dependencies = dependencies.getDependencies();
 		this.resolvableDependencies = dependencies.getIncoming();
 	}

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationVariant.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationVariant.java
@@ -5,12 +5,12 @@ import dev.nokee.platform.base.Binary;
 import dev.nokee.platform.base.internal.BuildVariantInternal;
 import dev.nokee.platform.base.internal.NamingScheme;
 import dev.nokee.platform.base.internal.VariantInternal;
+import dev.nokee.platform.base.internal.dependencies.ResolvableComponentDependencies;
 import dev.nokee.platform.ios.IosApplication;
-import dev.nokee.platform.nativebase.NativeComponentDependencies;
 import dev.nokee.platform.nativebase.internal.BaseNativeVariant;
 import dev.nokee.platform.nativebase.internal.dependencies.DefaultNativeComponentDependencies;
 import dev.nokee.platform.nativebase.internal.dependencies.VariantComponentDependencies;
-import org.gradle.api.Action;
+import lombok.Getter;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
@@ -21,11 +21,13 @@ import java.util.List;
 
 public class DefaultIosApplicationVariant extends BaseNativeVariant implements IosApplication, VariantInternal {
 	private final DefaultNativeComponentDependencies dependencies;
+	@Getter private final ResolvableComponentDependencies resolvableDependencies;
 
 	@Inject
 	public DefaultIosApplicationVariant(String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<DefaultNativeComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
 		super(name, names, buildVariant, objects, tasks, providers);
 		this.dependencies = dependencies.getDependencies();
+		this.resolvableDependencies = dependencies.getIncoming();
 	}
 
 	@Override

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationVariant.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationVariant.java
@@ -2,7 +2,6 @@ package dev.nokee.platform.ios.internal;
 
 import com.google.common.collect.ImmutableList;
 import dev.nokee.platform.base.Binary;
-import dev.nokee.platform.base.internal.BuildVariantInternal;
 import dev.nokee.platform.base.internal.NamingScheme;
 import dev.nokee.platform.base.internal.VariantIdentifier;
 import dev.nokee.platform.base.internal.VariantInternal;
@@ -25,8 +24,8 @@ public class DefaultIosApplicationVariant extends BaseNativeVariant implements I
 	@Getter private final ResolvableComponentDependencies resolvableDependencies;
 
 	@Inject
-	public DefaultIosApplicationVariant(VariantIdentifier<DefaultIosApplicationVariant> identifier, String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<DefaultNativeComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
-		super(identifier, name, names, buildVariant, objects, tasks, providers);
+	public DefaultIosApplicationVariant(VariantIdentifier<DefaultIosApplicationVariant> identifier, String name, NamingScheme names, VariantComponentDependencies<DefaultNativeComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
+		super(identifier, name, names, objects, tasks, providers);
 		this.dependencies = dependencies.getDependencies();
 		this.resolvableDependencies = dependencies.getIncoming();
 	}

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationVariant.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationVariant.java
@@ -1,23 +1,20 @@
 package dev.nokee.platform.ios.internal;
 
-import com.google.common.collect.ImmutableList;
-import dev.nokee.platform.base.Binary;
 import dev.nokee.platform.base.internal.NamingScheme;
 import dev.nokee.platform.base.internal.VariantIdentifier;
 import dev.nokee.platform.base.internal.VariantInternal;
 import dev.nokee.platform.base.internal.dependencies.ResolvableComponentDependencies;
 import dev.nokee.platform.ios.IosApplication;
+import dev.nokee.platform.ios.internal.rules.IosDevelopmentBinaryConvention;
 import dev.nokee.platform.nativebase.internal.BaseNativeVariant;
 import dev.nokee.platform.nativebase.internal.dependencies.DefaultNativeComponentDependencies;
 import dev.nokee.platform.nativebase.internal.dependencies.VariantComponentDependencies;
 import lombok.Getter;
 import org.gradle.api.model.ObjectFactory;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.TaskContainer;
 
 import javax.inject.Inject;
-import java.util.List;
 
 public class DefaultIosApplicationVariant extends BaseNativeVariant implements IosApplication, VariantInternal {
 	private final DefaultNativeComponentDependencies dependencies;
@@ -28,26 +25,12 @@ public class DefaultIosApplicationVariant extends BaseNativeVariant implements I
 		super(identifier, names, objects, tasks, providers);
 		this.dependencies = dependencies.getDependencies();
 		this.resolvableDependencies = dependencies.getIncoming();
+
+		getDevelopmentBinary().convention(getBinaries().getElements().flatMap(IosDevelopmentBinaryConvention.INSTANCE));
 	}
 
 	@Override
 	public DefaultNativeComponentDependencies getDependencies() {
 		return dependencies;
-	}
-
-	@Override
-	protected Provider<Binary> getDefaultBinary() {
-		return getProviders().provider(() -> {
-			List<? extends SignedIosApplicationBundleInternal> binaries = getBinaries().flatMap(it -> {
-				if (it instanceof SignedIosApplicationBundleInternal) {
-					return ImmutableList.of((SignedIosApplicationBundleInternal)it);
-				}
-				return ImmutableList.of();
-			}).get();
-			if (binaries.isEmpty()) {
-				return null;
-			}
-			return one(binaries);
-		});
 	}
 }

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/SignedIosApplicationBundle.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/SignedIosApplicationBundle.java
@@ -1,0 +1,6 @@
+package dev.nokee.platform.ios.internal;
+
+import dev.nokee.platform.base.Binary;
+
+public interface SignedIosApplicationBundle extends Binary {
+}

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/SignedIosApplicationBundleInternal.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/SignedIosApplicationBundleInternal.java
@@ -18,7 +18,7 @@ import javax.inject.Inject;
 // TODO: Not sure about implementing NativeBinary...
 //  BaseNativeVariant#getDevelopmentBinary() assume a NativeBinary...
 //  There should probably be something high level in Variant or BaseNativeVariant shouldn't be used for iOS variant.
-public class SignedIosApplicationBundleInternal implements Binary, Buildable {
+public class SignedIosApplicationBundleInternal implements SignedIosApplicationBundle, Binary, Buildable {
 	private final TaskProvider<SignIosApplicationBundleTask> bundleTask;
 	@Getter(AccessLevel.PROTECTED) private final TaskContainer tasks;
 

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/ObjectiveCIosApplicationPlugin.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/ObjectiveCIosApplicationPlugin.java
@@ -63,7 +63,7 @@ public class ObjectiveCIosApplicationPlugin implements Plugin<Project> {
 		project.getPluginManager().apply(ComponentBasePlugin.class);
 		val components = project.getExtensions().getByType(ComponentContainer.class);
 		components.registerFactory(DefaultObjectiveCIosApplicationExtension.class, id -> {
-			val identifier = ComponentIdentifier.builder().withName(ComponentName.of("main")).withProjectIdentifier(ProjectIdentifier.of(project)).withDisplayName("main iOS application").withType(DefaultIosApplicationComponent.class).build();
+			val identifier = ComponentIdentifier.ofMain(DefaultIosApplicationComponent.class, ProjectIdentifier.of(project));
 			val component = store.register(identifier, DefaultIosApplicationComponent.class, newFactory(getObjects(), new NamingSchemeFactory(project.getName())));
 			return getObjects().newInstance(DefaultObjectiveCIosApplicationExtension.class, component.get());
 		});

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/SwiftIosApplicationPlugin.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/SwiftIosApplicationPlugin.java
@@ -46,7 +46,7 @@ public class SwiftIosApplicationPlugin implements Plugin<Project> {
 		project.getPluginManager().apply(ComponentBasePlugin.class);
 		val components = project.getExtensions().getByType(ComponentContainer.class);
 		components.registerFactory(DefaultSwiftIosApplicationExtension.class, id -> {
-			val identifier = ComponentIdentifier.builder().withName(ComponentName.of("main")).withProjectIdentifier(ProjectIdentifier.of(project)).withDisplayName("main iOS application").withType(DefaultIosApplicationComponent.class).build();
+			val identifier = ComponentIdentifier.ofMain(DefaultIosApplicationComponent.class, ProjectIdentifier.of(project));
 			val component = store.register(identifier, DefaultIosApplicationComponent.class, newFactory(getObjects(), new NamingSchemeFactory(project.getName())));
 			return getObjects().newInstance(DefaultSwiftIosApplicationExtension.class, component.get());
 		});

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/rules/IosDevelopmentBinaryConvention.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/rules/IosDevelopmentBinaryConvention.java
@@ -1,0 +1,17 @@
+package dev.nokee.platform.ios.internal.rules;
+
+import dev.nokee.platform.base.Binary;
+import dev.nokee.platform.ios.internal.SignedIosApplicationBundle;
+import org.gradle.api.Transformer;
+import org.gradle.api.provider.Provider;
+
+import static dev.nokee.platform.base.internal.DevelopmentBinaryUtils.selectSingleBinaryByType;
+
+public enum IosDevelopmentBinaryConvention implements Transformer<Provider<? extends Binary>, Iterable<? extends Binary>> {
+	INSTANCE;
+
+	@Override
+	public Provider<? extends Binary> transform(Iterable<? extends Binary> binaries) {
+		return selectSingleBinaryByType(SignedIosApplicationBundle.class, binaries);
+	}
+}

--- a/subprojects/platform-ios/src/test/groovy/dev/nokee/platform/ios/internal/rules/IosDevelopmentBinaryConventionTest.groovy
+++ b/subprojects/platform-ios/src/test/groovy/dev/nokee/platform/ios/internal/rules/IosDevelopmentBinaryConventionTest.groovy
@@ -1,0 +1,56 @@
+package dev.nokee.platform.ios.internal.rules
+
+import dev.nokee.platform.base.Binary
+import dev.nokee.platform.ios.internal.SignedIosApplicationBundle
+import dev.nokee.utils.ProviderUtils
+import spock.lang.Specification
+import spock.lang.Subject
+
+import static dev.nokee.platform.ios.internal.rules.IosDevelopmentBinaryConvention.INSTANCE
+
+@Subject(IosDevelopmentBinaryConvention)
+class IosDevelopmentBinaryConventionTest extends Specification {
+	def "returns undefined provider on empty list"() {
+		expect:
+		INSTANCE.transform([]) == ProviderUtils.notDefined()
+	}
+
+	def "throws exception when multiple SignedIosApplicationBundle binaries"() {
+		when:
+		INSTANCE.transform([Stub(SignedIosApplicationBundle), Stub(SignedIosApplicationBundle)])
+
+		then:
+		def ex = thrown(IllegalArgumentException)
+		ex.message == "expected one element but was: <Mock for type 'SignedIosApplicationBundle', Mock for type 'SignedIosApplicationBundle'>"
+	}
+
+	def "returns a provider of the single SignedIosApplicationBundle binary list"() {
+		given:
+		def binary = Stub(SignedIosApplicationBundle)
+
+		expect:
+		def result = INSTANCE.transform([binary])
+		result.present
+		result.get() == binary
+	}
+
+	def "returns a provider of a multi-binary list containing one SignedIosApplicationBundle binary"() {
+		given:
+		def binary = Stub(SignedIosApplicationBundle)
+
+		expect:
+		def result1 = INSTANCE.transform([binary, Stub(Binary)])
+		result1.present
+		result1.get() == binary
+
+		and:
+		def result2 = INSTANCE.transform([Stub(Binary), binary])
+		result2.present
+		result2.get() == binary
+
+		and:
+		def result3 = INSTANCE.transform([Stub(Binary), binary, Stub(Binary)])
+		result3.present
+		result3.get() == binary
+	}
+}

--- a/subprojects/platform-jni/src/functionalTest/groovy/dev/nokee/platform/jni/AbstractVariantAwareComponentFunctionalTest.groovy
+++ b/subprojects/platform-jni/src/functionalTest/groovy/dev/nokee/platform/jni/AbstractVariantAwareComponentFunctionalTest.groovy
@@ -50,9 +50,9 @@ abstract class AbstractVariantAwareComponentFunctionalTest extends AbstractInsta
 			library {
 				variants.configureEach { variant ->
 					configuredVariants << variant
-					tasks.register("custom${variant.name.capitalize()}") {
+					tasks.register("custom${variant.identifier.fullName.capitalize()}") {
 						group = 'Custom'
-						description = "Custom task for variant '${variant.name}'."
+						description = "Custom task for variant '${variant.identifier.fullName}'."
 					}
 				}
 			}
@@ -83,8 +83,8 @@ customWindows${currentArchitecture.capitalize()} - Custom task for variant 'wind
 			library {
 				variants.configureEach { variant ->
 					configuredVariants << variant
-					configurations.create("custom${variant.name.capitalize()}") {
-						description = "Custom configuration for variant '${variant.name}'."
+					configurations.create("custom${variant.identifier.fullName.capitalize()}") {
+						description = "Custom configuration for variant '${variant.identifier.fullName}'."
 					}
 				}
 			}
@@ -119,11 +119,11 @@ No dependencies
 			library {
 				variants.configureEach { variant ->
 					configuredVariants << variant
-					configurations.create("custom${variant.name.capitalize()}Elements") {
-						description = "Custom configuration for variant '${variant.name}'."
+					configurations.create("custom${variant.identifier.fullName.capitalize()}Elements") {
+						description = "Custom configuration for variant '${variant.identifier.fullName}'."
 						canBeConsumed = true
 						canBeResolved = false
-						outgoing.artifact(file("build/${variant.name}.potato"))
+						outgoing.artifact(file("build/${variant.identifier.fullName}.potato"))
 					}
 				}
 			}
@@ -177,8 +177,8 @@ Artifacts
 			library {
 				variants.configureEach { variant ->
 					configuredVariants << variant
-					configurations.create("custom${variant.name.capitalize()}") {
-						description = "Custom configuration for variant '${variant.name}'."
+					configurations.create("custom${variant.identifier.fullName.capitalize()}") {
+						description = "Custom configuration for variant '${variant.identifier.fullName}'."
 						canBeConsumed = false
 						canBeResolved = true
 						dependencies.add(project.dependencies.create('dev.nokee:platformJni:0.3.0'))

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryComponentInternal.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryComponentInternal.java
@@ -81,13 +81,13 @@ public class JniLibraryComponentInternal extends BaseComponent<JniLibraryInterna
 		return getVariantCollection().getAsView(JniLibrary.class);
 	}
 
-	public JniLibraryInternal createVariant(String name, BuildVariantInternal buildVariant, VariantComponentDependencies variantDependencies) {
+	public JniLibraryInternal createVariant(VariantIdentifier<JniLibraryInternal> identifier, String name, BuildVariantInternal buildVariant, VariantComponentDependencies variantDependencies) {
 		Preconditions.checkArgument(buildVariant.getDimensions().size() == 2);
 		Preconditions.checkArgument(buildVariant.getDimensions().get(0) instanceof OperatingSystemFamily);
 		Preconditions.checkArgument(buildVariant.getDimensions().get(1) instanceof MachineArchitecture);
 		NamingScheme names = getNames().forBuildVariant(buildVariant, getBuildVariants().get());
 
-		JniLibraryInternal result = getObjects().newInstance(JniLibraryInternal.class, name, names, sources, buildVariant, groupId, getBinaryCollection(), variantDependencies);
+		JniLibraryInternal result = getObjects().newInstance(JniLibraryInternal.class, identifier, name, names, sources, buildVariant, groupId, getBinaryCollection(), variantDependencies);
 		return result;
 	}
 

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryComponentInternal.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryComponentInternal.java
@@ -49,8 +49,8 @@ public class JniLibraryComponentInternal extends BaseComponent<JniLibraryInterna
 	@Getter private final SetProperty<TargetMachine> targetMachines;
 
 	@Inject
-	public JniLibraryComponentInternal(NamingScheme names, GroupId groupId, ObjectFactory objects, ConfigurationContainer configurations, DependencyHandler dependencyHandler, ProviderFactory providers) {
-		super(names, JniLibraryInternal.class, objects);
+	public JniLibraryComponentInternal(ComponentIdentifier<JniLibraryComponentInternal> identifier, NamingScheme names, GroupId groupId, ObjectFactory objects, ConfigurationContainer configurations, DependencyHandler dependencyHandler, ProviderFactory providers) {
+		super(identifier, names, JniLibraryInternal.class, objects);
 		this.configurations = configurations;
 		this.dependencyHandler = dependencyHandler;
 		this.providers = providers;

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryComponentInternal.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryComponentInternal.java
@@ -81,14 +81,14 @@ public class JniLibraryComponentInternal extends BaseComponent<JniLibraryInterna
 		return getVariantCollection().getAsView(JniLibrary.class);
 	}
 
-	public JniLibraryInternal createVariant(VariantIdentifier<JniLibraryInternal> identifier, String name, VariantComponentDependencies variantDependencies) {
+	public JniLibraryInternal createVariant(VariantIdentifier<JniLibraryInternal> identifier, VariantComponentDependencies variantDependencies) {
 		val buildVariant = (BuildVariantInternal) identifier.getBuildVariant();
 		Preconditions.checkArgument(buildVariant.getDimensions().size() == 2);
 		Preconditions.checkArgument(buildVariant.getDimensions().get(0) instanceof OperatingSystemFamily);
 		Preconditions.checkArgument(buildVariant.getDimensions().get(1) instanceof MachineArchitecture);
 		NamingScheme names = getNames().forBuildVariant(buildVariant, getBuildVariants().get());
 
-		JniLibraryInternal result = getObjects().newInstance(JniLibraryInternal.class, identifier, name, names, sources, groupId, getBinaryCollection(), variantDependencies);
+		JniLibraryInternal result = getObjects().newInstance(JniLibraryInternal.class, identifier, names, sources, groupId, getBinaryCollection(), variantDependencies);
 		return result;
 	}
 

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryComponentInternal.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryComponentInternal.java
@@ -81,13 +81,14 @@ public class JniLibraryComponentInternal extends BaseComponent<JniLibraryInterna
 		return getVariantCollection().getAsView(JniLibrary.class);
 	}
 
-	public JniLibraryInternal createVariant(VariantIdentifier<JniLibraryInternal> identifier, String name, BuildVariantInternal buildVariant, VariantComponentDependencies variantDependencies) {
+	public JniLibraryInternal createVariant(VariantIdentifier<JniLibraryInternal> identifier, String name, VariantComponentDependencies variantDependencies) {
+		val buildVariant = (BuildVariantInternal) identifier.getBuildVariant();
 		Preconditions.checkArgument(buildVariant.getDimensions().size() == 2);
 		Preconditions.checkArgument(buildVariant.getDimensions().get(0) instanceof OperatingSystemFamily);
 		Preconditions.checkArgument(buildVariant.getDimensions().get(1) instanceof MachineArchitecture);
 		NamingScheme names = getNames().forBuildVariant(buildVariant, getBuildVariants().get());
 
-		JniLibraryInternal result = getObjects().newInstance(JniLibraryInternal.class, identifier, name, names, sources, buildVariant, groupId, getBinaryCollection(), variantDependencies);
+		JniLibraryInternal result = getObjects().newInstance(JniLibraryInternal.class, identifier, name, names, sources, groupId, getBinaryCollection(), variantDependencies);
 		return result;
 	}
 

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryExtensionInternal.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryExtensionInternal.java
@@ -5,10 +5,7 @@ import dev.nokee.platform.base.Binary;
 import dev.nokee.platform.base.BinaryView;
 import dev.nokee.platform.base.Component;
 import dev.nokee.platform.base.VariantView;
-import dev.nokee.platform.base.internal.BuildVariantInternal;
-import dev.nokee.platform.base.internal.GroupId;
-import dev.nokee.platform.base.internal.NamingScheme;
-import dev.nokee.platform.base.internal.VariantCollection;
+import dev.nokee.platform.base.internal.*;
 import dev.nokee.platform.jni.JniLibrary;
 import dev.nokee.platform.jni.JniLibraryExtension;
 import dev.nokee.platform.nativebase.TargetMachineFactory;
@@ -33,11 +30,11 @@ public class JniLibraryExtensionInternal implements JniLibraryExtension, Compone
 	@Getter(AccessLevel.PROTECTED) private final ProviderFactory providers;
 
 	@Inject
-	public JniLibraryExtensionInternal(GroupId groupId, NamingScheme names, ConfigurationContainer configurations, ObjectFactory objects, ProviderFactory providers) {
+	public JniLibraryExtensionInternal(ComponentIdentifier<?> identifier, GroupId groupId, NamingScheme names, ConfigurationContainer configurations, ObjectFactory objects, ProviderFactory providers) {
 		this.configurations = configurations;
 		this.objects = objects;
 		this.providers = providers;
-		this.component = objects.newInstance(JniLibraryComponentInternal.class, names, groupId);
+		this.component = objects.newInstance(JniLibraryComponentInternal.class, identifier, names, groupId);
 	}
 
 	//region Variant-awareness

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryInternal.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryInternal.java
@@ -46,15 +46,15 @@ public class JniLibraryInternal extends BaseVariant implements JniLibrary, Varia
 	@Getter private final ResolvableComponentDependencies resolvableDependencies;
 
 	@Inject
-	public JniLibraryInternal(VariantIdentifier<JniLibraryInternal> identifier, String name, NamingScheme names, DomainObjectSet<LanguageSourceSetInternal> parentSources, BuildVariantInternal buildVariant, GroupId groupId, DomainObjectSet<Binary> parentBinaries, VariantComponentDependencies dependencies, ObjectFactory objects, ConfigurationContainer configurations, ProviderFactory providers, TaskContainer tasks) {
-		super(identifier, name, buildVariant, objects);
+	public JniLibraryInternal(VariantIdentifier<JniLibraryInternal> identifier, String name, NamingScheme names, DomainObjectSet<LanguageSourceSetInternal> parentSources, GroupId groupId, DomainObjectSet<Binary> parentBinaries, VariantComponentDependencies dependencies, ObjectFactory objects, ConfigurationContainer configurations, ProviderFactory providers, TaskContainer tasks) {
+		super(identifier, name, objects);
 		this.names = names;
 		this.dependencies = dependencies.getDependencies();
 		this.configurations = configurations;
 		this.providers = providers;
 		this.tasks = tasks;
 		this.sources = objects.domainObjectSet(LanguageSourceSetInternal.class);
-		this.targetMachine = new DefaultTargetMachine((DefaultOperatingSystemFamily)buildVariant.getDimensions().get(0), (DefaultMachineArchitecture)buildVariant.getDimensions().get(1));
+		this.targetMachine = new DefaultTargetMachine((DefaultOperatingSystemFamily)getBuildVariant().getDimensions().get(0), (DefaultMachineArchitecture)getBuildVariant().getDimensions().get(1));
 		this.groupId = groupId;
 		this.resourcePath = objects.property(String.class);
 		this.nativeRuntimeFiles = objects.fileCollection();

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryInternal.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryInternal.java
@@ -46,8 +46,8 @@ public class JniLibraryInternal extends BaseVariant implements JniLibrary, Varia
 	@Getter private final ResolvableComponentDependencies resolvableDependencies;
 
 	@Inject
-	public JniLibraryInternal(VariantIdentifier<JniLibraryInternal> identifier, String name, NamingScheme names, DomainObjectSet<LanguageSourceSetInternal> parentSources, GroupId groupId, DomainObjectSet<Binary> parentBinaries, VariantComponentDependencies dependencies, ObjectFactory objects, ConfigurationContainer configurations, ProviderFactory providers, TaskContainer tasks) {
-		super(identifier, name, objects);
+	public JniLibraryInternal(VariantIdentifier<JniLibraryInternal> identifier, NamingScheme names, DomainObjectSet<LanguageSourceSetInternal> parentSources, GroupId groupId, DomainObjectSet<Binary> parentBinaries, VariantComponentDependencies dependencies, ObjectFactory objects, ConfigurationContainer configurations, ProviderFactory providers, TaskContainer tasks) {
+		super(identifier, objects);
 		this.names = names;
 		this.dependencies = dependencies.getDependencies();
 		this.configurations = configurations;

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryInternal.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryInternal.java
@@ -4,7 +4,7 @@ import dev.nokee.language.base.internal.GeneratedSourceSet;
 import dev.nokee.language.base.internal.LanguageSourceSetInternal;
 import dev.nokee.platform.base.Binary;
 import dev.nokee.platform.base.internal.*;
-import dev.nokee.platform.jni.JavaNativeInterfaceNativeComponentDependencies;
+import dev.nokee.platform.base.internal.dependencies.ResolvableComponentDependencies;
 import dev.nokee.platform.jni.JniLibrary;
 import dev.nokee.platform.nativebase.SharedLibraryBinary;
 import dev.nokee.platform.nativebase.internal.SharedLibraryBinaryInternal;
@@ -43,6 +43,7 @@ public class JniLibraryInternal extends BaseVariant implements JniLibrary, Varia
 	private SharedLibraryBinaryInternal sharedLibraryBinary;
 	@Getter private final Property<String> resourcePath;
 	@Getter private final ConfigurableFileCollection nativeRuntimeFiles;
+	@Getter private final ResolvableComponentDependencies resolvableDependencies;
 
 	@Inject
 	public JniLibraryInternal(String name, NamingScheme names, DomainObjectSet<LanguageSourceSetInternal> parentSources, BuildVariantInternal buildVariant, GroupId groupId, DomainObjectSet<Binary> parentBinaries, VariantComponentDependencies dependencies, ObjectFactory objects, ConfigurationContainer configurations, ProviderFactory providers, TaskContainer tasks) {
@@ -57,6 +58,7 @@ public class JniLibraryInternal extends BaseVariant implements JniLibrary, Varia
 		this.groupId = groupId;
 		this.resourcePath = objects.property(String.class);
 		this.nativeRuntimeFiles = objects.fileCollection();
+		this.resolvableDependencies = dependencies.getIncoming();
 
 		parentSources.all(sources::add);
 

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryInternal.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryInternal.java
@@ -46,8 +46,8 @@ public class JniLibraryInternal extends BaseVariant implements JniLibrary, Varia
 	@Getter private final ResolvableComponentDependencies resolvableDependencies;
 
 	@Inject
-	public JniLibraryInternal(String name, NamingScheme names, DomainObjectSet<LanguageSourceSetInternal> parentSources, BuildVariantInternal buildVariant, GroupId groupId, DomainObjectSet<Binary> parentBinaries, VariantComponentDependencies dependencies, ObjectFactory objects, ConfigurationContainer configurations, ProviderFactory providers, TaskContainer tasks) {
-		super(name, buildVariant, objects);
+	public JniLibraryInternal(VariantIdentifier<JniLibraryInternal> identifier, String name, NamingScheme names, DomainObjectSet<LanguageSourceSetInternal> parentSources, BuildVariantInternal buildVariant, GroupId groupId, DomainObjectSet<Binary> parentBinaries, VariantComponentDependencies dependencies, ObjectFactory objects, ConfigurationContainer configurations, ProviderFactory providers, TaskContainer tasks) {
+		super(identifier, name, buildVariant, objects);
 		this.names = names;
 		this.dependencies = dependencies.getDependencies();
 		this.configurations = configurations;

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/plugins/JniLibraryPlugin.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/plugins/JniLibraryPlugin.java
@@ -183,7 +183,7 @@ public class JniLibraryPlugin implements Plugin<Project> {
 
 				val dependencies = newDependencies(names.withComponentDisplayName("JNI shared library"), buildVariant, extension.getComponent());
 				final VariantProvider<JniLibraryInternal> library = extension.getVariantCollection().registerVariant(variantIdentifier, (name, bv) -> {
-					JniLibraryInternal it = extension.getComponent().createVariant(name, bv, dependencies);
+					JniLibraryInternal it = extension.getComponent().createVariant(variantIdentifier, name, bv, dependencies);
 
 					// Build all language source set
 					DomainObjectSet<GeneratedSourceSet> objectSourceSets = getObjects().domainObjectSet(GeneratedSourceSet.class);

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/plugins/JniLibraryPlugin.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/plugins/JniLibraryPlugin.java
@@ -183,7 +183,7 @@ public class JniLibraryPlugin implements Plugin<Project> {
 
 				val dependencies = newDependencies(names.withComponentDisplayName("JNI shared library"), buildVariant, extension.getComponent());
 				final VariantProvider<JniLibraryInternal> library = extension.getVariantCollection().registerVariant(variantIdentifier, (name, bv) -> {
-					JniLibraryInternal it = extension.getComponent().createVariant(variantIdentifier, name, dependencies);
+					JniLibraryInternal it = extension.getComponent().createVariant(variantIdentifier, dependencies);
 
 					// Build all language source set
 					DomainObjectSet<GeneratedSourceSet> objectSourceSets = getObjects().domainObjectSet(GeneratedSourceSet.class);

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/plugins/JniLibraryPlugin.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/plugins/JniLibraryPlugin.java
@@ -183,7 +183,7 @@ public class JniLibraryPlugin implements Plugin<Project> {
 
 				val dependencies = newDependencies(names.withComponentDisplayName("JNI shared library"), buildVariant, extension.getComponent());
 				final VariantProvider<JniLibraryInternal> library = extension.getVariantCollection().registerVariant(variantIdentifier, (name, bv) -> {
-					JniLibraryInternal it = extension.getComponent().createVariant(variantIdentifier, name, bv, dependencies);
+					JniLibraryInternal it = extension.getComponent().createVariant(variantIdentifier, name, dependencies);
 
 					// Build all language source set
 					DomainObjectSet<GeneratedSourceSet> objectSourceSets = getObjects().domainObjectSet(GeneratedSourceSet.class);

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/plugins/JniLibraryPlugin.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/plugins/JniLibraryPlugin.java
@@ -179,9 +179,10 @@ public class JniLibraryPlugin implements Plugin<Project> {
 			extension.getBuildVariants().get().forEach(buildVariant -> {
 				final DefaultTargetMachine targetMachineInternal = new DefaultTargetMachine((DefaultOperatingSystemFamily)buildVariant.getDimensions().get(0), (DefaultMachineArchitecture)buildVariant.getDimensions().get(1));
 				final NamingScheme names = mainComponentNames.forBuildVariant(buildVariant, extension.getBuildVariants().get());
+				final VariantIdentifier<JniLibraryInternal> variantIdentifier = VariantIdentifier.builder().withUnambiguousNameFromBuildVariants(buildVariant, extension.getBuildVariants().get()).withComponentIdentifier(ComponentIdentifier.ofMain(JniLibraryComponentInternal.class, ProjectIdentifier.of(project))).withType(JniLibraryInternal.class).build();
 
 				val dependencies = newDependencies(names.withComponentDisplayName("JNI shared library"), buildVariant, extension.getComponent());
-				final VariantProvider<JniLibraryInternal> library = extension.getVariantCollection().registerVariant(buildVariant, (name, bv) -> {
+				final VariantProvider<JniLibraryInternal> library = extension.getVariantCollection().registerVariant(variantIdentifier, (name, bv) -> {
 					JniLibraryInternal it = extension.getComponent().createVariant(name, bv, dependencies);
 
 					// Build all language source set

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/plugins/JniLibraryPlugin.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/plugins/JniLibraryPlugin.java
@@ -143,7 +143,7 @@ public class JniLibraryPlugin implements Plugin<Project> {
 		project.getPluginManager().apply(StandardToolChainsPlugin.class);
 
 		NamingSchemeFactory namingSchemeFactory = new NamingSchemeFactory(project.getName());
-		NamingScheme mainComponentNames = namingSchemeFactory.forMainComponent().withComponentDisplayName("JNI library");
+		NamingScheme mainComponentNames = namingSchemeFactory.forMainComponent().withComponentDisplayName("main component");
 		JniLibraryExtensionInternal extension = registerExtension(project, mainComponentNames);
 		project.afterEvaluate(getObjects().newInstance(TargetMachineRule.class, extension.getTargetMachines(), EXTENSION_NAME));
 

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/plugins/JniLibraryPlugin.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/plugins/JniLibraryPlugin.java
@@ -179,7 +179,7 @@ public class JniLibraryPlugin implements Plugin<Project> {
 			extension.getBuildVariants().get().forEach(buildVariant -> {
 				final DefaultTargetMachine targetMachineInternal = new DefaultTargetMachine((DefaultOperatingSystemFamily)buildVariant.getDimensions().get(0), (DefaultMachineArchitecture)buildVariant.getDimensions().get(1));
 				final NamingScheme names = mainComponentNames.forBuildVariant(buildVariant, extension.getBuildVariants().get());
-				final VariantIdentifier<JniLibraryInternal> variantIdentifier = VariantIdentifier.builder().withUnambiguousNameFromBuildVariants(buildVariant, extension.getBuildVariants().get()).withComponentIdentifier(ComponentIdentifier.ofMain(JniLibraryComponentInternal.class, ProjectIdentifier.of(project))).withType(JniLibraryInternal.class).build();
+				final VariantIdentifier<JniLibraryInternal> variantIdentifier = VariantIdentifier.builder().withUnambiguousNameFromBuildVariants(buildVariant, extension.getBuildVariants().get()).withComponentIdentifier(extension.getComponent().getIdentifier()).withType(JniLibraryInternal.class).build();
 
 				val dependencies = newDependencies(names.withComponentDisplayName("JNI shared library"), buildVariant, extension.getComponent());
 				final VariantProvider<JniLibraryInternal> library = extension.getVariantCollection().registerVariant(variantIdentifier, (name, bv) -> {
@@ -457,7 +457,7 @@ public class JniLibraryPlugin implements Plugin<Project> {
 		val components = project.getExtensions().getByType(ComponentContainer.class);
 		components.registerFactory(JniLibraryExtensionInternal.class, identifier -> {
 			assert ((ComponentIdentifier<?>) identifier).isMainComponent();
-			return project.getObjects().newInstance(JniLibraryExtensionInternal.class, GroupId.of(project::getGroup), names);
+			return project.getObjects().newInstance(JniLibraryExtensionInternal.class, identifier, GroupId.of(project::getGroup), names);
 		});
 		val library = components.register("main", JniLibraryExtensionInternal.class).get();
 

--- a/subprojects/platform-jni/src/test/groovy/dev/nokee/platform/jni/internal/plugins/JniLibraryPluginTest.groovy
+++ b/subprojects/platform-jni/src/test/groovy/dev/nokee/platform/jni/internal/plugins/JniLibraryPluginTest.groovy
@@ -853,9 +853,9 @@ abstract class AbstractJniLibraryPluginConfigurationsTest extends AbstractJniLib
 		resolveAllVariants('plugin creates configurations on demand')
 
 		expect:
-		project.configurations.api.description == "API dependencies for JNI library."
-		project.configurations.jvmImplementation.description == "Implementation only dependencies for JNI library."
-		project.configurations.jvmRuntimeOnly.description == "Runtime only dependencies for JNI library."
+		project.configurations.api.description == "API dependencies for main component."
+		project.configurations.jvmImplementation.description == "Implementation only dependencies for main component."
+		project.configurations.jvmRuntimeOnly.description == "Runtime only dependencies for main component."
 		project.configurations.apiElements.description == "API elements for main."
 		project.configurations.runtimeElements.description == "Elements of runtime for main."
 	}
@@ -866,11 +866,11 @@ abstract class AbstractJniLibraryPluginConfigurationsTest extends AbstractJniLib
 		resolveAllVariants('plugin creates configurations on demand')
 
 		expect:
-		project.configurations.nativeImplementation.description == 'Implementation only dependencies for JNI library.'
-		project.configurations.nativeLinkOnly.description == 'Link only dependencies for JNI library.'
-		project.configurations.nativeRuntimeOnly.description == 'Runtime only dependencies for JNI library.'
-		project.configurations.nativeLinkLibraries.description == 'Link libraries for JNI library.'
-		project.configurations.nativeRuntimeLibraries.description == 'Runtime libraries for JNI library.'
+		project.configurations.nativeImplementation.description == 'Implementation only dependencies for main component.'
+		project.configurations.nativeLinkOnly.description == 'Link only dependencies for main component.'
+		project.configurations.nativeRuntimeOnly.description == 'Runtime only dependencies for main component.'
+		project.configurations.nativeLinkLibraries.description == 'Link libraries for main component.'
+		project.configurations.nativeRuntimeLibraries.description == 'Runtime libraries for main component.'
 	}
 }
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/plugins/CApplicationPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/plugins/CApplicationPlugin.java
@@ -42,7 +42,7 @@ public class CApplicationPlugin implements Plugin<Project> {
 		project.getPluginManager().apply(ComponentBasePlugin.class);
 		val components = project.getExtensions().getByType(ComponentContainer.class);
 		components.registerFactory(DefaultCApplicationExtension.class, id -> {
-			val identifier = ComponentIdentifier.builder().withName(((ComponentIdentifier<?>)id).getName()).withProjectIdentifier(ProjectIdentifier.of(project)).withDisplayName("main native component").withType(DefaultNativeApplicationComponent.class).build();
+			val identifier = ComponentIdentifier.of(((ComponentIdentifier<?>)id).getName(), DefaultNativeApplicationComponent.class, ProjectIdentifier.of(project));
 			val component = store.register(identifier, DefaultNativeApplicationComponent.class, newFactory(getObjects(), new NamingSchemeFactory(project.getName())));
 			return getObjects().newInstance(DefaultCApplicationExtension.class, component.get());
 		});

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/plugins/CLibraryPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/plugins/CLibraryPlugin.java
@@ -1,15 +1,15 @@
 package dev.nokee.platform.c.internal.plugins;
 
 import dev.nokee.platform.base.ComponentContainer;
-import dev.nokee.platform.base.internal.*;
+import dev.nokee.platform.base.internal.ComponentIdentifier;
+import dev.nokee.platform.base.internal.DomainObjectStore;
+import dev.nokee.platform.base.internal.NamingSchemeFactory;
+import dev.nokee.platform.base.internal.ProjectIdentifier;
 import dev.nokee.platform.base.internal.plugins.ComponentBasePlugin;
 import dev.nokee.platform.base.internal.plugins.ProjectStorePlugin;
 import dev.nokee.platform.c.CLibraryExtension;
 import dev.nokee.platform.c.internal.DefaultCLibraryExtension;
-import dev.nokee.platform.nativebase.internal.DefaultNativeLibraryComponent;
-import dev.nokee.platform.nativebase.internal.TargetBuildTypeRule;
-import dev.nokee.platform.nativebase.internal.TargetLinkageRule;
-import dev.nokee.platform.nativebase.internal.TargetMachineRule;
+import dev.nokee.platform.nativebase.internal.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.val;
@@ -43,7 +43,7 @@ public class CLibraryPlugin implements Plugin<Project> {
 		project.getPluginManager().apply(ComponentBasePlugin.class);
 		val components = project.getExtensions().getByType(ComponentContainer.class);
 		components.registerFactory(DefaultCLibraryExtension.class, id -> {
-			val identifier = ComponentIdentifier.builder().withName(((ComponentIdentifier<?>)id).getName()).withProjectIdentifier(ProjectIdentifier.of(project)).withDisplayName("main native component").withType(DefaultNativeLibraryComponent.class).build();
+			val identifier = ComponentIdentifier.of(((ComponentIdentifier<?>)id).getName(), DefaultNativeLibraryComponent.class, ProjectIdentifier.of(project));
 			val component = store.register(identifier, DefaultNativeLibraryComponent.class, newFactory(getObjects(), new NamingSchemeFactory(project.getName())));
 			return getObjects().newInstance(DefaultCLibraryExtension.class, component.get());
 		});

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppApplicationPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppApplicationPlugin.java
@@ -42,7 +42,7 @@ public class CppApplicationPlugin implements Plugin<Project> {
 		project.getPluginManager().apply(ComponentBasePlugin.class);
 		val components = project.getExtensions().getByType(ComponentContainer.class);
 		components.registerFactory(DefaultCppApplicationExtension.class, id -> {
-			val identifier = ComponentIdentifier.builder().withName(((ComponentIdentifier<?>)id).getName()).withProjectIdentifier(ProjectIdentifier.of(project)).withDisplayName("main native component").withType(DefaultNativeApplicationComponent.class).build();
+			val identifier = ComponentIdentifier.of(((ComponentIdentifier<?>)id).getName(), DefaultNativeApplicationComponent.class, ProjectIdentifier.of(project));
 			val component = store.register(identifier, DefaultNativeApplicationComponent.class, newFactory(getObjects(), new NamingSchemeFactory(project.getName())));
 			return getObjects().newInstance(DefaultCppApplicationExtension.class, component.get());
 		});

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppLibraryPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppLibraryPlugin.java
@@ -43,7 +43,7 @@ public class CppLibraryPlugin implements Plugin<Project> {
 		project.getPluginManager().apply(ComponentBasePlugin.class);
 		val components = project.getExtensions().getByType(ComponentContainer.class);
 		components.registerFactory(DefaultCppLibraryExtension.class, id -> {
-			val identifier = ComponentIdentifier.builder().withName(((ComponentIdentifier<?>)id).getName()).withProjectIdentifier(ProjectIdentifier.of(project)).withDisplayName("main native component").withType(DefaultNativeLibraryComponent.class).build();
+			val identifier = ComponentIdentifier.of(((ComponentIdentifier<?>)id).getName(), DefaultNativeLibraryComponent.class, ProjectIdentifier.of(project));
 			val component = store.register(identifier, DefaultNativeLibraryComponent.class, newFactory(getObjects(), new NamingSchemeFactory(project.getName())));
 			return getObjects().newInstance(DefaultCppLibraryExtension.class, component.get());
 		});

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeComponent.java
@@ -161,7 +161,7 @@ public abstract class BaseNativeComponent<T extends VariantInternal> extends Bas
 			final NamingScheme names = this.getNames().forBuildVariant(buildVariant, getBuildVariants().get());
 			final VariantIdentifier<T> variantIdentifier = VariantIdentifier.builder().withUnambiguousNameFromBuildVariants(buildVariant, getBuildVariants().get()).withComponentIdentifier(getIdentifier()).withType(variantType).build();
 
-			val dependencies = newDependencies(names.withComponentDisplayName("main native component"), buildVariant);
+			val dependencies = newDependencies(names.withComponentDisplayName(getIdentifier().getDisplayName()), buildVariant);
 			VariantProvider<T> variant = getVariantCollection().registerVariant(variantIdentifier, (name, bv) -> createVariant(name, bv, dependencies));
 
 			onEachVariantDependencies(variant, dependencies);

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeComponent.java
@@ -56,8 +56,8 @@ public abstract class BaseNativeComponent<T extends VariantInternal> extends Bas
 	@Getter(AccessLevel.PROTECTED) private final ConfigurationContainer configurations;
 	private final TaskRegistry taskRegistry;
 
-	public BaseNativeComponent(NamingScheme names, Class<T> variantType, ObjectFactory objects, ProviderFactory providers, TaskContainer tasks, ProjectLayout layout, ConfigurationContainer configurations) {
-		super(names, variantType, objects);
+	public BaseNativeComponent(ComponentIdentifier<?> identifier, NamingScheme names, Class<T> variantType, ObjectFactory objects, ProviderFactory providers, TaskContainer tasks, ProjectLayout layout, ConfigurationContainer configurations) {
+		super(identifier, names, variantType, objects);
 		this.providers = providers;
 		this.layout = layout;
 		this.configurations = configurations;

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeComponent.java
@@ -81,7 +81,7 @@ public abstract class BaseNativeComponent<T extends VariantInternal> extends Bas
 		return result;
 	}
 
-	protected abstract T createVariant(VariantIdentifier<?> identifier, String name, BuildVariantInternal buildVariant, VariantComponentDependencies<?> dependencies);
+	protected abstract T createVariant(VariantIdentifier<?> identifier, String name, VariantComponentDependencies<?> dependencies);
 
 	protected abstract VariantComponentDependencies<?> newDependencies(NamingScheme names, BuildVariantInternal buildVariant);
 
@@ -162,7 +162,7 @@ public abstract class BaseNativeComponent<T extends VariantInternal> extends Bas
 			final VariantIdentifier<T> variantIdentifier = VariantIdentifier.builder().withUnambiguousNameFromBuildVariants(buildVariant, getBuildVariants().get()).withComponentIdentifier(getIdentifier()).withType(variantType).build();
 
 			val dependencies = newDependencies(names.withComponentDisplayName(getIdentifier().getDisplayName()), buildVariant);
-			VariantProvider<T> variant = getVariantCollection().registerVariant(variantIdentifier, (name, bv) -> createVariant(variantIdentifier, name, bv, dependencies));
+			VariantProvider<T> variant = getVariantCollection().registerVariant(variantIdentifier, (name, bv) -> createVariant(variantIdentifier, name, dependencies));
 
 			onEachVariantDependencies(variant, dependencies);
 		});

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeComponent.java
@@ -81,7 +81,7 @@ public abstract class BaseNativeComponent<T extends VariantInternal> extends Bas
 		return result;
 	}
 
-	protected abstract T createVariant(String name, BuildVariantInternal buildVariant, VariantComponentDependencies<?> dependencies);
+	protected abstract T createVariant(VariantIdentifier<?> identifier, String name, BuildVariantInternal buildVariant, VariantComponentDependencies<?> dependencies);
 
 	protected abstract VariantComponentDependencies<?> newDependencies(NamingScheme names, BuildVariantInternal buildVariant);
 
@@ -162,7 +162,7 @@ public abstract class BaseNativeComponent<T extends VariantInternal> extends Bas
 			final VariantIdentifier<T> variantIdentifier = VariantIdentifier.builder().withUnambiguousNameFromBuildVariants(buildVariant, getBuildVariants().get()).withComponentIdentifier(getIdentifier()).withType(variantType).build();
 
 			val dependencies = newDependencies(names.withComponentDisplayName(getIdentifier().getDisplayName()), buildVariant);
-			VariantProvider<T> variant = getVariantCollection().registerVariant(variantIdentifier, (name, bv) -> createVariant(name, bv, dependencies));
+			VariantProvider<T> variant = getVariantCollection().registerVariant(variantIdentifier, (name, bv) -> createVariant(variantIdentifier, name, bv, dependencies));
 
 			onEachVariantDependencies(variant, dependencies);
 		});

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeComponent.java
@@ -81,7 +81,7 @@ public abstract class BaseNativeComponent<T extends VariantInternal> extends Bas
 		return result;
 	}
 
-	protected abstract T createVariant(VariantIdentifier<?> identifier, String name, VariantComponentDependencies<?> dependencies);
+	protected abstract T createVariant(VariantIdentifier<?> identifier, VariantComponentDependencies<?> dependencies);
 
 	protected abstract VariantComponentDependencies<?> newDependencies(NamingScheme names, BuildVariantInternal buildVariant);
 
@@ -162,7 +162,7 @@ public abstract class BaseNativeComponent<T extends VariantInternal> extends Bas
 			final VariantIdentifier<T> variantIdentifier = VariantIdentifier.builder().withUnambiguousNameFromBuildVariants(buildVariant, getBuildVariants().get()).withComponentIdentifier(getIdentifier()).withType(variantType).build();
 
 			val dependencies = newDependencies(names.withComponentDisplayName(getIdentifier().getDisplayName()), buildVariant);
-			VariantProvider<T> variant = getVariantCollection().registerVariant(variantIdentifier, (name, bv) -> createVariant(variantIdentifier, name, dependencies));
+			VariantProvider<T> variant = getVariantCollection().registerVariant(variantIdentifier, (name, bv) -> createVariant(variantIdentifier, dependencies));
 
 			onEachVariantDependencies(variant, dependencies);
 		});

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeVariant.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeVariant.java
@@ -1,20 +1,16 @@
 package dev.nokee.platform.nativebase.internal;
 
-import com.google.common.base.Preconditions;
-import dev.nokee.platform.base.Binary;
 import dev.nokee.platform.base.internal.BaseVariant;
 import dev.nokee.platform.base.internal.NamingScheme;
 import dev.nokee.platform.base.internal.VariantIdentifier;
+import dev.nokee.platform.nativebase.internal.rules.NativeDevelopmentBinaryConvention;
 import lombok.AccessLevel;
 import lombok.Getter;
 import org.gradle.api.Task;
 import org.gradle.api.model.ObjectFactory;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
-
-import java.util.Iterator;
 
 public class BaseNativeVariant extends BaseVariant {
 	@Getter private final NamingScheme names;
@@ -27,32 +23,10 @@ public class BaseNativeVariant extends BaseVariant {
 		this.tasks = tasks;
 		this.providers = providers;
 
-		getDevelopmentBinary().convention(getDefaultBinary());
+		getDevelopmentBinary().convention(getBinaries().getElements().flatMap(NativeDevelopmentBinaryConvention.of(getBuildVariant().getAxisValue(DefaultBinaryLinkage.DIMENSION_TYPE))));
 	}
 
 	public TaskProvider<Task> getAssembleTask() {
 		return getTasks().named(names.getTaskName("assemble"));
-	}
-
-	protected Provider<Binary> getDefaultBinary() {
-		return getProviders().provider(() -> {
-			DefaultBinaryLinkage linkage = getBuildVariant().getAxisValue(DefaultBinaryLinkage.DIMENSION_TYPE);
-			if (linkage.equals(DefaultBinaryLinkage.EXECUTABLE)) {
-				return one(getBinaryCollection().withType(ExecutableBinaryInternal.class));
-			} else if (linkage.equals(DefaultBinaryLinkage.SHARED)) {
-				return one(getBinaryCollection().withType(SharedLibraryBinaryInternal.class));
-			} else if (linkage.equals(DefaultBinaryLinkage.STATIC)) {
-				return one(getBinaryCollection().withType(StaticLibraryBinaryInternal.class));
-			}
-			return null;
-		});
-	}
-
-	protected static <T> T one(Iterable<T> c) {
-		Iterator<T> iterator = c.iterator();
-		Preconditions.checkArgument(iterator.hasNext(), "collection needs to have one element, was empty");
-		T result = iterator.next();
-		Preconditions.checkArgument(!iterator.hasNext(), "collection needs to only have one element, more than one element found");
-		return result;
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeVariant.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeVariant.java
@@ -21,8 +21,8 @@ public class BaseNativeVariant extends BaseVariant {
 	@Getter(AccessLevel.PROTECTED) private final TaskContainer tasks;
 	@Getter(AccessLevel.PROTECTED) private final ProviderFactory providers;
 
-	public BaseNativeVariant(VariantIdentifier<?> identifier, String name, NamingScheme names, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
-		super(identifier, name, objects);
+	public BaseNativeVariant(VariantIdentifier<?> identifier, NamingScheme names, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
+		super(identifier, objects);
 		this.names = names;
 		this.tasks = tasks;
 		this.providers = providers;

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeVariant.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeVariant.java
@@ -3,7 +3,6 @@ package dev.nokee.platform.nativebase.internal;
 import com.google.common.base.Preconditions;
 import dev.nokee.platform.base.Binary;
 import dev.nokee.platform.base.internal.BaseVariant;
-import dev.nokee.platform.base.internal.BuildVariantInternal;
 import dev.nokee.platform.base.internal.NamingScheme;
 import dev.nokee.platform.base.internal.VariantIdentifier;
 import lombok.AccessLevel;
@@ -22,8 +21,8 @@ public class BaseNativeVariant extends BaseVariant {
 	@Getter(AccessLevel.PROTECTED) private final TaskContainer tasks;
 	@Getter(AccessLevel.PROTECTED) private final ProviderFactory providers;
 
-	public BaseNativeVariant(VariantIdentifier<?> identifier, String name, NamingScheme names, BuildVariantInternal buildVariant, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
-		super(identifier, name, buildVariant, objects);
+	public BaseNativeVariant(VariantIdentifier<?> identifier, String name, NamingScheme names, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
+		super(identifier, name, objects);
 		this.names = names;
 		this.tasks = tasks;
 		this.providers = providers;

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeVariant.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeVariant.java
@@ -5,6 +5,7 @@ import dev.nokee.platform.base.Binary;
 import dev.nokee.platform.base.internal.BaseVariant;
 import dev.nokee.platform.base.internal.BuildVariantInternal;
 import dev.nokee.platform.base.internal.NamingScheme;
+import dev.nokee.platform.base.internal.VariantIdentifier;
 import lombok.AccessLevel;
 import lombok.Getter;
 import org.gradle.api.Task;
@@ -21,8 +22,8 @@ public class BaseNativeVariant extends BaseVariant {
 	@Getter(AccessLevel.PROTECTED) private final TaskContainer tasks;
 	@Getter(AccessLevel.PROTECTED) private final ProviderFactory providers;
 
-	public BaseNativeVariant(String name, NamingScheme names, BuildVariantInternal buildVariant, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
-		super(name, buildVariant, objects);
+	public BaseNativeVariant(VariantIdentifier<?> identifier, String name, NamingScheme names, BuildVariantInternal buildVariant, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
+		super(identifier, name, buildVariant, objects);
 		this.names = names;
 		this.tasks = tasks;
 		this.providers = providers;

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationComponent.java
@@ -6,10 +6,7 @@ import dev.nokee.model.DomainObjectFactory;
 import dev.nokee.platform.base.BinaryAwareComponent;
 import dev.nokee.platform.base.Component;
 import dev.nokee.platform.base.DependencyAwareComponent;
-import dev.nokee.platform.base.internal.BuildVariantInternal;
-import dev.nokee.platform.base.internal.ComponentIdentifier;
-import dev.nokee.platform.base.internal.NamingScheme;
-import dev.nokee.platform.base.internal.NamingSchemeFactory;
+import dev.nokee.platform.base.internal.*;
 import dev.nokee.platform.base.internal.dependencies.ConfigurationFactories;
 import dev.nokee.platform.base.internal.dependencies.DefaultComponentDependencies;
 import dev.nokee.platform.base.internal.dependencies.DefaultDependencyBucketFactory;
@@ -77,10 +74,10 @@ public class DefaultNativeApplicationComponent extends BaseNativeComponent<Defau
 	}
 
 	@Override
-	protected DefaultNativeApplicationVariant createVariant(String name, BuildVariantInternal buildVariant, VariantComponentDependencies<?> variantDependencies) {
+	protected DefaultNativeApplicationVariant createVariant(VariantIdentifier<?> identifier, String name, BuildVariantInternal buildVariant, VariantComponentDependencies<?> variantDependencies) {
 		NamingScheme names = getNames().forBuildVariant(buildVariant, getBuildVariants().get());
 
-		DefaultNativeApplicationVariant result = getObjects().newInstance(DefaultNativeApplicationVariant.class, name, names, buildVariant, variantDependencies);
+		DefaultNativeApplicationVariant result = getObjects().newInstance(DefaultNativeApplicationVariant.class, identifier, name, names, buildVariant, variantDependencies);
 		return result;
 	}
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationComponent.java
@@ -74,10 +74,11 @@ public class DefaultNativeApplicationComponent extends BaseNativeComponent<Defau
 	}
 
 	@Override
-	protected DefaultNativeApplicationVariant createVariant(VariantIdentifier<?> identifier, String name, BuildVariantInternal buildVariant, VariantComponentDependencies<?> variantDependencies) {
+	protected DefaultNativeApplicationVariant createVariant(VariantIdentifier<?> identifier, String name, VariantComponentDependencies<?> variantDependencies) {
+		val buildVariant = (BuildVariantInternal) identifier.getBuildVariant();
 		NamingScheme names = getNames().forBuildVariant(buildVariant, getBuildVariants().get());
 
-		DefaultNativeApplicationVariant result = getObjects().newInstance(DefaultNativeApplicationVariant.class, identifier, name, names, buildVariant, variantDependencies);
+		DefaultNativeApplicationVariant result = getObjects().newInstance(DefaultNativeApplicationVariant.class, identifier, name, names, variantDependencies);
 		return result;
 	}
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationComponent.java
@@ -7,6 +7,7 @@ import dev.nokee.platform.base.BinaryAwareComponent;
 import dev.nokee.platform.base.Component;
 import dev.nokee.platform.base.DependencyAwareComponent;
 import dev.nokee.platform.base.internal.BuildVariantInternal;
+import dev.nokee.platform.base.internal.ComponentIdentifier;
 import dev.nokee.platform.base.internal.NamingScheme;
 import dev.nokee.platform.base.internal.NamingSchemeFactory;
 import dev.nokee.platform.base.internal.dependencies.ConfigurationFactories;
@@ -35,8 +36,8 @@ public class DefaultNativeApplicationComponent extends BaseNativeComponent<Defau
 	@Getter(AccessLevel.PROTECTED) private final DependencyHandler dependencyHandler;
 
 	@Inject
-	public DefaultNativeApplicationComponent(NamingScheme names, ObjectFactory objects, ProviderFactory providers, TaskContainer tasks, ProjectLayout layout, ConfigurationContainer configurations, DependencyHandler dependencyHandler) {
-		super(names, DefaultNativeApplicationVariant.class, objects, providers, tasks, layout, configurations);
+	public DefaultNativeApplicationComponent(ComponentIdentifier<DefaultNativeApplicationComponent> identifier, NamingScheme names, ObjectFactory objects, ProviderFactory providers, TaskContainer tasks, ProjectLayout layout, ConfigurationContainer configurations, DependencyHandler dependencyHandler) {
+		super(identifier, names, DefaultNativeApplicationVariant.class, objects, providers, tasks, layout, configurations);
 		this.dependencyHandler = dependencyHandler;
 		val dependencyContainer = objects.newInstance(DefaultComponentDependencies.class, names.getComponentDisplayName(), new FrameworkAwareDependencyBucketFactory(new DefaultDependencyBucketFactory(new ConfigurationFactories.Prefixing(new ConfigurationFactories.Creating(getConfigurations()), names::getConfigurationName), new DefaultDependencyFactory(getDependencyHandler()))));
 		this.dependencies = objects.newInstance(DefaultNativeApplicationComponentDependencies.class, dependencyContainer);
@@ -86,7 +87,7 @@ public class DefaultNativeApplicationComponent extends BaseNativeComponent<Defau
 	public static DomainObjectFactory<DefaultNativeApplicationComponent> newFactory(ObjectFactory objects, NamingSchemeFactory namingSchemeFactory) {
 		return identifier -> {
 			NamingScheme names = namingSchemeFactory.forMainComponent().withComponentDisplayName("main native component");
-			return objects.newInstance(DefaultNativeApplicationComponent.class, names);
+			return objects.newInstance(DefaultNativeApplicationComponent.class, identifier, names);
 		};
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationComponent.java
@@ -74,11 +74,11 @@ public class DefaultNativeApplicationComponent extends BaseNativeComponent<Defau
 	}
 
 	@Override
-	protected DefaultNativeApplicationVariant createVariant(VariantIdentifier<?> identifier, String name, VariantComponentDependencies<?> variantDependencies) {
+	protected DefaultNativeApplicationVariant createVariant(VariantIdentifier<?> identifier, VariantComponentDependencies<?> variantDependencies) {
 		val buildVariant = (BuildVariantInternal) identifier.getBuildVariant();
 		NamingScheme names = getNames().forBuildVariant(buildVariant, getBuildVariants().get());
 
-		DefaultNativeApplicationVariant result = getObjects().newInstance(DefaultNativeApplicationVariant.class, identifier, name, names, variantDependencies);
+		DefaultNativeApplicationVariant result = getObjects().newInstance(DefaultNativeApplicationVariant.class, identifier, names, variantDependencies);
 		return result;
 	}
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationComponent.java
@@ -36,7 +36,7 @@ public class DefaultNativeApplicationComponent extends BaseNativeComponent<Defau
 	@Getter(AccessLevel.PROTECTED) private final DependencyHandler dependencyHandler;
 
 	@Inject
-	public DefaultNativeApplicationComponent(ComponentIdentifier<DefaultNativeApplicationComponent> identifier, NamingScheme names, ObjectFactory objects, ProviderFactory providers, TaskContainer tasks, ProjectLayout layout, ConfigurationContainer configurations, DependencyHandler dependencyHandler) {
+	public DefaultNativeApplicationComponent(ComponentIdentifier<?> identifier, NamingScheme names, ObjectFactory objects, ProviderFactory providers, TaskContainer tasks, ProjectLayout layout, ConfigurationContainer configurations, DependencyHandler dependencyHandler) {
 		super(identifier, names, DefaultNativeApplicationVariant.class, objects, providers, tasks, layout, configurations);
 		this.dependencyHandler = dependencyHandler;
 		val dependencyContainer = objects.newInstance(DefaultComponentDependencies.class, names.getComponentDisplayName(), new FrameworkAwareDependencyBucketFactory(new DefaultDependencyBucketFactory(new ConfigurationFactories.Prefixing(new ConfigurationFactories.Creating(getConfigurations()), names::getConfigurationName), new DefaultDependencyFactory(getDependencyHandler()))));
@@ -86,7 +86,7 @@ public class DefaultNativeApplicationComponent extends BaseNativeComponent<Defau
 
 	public static DomainObjectFactory<DefaultNativeApplicationComponent> newFactory(ObjectFactory objects, NamingSchemeFactory namingSchemeFactory) {
 		return identifier -> {
-			NamingScheme names = namingSchemeFactory.forMainComponent().withComponentDisplayName("main native component");
+			NamingScheme names = namingSchemeFactory.forMainComponent().withComponentDisplayName(((ComponentIdentifier<?>)identifier).getDisplayName());
 			return objects.newInstance(DefaultNativeApplicationComponent.class, identifier, names);
 		};
 	}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationVariant.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationVariant.java
@@ -1,6 +1,5 @@
 package dev.nokee.platform.nativebase.internal;
 
-import dev.nokee.platform.base.internal.BuildVariantInternal;
 import dev.nokee.platform.base.internal.NamingScheme;
 import dev.nokee.platform.base.internal.VariantIdentifier;
 import dev.nokee.platform.base.internal.VariantInternal;
@@ -20,8 +19,8 @@ public class DefaultNativeApplicationVariant extends BaseNativeVariant implement
 	@Getter private final ResolvableComponentDependencies resolvableDependencies;
 
 	@Inject
-	public DefaultNativeApplicationVariant(VariantIdentifier<DefaultNativeApplicationVariant> identifier, String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<DefaultNativeApplicationComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
-		super(identifier, name, names, buildVariant, objects, tasks, providers);
+	public DefaultNativeApplicationVariant(VariantIdentifier<DefaultNativeApplicationVariant> identifier, String name, NamingScheme names, VariantComponentDependencies<DefaultNativeApplicationComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
+		super(identifier, name, names, objects, tasks, providers);
 		this.dependencies = dependencies.getDependencies();
 		this.resolvableDependencies = dependencies.getIncoming();
 	}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationVariant.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationVariant.java
@@ -3,12 +3,11 @@ package dev.nokee.platform.nativebase.internal;
 import dev.nokee.platform.base.internal.BuildVariantInternal;
 import dev.nokee.platform.base.internal.NamingScheme;
 import dev.nokee.platform.base.internal.VariantInternal;
+import dev.nokee.platform.base.internal.dependencies.ResolvableComponentDependencies;
 import dev.nokee.platform.nativebase.NativeApplication;
-import dev.nokee.platform.nativebase.NativeApplicationComponentDependencies;
 import dev.nokee.platform.nativebase.internal.dependencies.DefaultNativeApplicationComponentDependencies;
 import dev.nokee.platform.nativebase.internal.dependencies.VariantComponentDependencies;
 import lombok.Getter;
-import org.gradle.api.Action;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.TaskContainer;
@@ -17,10 +16,12 @@ import javax.inject.Inject;
 
 public class DefaultNativeApplicationVariant extends BaseNativeVariant implements NativeApplication, VariantInternal {
 	@Getter private final DefaultNativeApplicationComponentDependencies dependencies;
+	@Getter private final ResolvableComponentDependencies resolvableDependencies;
 
 	@Inject
 	public DefaultNativeApplicationVariant(String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<DefaultNativeApplicationComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
 		super(name, names, buildVariant, objects, tasks, providers);
 		this.dependencies = dependencies.getDependencies();
+		this.resolvableDependencies = dependencies.getIncoming();
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationVariant.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationVariant.java
@@ -19,8 +19,8 @@ public class DefaultNativeApplicationVariant extends BaseNativeVariant implement
 	@Getter private final ResolvableComponentDependencies resolvableDependencies;
 
 	@Inject
-	public DefaultNativeApplicationVariant(VariantIdentifier<DefaultNativeApplicationVariant> identifier, String name, NamingScheme names, VariantComponentDependencies<DefaultNativeApplicationComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
-		super(identifier, name, names, objects, tasks, providers);
+	public DefaultNativeApplicationVariant(VariantIdentifier<DefaultNativeApplicationVariant> identifier, NamingScheme names, VariantComponentDependencies<DefaultNativeApplicationComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
+		super(identifier, names, objects, tasks, providers);
 		this.dependencies = dependencies.getDependencies();
 		this.resolvableDependencies = dependencies.getIncoming();
 	}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationVariant.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationVariant.java
@@ -2,6 +2,7 @@ package dev.nokee.platform.nativebase.internal;
 
 import dev.nokee.platform.base.internal.BuildVariantInternal;
 import dev.nokee.platform.base.internal.NamingScheme;
+import dev.nokee.platform.base.internal.VariantIdentifier;
 import dev.nokee.platform.base.internal.VariantInternal;
 import dev.nokee.platform.base.internal.dependencies.ResolvableComponentDependencies;
 import dev.nokee.platform.nativebase.NativeApplication;
@@ -19,8 +20,8 @@ public class DefaultNativeApplicationVariant extends BaseNativeVariant implement
 	@Getter private final ResolvableComponentDependencies resolvableDependencies;
 
 	@Inject
-	public DefaultNativeApplicationVariant(String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<DefaultNativeApplicationComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
-		super(name, names, buildVariant, objects, tasks, providers);
+	public DefaultNativeApplicationVariant(VariantIdentifier<DefaultNativeApplicationVariant> identifier, String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<DefaultNativeApplicationComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
+		super(identifier, name, names, buildVariant, objects, tasks, providers);
 		this.dependencies = dependencies.getDependencies();
 		this.resolvableDependencies = dependencies.getIncoming();
 	}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryComponent.java
@@ -36,7 +36,7 @@ public class DefaultNativeLibraryComponent extends BaseNativeComponent<DefaultNa
 	@Getter(AccessLevel.PROTECTED) private final DependencyHandler dependencyHandler;
 
 	@Inject
-	public DefaultNativeLibraryComponent(ComponentIdentifier<DefaultNativeLibraryComponent> identifier, NamingScheme names, ObjectFactory objects, ProviderFactory providers, TaskContainer tasks, ProjectLayout layout, ConfigurationContainer configurations, DependencyHandler dependencyHandler) {
+	public DefaultNativeLibraryComponent(ComponentIdentifier<?> identifier, NamingScheme names, ObjectFactory objects, ProviderFactory providers, TaskContainer tasks, ProjectLayout layout, ConfigurationContainer configurations, DependencyHandler dependencyHandler) {
 		super(identifier, names, DefaultNativeLibraryVariant.class, objects, providers, tasks, layout, configurations);
 		this.dependencyHandler = dependencyHandler;
 		val dependencyContainer = objects.newInstance(DefaultComponentDependencies.class, names.getComponentDisplayName(), new FrameworkAwareDependencyBucketFactory(new DefaultDependencyBucketFactory(new ConfigurationFactories.Prefixing(new ConfigurationFactories.Creating(getConfigurations()), names::getConfigurationName), new DefaultDependencyFactory(getDependencyHandler()))));
@@ -92,7 +92,7 @@ public class DefaultNativeLibraryComponent extends BaseNativeComponent<DefaultNa
 
 	public static DomainObjectFactory<DefaultNativeLibraryComponent> newFactory(ObjectFactory objects, NamingSchemeFactory namingSchemeFactory) {
 		return identifier -> {
-			NamingScheme names = namingSchemeFactory.forMainComponent().withComponentDisplayName("main native component");
+			NamingScheme names = namingSchemeFactory.forMainComponent().withComponentDisplayName(((ComponentIdentifier<?>)identifier).getDisplayName());
 			return objects.newInstance(DefaultNativeLibraryComponent.class, identifier, names);
 		};
 	}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryComponent.java
@@ -7,6 +7,7 @@ import dev.nokee.platform.base.BinaryAwareComponent;
 import dev.nokee.platform.base.Component;
 import dev.nokee.platform.base.DependencyAwareComponent;
 import dev.nokee.platform.base.internal.BuildVariantInternal;
+import dev.nokee.platform.base.internal.ComponentIdentifier;
 import dev.nokee.platform.base.internal.NamingScheme;
 import dev.nokee.platform.base.internal.NamingSchemeFactory;
 import dev.nokee.platform.base.internal.dependencies.ConfigurationFactories;
@@ -35,8 +36,8 @@ public class DefaultNativeLibraryComponent extends BaseNativeComponent<DefaultNa
 	@Getter(AccessLevel.PROTECTED) private final DependencyHandler dependencyHandler;
 
 	@Inject
-	public DefaultNativeLibraryComponent(NamingScheme names, ObjectFactory objects, ProviderFactory providers, TaskContainer tasks, ProjectLayout layout, ConfigurationContainer configurations, DependencyHandler dependencyHandler) {
-		super(names, DefaultNativeLibraryVariant.class, objects, providers, tasks, layout, configurations);
+	public DefaultNativeLibraryComponent(ComponentIdentifier<DefaultNativeLibraryComponent> identifier, NamingScheme names, ObjectFactory objects, ProviderFactory providers, TaskContainer tasks, ProjectLayout layout, ConfigurationContainer configurations, DependencyHandler dependencyHandler) {
+		super(identifier, names, DefaultNativeLibraryVariant.class, objects, providers, tasks, layout, configurations);
 		this.dependencyHandler = dependencyHandler;
 		val dependencyContainer = objects.newInstance(DefaultComponentDependencies.class, names.getComponentDisplayName(), new FrameworkAwareDependencyBucketFactory(new DefaultDependencyBucketFactory(new ConfigurationFactories.Prefixing(new ConfigurationFactories.Creating(getConfigurations()), names::getConfigurationName), new DefaultDependencyFactory(getDependencyHandler()))));
 		this.dependencies = objects.newInstance(DefaultNativeLibraryComponentDependencies.class, dependencyContainer);
@@ -92,7 +93,7 @@ public class DefaultNativeLibraryComponent extends BaseNativeComponent<DefaultNa
 	public static DomainObjectFactory<DefaultNativeLibraryComponent> newFactory(ObjectFactory objects, NamingSchemeFactory namingSchemeFactory) {
 		return identifier -> {
 			NamingScheme names = namingSchemeFactory.forMainComponent().withComponentDisplayName("main native component");
-			return objects.newInstance(DefaultNativeLibraryComponent.class, names);
+			return objects.newInstance(DefaultNativeLibraryComponent.class, identifier, names);
 		};
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryComponent.java
@@ -80,10 +80,11 @@ public class DefaultNativeLibraryComponent extends BaseNativeComponent<DefaultNa
 	}
 
 	@Override
-	protected DefaultNativeLibraryVariant createVariant(VariantIdentifier<?> identifier, String name, BuildVariantInternal buildVariant, VariantComponentDependencies<?> variantDependencies) {
+	protected DefaultNativeLibraryVariant createVariant(VariantIdentifier<?> identifier, String name, VariantComponentDependencies<?> variantDependencies) {
+		val buildVariant = (BuildVariantInternal) identifier.getBuildVariant();
 		NamingScheme names = getNames().forBuildVariant(buildVariant, getBuildVariants().get());
 
-		DefaultNativeLibraryVariant result = getObjects().newInstance(DefaultNativeLibraryVariant.class, identifier, name, names, buildVariant, variantDependencies);
+		DefaultNativeLibraryVariant result = getObjects().newInstance(DefaultNativeLibraryVariant.class, identifier, name, names, variantDependencies);
 		return result;
 	}
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryComponent.java
@@ -80,11 +80,11 @@ public class DefaultNativeLibraryComponent extends BaseNativeComponent<DefaultNa
 	}
 
 	@Override
-	protected DefaultNativeLibraryVariant createVariant(VariantIdentifier<?> identifier, String name, VariantComponentDependencies<?> variantDependencies) {
+	protected DefaultNativeLibraryVariant createVariant(VariantIdentifier<?> identifier, VariantComponentDependencies<?> variantDependencies) {
 		val buildVariant = (BuildVariantInternal) identifier.getBuildVariant();
 		NamingScheme names = getNames().forBuildVariant(buildVariant, getBuildVariants().get());
 
-		DefaultNativeLibraryVariant result = getObjects().newInstance(DefaultNativeLibraryVariant.class, identifier, name, names, variantDependencies);
+		DefaultNativeLibraryVariant result = getObjects().newInstance(DefaultNativeLibraryVariant.class, identifier, names, variantDependencies);
 		return result;
 	}
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryComponent.java
@@ -6,10 +6,7 @@ import dev.nokee.model.DomainObjectFactory;
 import dev.nokee.platform.base.BinaryAwareComponent;
 import dev.nokee.platform.base.Component;
 import dev.nokee.platform.base.DependencyAwareComponent;
-import dev.nokee.platform.base.internal.BuildVariantInternal;
-import dev.nokee.platform.base.internal.ComponentIdentifier;
-import dev.nokee.platform.base.internal.NamingScheme;
-import dev.nokee.platform.base.internal.NamingSchemeFactory;
+import dev.nokee.platform.base.internal.*;
 import dev.nokee.platform.base.internal.dependencies.ConfigurationFactories;
 import dev.nokee.platform.base.internal.dependencies.DefaultComponentDependencies;
 import dev.nokee.platform.base.internal.dependencies.DefaultDependencyBucketFactory;
@@ -83,10 +80,10 @@ public class DefaultNativeLibraryComponent extends BaseNativeComponent<DefaultNa
 	}
 
 	@Override
-	protected DefaultNativeLibraryVariant createVariant(String name, BuildVariantInternal buildVariant, VariantComponentDependencies<?> variantDependencies) {
+	protected DefaultNativeLibraryVariant createVariant(VariantIdentifier<?> identifier, String name, BuildVariantInternal buildVariant, VariantComponentDependencies<?> variantDependencies) {
 		NamingScheme names = getNames().forBuildVariant(buildVariant, getBuildVariants().get());
 
-		DefaultNativeLibraryVariant result = getObjects().newInstance(DefaultNativeLibraryVariant.class, name, names, buildVariant, variantDependencies);
+		DefaultNativeLibraryVariant result = getObjects().newInstance(DefaultNativeLibraryVariant.class, identifier, name, names, buildVariant, variantDependencies);
 		return result;
 	}
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryVariant.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryVariant.java
@@ -3,13 +3,12 @@ package dev.nokee.platform.nativebase.internal;
 import dev.nokee.platform.base.internal.BuildVariantInternal;
 import dev.nokee.platform.base.internal.NamingScheme;
 import dev.nokee.platform.base.internal.VariantInternal;
+import dev.nokee.platform.base.internal.dependencies.ResolvableComponentDependencies;
 import dev.nokee.platform.nativebase.NativeLibrary;
-import dev.nokee.platform.nativebase.NativeLibraryComponentDependencies;
 import dev.nokee.platform.nativebase.internal.dependencies.DefaultNativeLibraryComponentDependencies;
 import dev.nokee.platform.nativebase.internal.dependencies.VariantComponentDependencies;
 import lombok.AccessLevel;
 import lombok.Getter;
-import org.gradle.api.Action;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ProviderFactory;
@@ -20,11 +19,13 @@ import javax.inject.Inject;
 public class DefaultNativeLibraryVariant extends BaseNativeVariant implements NativeLibrary, VariantInternal {
 	@Getter private final DefaultNativeLibraryComponentDependencies dependencies;
 	@Getter(AccessLevel.PROTECTED) private final ProjectLayout layout;
+	@Getter private final ResolvableComponentDependencies resolvableDependencies;
 
 	@Inject
 	public DefaultNativeLibraryVariant(String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<DefaultNativeLibraryComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers, ProjectLayout layout) {
 		super(name, names, buildVariant, objects, tasks, providers);
 		this.dependencies = dependencies.getDependencies();
 		this.layout = layout;
+		this.resolvableDependencies = dependencies.getIncoming();
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryVariant.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryVariant.java
@@ -2,6 +2,7 @@ package dev.nokee.platform.nativebase.internal;
 
 import dev.nokee.platform.base.internal.BuildVariantInternal;
 import dev.nokee.platform.base.internal.NamingScheme;
+import dev.nokee.platform.base.internal.VariantIdentifier;
 import dev.nokee.platform.base.internal.VariantInternal;
 import dev.nokee.platform.base.internal.dependencies.ResolvableComponentDependencies;
 import dev.nokee.platform.nativebase.NativeLibrary;
@@ -22,8 +23,8 @@ public class DefaultNativeLibraryVariant extends BaseNativeVariant implements Na
 	@Getter private final ResolvableComponentDependencies resolvableDependencies;
 
 	@Inject
-	public DefaultNativeLibraryVariant(String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<DefaultNativeLibraryComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers, ProjectLayout layout) {
-		super(name, names, buildVariant, objects, tasks, providers);
+	public DefaultNativeLibraryVariant(VariantIdentifier<DefaultNativeLibraryVariant> identifier, String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<DefaultNativeLibraryComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers, ProjectLayout layout) {
+		super(identifier, name, names, buildVariant, objects, tasks, providers);
 		this.dependencies = dependencies.getDependencies();
 		this.layout = layout;
 		this.resolvableDependencies = dependencies.getIncoming();

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryVariant.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryVariant.java
@@ -22,8 +22,8 @@ public class DefaultNativeLibraryVariant extends BaseNativeVariant implements Na
 	@Getter private final ResolvableComponentDependencies resolvableDependencies;
 
 	@Inject
-	public DefaultNativeLibraryVariant(VariantIdentifier<DefaultNativeLibraryVariant> identifier, String name, NamingScheme names, VariantComponentDependencies<DefaultNativeLibraryComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers, ProjectLayout layout) {
-		super(identifier, name, names, objects, tasks, providers);
+	public DefaultNativeLibraryVariant(VariantIdentifier<DefaultNativeLibraryVariant> identifier, NamingScheme names, VariantComponentDependencies<DefaultNativeLibraryComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers, ProjectLayout layout) {
+		super(identifier, names, objects, tasks, providers);
 		this.dependencies = dependencies.getDependencies();
 		this.layout = layout;
 		this.resolvableDependencies = dependencies.getIncoming();

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryVariant.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryVariant.java
@@ -1,6 +1,5 @@
 package dev.nokee.platform.nativebase.internal;
 
-import dev.nokee.platform.base.internal.BuildVariantInternal;
 import dev.nokee.platform.base.internal.NamingScheme;
 import dev.nokee.platform.base.internal.VariantIdentifier;
 import dev.nokee.platform.base.internal.VariantInternal;
@@ -23,8 +22,8 @@ public class DefaultNativeLibraryVariant extends BaseNativeVariant implements Na
 	@Getter private final ResolvableComponentDependencies resolvableDependencies;
 
 	@Inject
-	public DefaultNativeLibraryVariant(VariantIdentifier<DefaultNativeLibraryVariant> identifier, String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<DefaultNativeLibraryComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers, ProjectLayout layout) {
-		super(identifier, name, names, buildVariant, objects, tasks, providers);
+	public DefaultNativeLibraryVariant(VariantIdentifier<DefaultNativeLibraryVariant> identifier, String name, NamingScheme names, VariantComponentDependencies<DefaultNativeLibraryComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers, ProjectLayout layout) {
+		super(identifier, name, names, objects, tasks, providers);
 		this.dependencies = dependencies.getDependencies();
 		this.layout = layout;
 		this.resolvableDependencies = dependencies.getIncoming();

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/dependencies/NativeIncomingDependencies.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/dependencies/NativeIncomingDependencies.java
@@ -1,8 +1,9 @@
 package dev.nokee.platform.nativebase.internal.dependencies;
 
+import dev.nokee.platform.base.internal.dependencies.ResolvableComponentDependencies;
 import org.gradle.api.file.FileCollection;
 
-public interface NativeIncomingDependencies {
+public interface NativeIncomingDependencies extends ResolvableComponentDependencies {
 	FileCollection getHeaderSearchPaths();
 	FileCollection getFrameworkSearchPaths();
 	FileCollection getSwiftModules();

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/rules/NativeDevelopmentBinaryConvention.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/rules/NativeDevelopmentBinaryConvention.java
@@ -1,0 +1,39 @@
+package dev.nokee.platform.nativebase.internal.rules;
+
+import dev.nokee.platform.base.Binary;
+import dev.nokee.platform.nativebase.ExecutableBinary;
+import dev.nokee.platform.nativebase.SharedLibraryBinary;
+import dev.nokee.platform.nativebase.StaticLibraryBinary;
+import dev.nokee.platform.nativebase.internal.DefaultBinaryLinkage;
+import org.gradle.api.Transformer;
+import org.gradle.api.provider.Provider;
+
+import static dev.nokee.platform.base.internal.DevelopmentBinaryUtils.selectSingleBinaryByType;
+
+public enum NativeDevelopmentBinaryConvention implements Transformer<Provider<? extends Binary>, Iterable<? extends Binary>> {
+	EXECUTABLE(ExecutableBinary.class),
+	SHARED(SharedLibraryBinary.class),
+	STATIC(StaticLibraryBinary.class);
+
+	private final Class<? extends Binary> binaryTypeToSelect;
+
+	NativeDevelopmentBinaryConvention(Class<? extends Binary> binaryTypeToSelect) {
+		this.binaryTypeToSelect = binaryTypeToSelect;
+	}
+
+	@Override
+	public Provider<? extends Binary> transform(Iterable<? extends Binary> binaries) {
+		return selectSingleBinaryByType(binaryTypeToSelect, binaries);
+	}
+
+	public static NativeDevelopmentBinaryConvention of(DefaultBinaryLinkage linkage) {
+		if (linkage.isExecutable()) {
+			return EXECUTABLE;
+		} else if (linkage.isShared()) {
+			return SHARED;
+		} else if (linkage.isStatic()) {
+			return STATIC;
+		}
+		throw new IllegalArgumentException(String.format("Unsupported binary linkage '%s' for native development binary convention", linkage.getName()));
+	}
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCApplicationPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCApplicationPlugin.java
@@ -42,7 +42,7 @@ public class ObjectiveCApplicationPlugin implements Plugin<Project> {
 		project.getPluginManager().apply(ComponentBasePlugin.class);
 		val components = project.getExtensions().getByType(ComponentContainer.class);
 		components.registerFactory(DefaultObjectiveCApplicationExtension.class, id -> {
-			val identifier = ComponentIdentifier.builder().withName(((ComponentIdentifier<?>)id).getName()).withProjectIdentifier(ProjectIdentifier.of(project)).withDisplayName("main native component").withType(DefaultNativeApplicationComponent.class).build();
+			val identifier = ComponentIdentifier.of(((ComponentIdentifier<?>)id).getName(), DefaultNativeApplicationComponent.class, ProjectIdentifier.of(project));
 			val component = store.register(identifier, DefaultNativeApplicationComponent.class, newFactory(getObjects(), new NamingSchemeFactory(project.getName())));
 			return getObjects().newInstance(DefaultObjectiveCApplicationExtension.class, component.get());
 		});

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCLibraryPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCLibraryPlugin.java
@@ -43,7 +43,7 @@ public class ObjectiveCLibraryPlugin implements Plugin<Project> {
 		project.getPluginManager().apply(ComponentBasePlugin.class);
 		val components = project.getExtensions().getByType(ComponentContainer.class);
 		components.registerFactory(DefaultObjectiveCLibraryExtension.class, id -> {
-			val identifier = ComponentIdentifier.builder().withName(((ComponentIdentifier<?>)id).getName()).withProjectIdentifier(ProjectIdentifier.of(project)).withDisplayName("main native component").withType(DefaultNativeLibraryComponent.class).build();
+			val identifier = ComponentIdentifier.of(((ComponentIdentifier<?>)id).getName(), DefaultNativeLibraryComponent.class, ProjectIdentifier.of(project));
 			val component = store.register(identifier, DefaultNativeLibraryComponent.class, newFactory(getObjects(), new NamingSchemeFactory(project.getName())));
 			return getObjects().newInstance(DefaultObjectiveCLibraryExtension.class, component.get());
 		});

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/plugins/ObjectiveCppApplicationPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/plugins/ObjectiveCppApplicationPlugin.java
@@ -42,7 +42,7 @@ public class ObjectiveCppApplicationPlugin implements Plugin<Project> {
 		project.getPluginManager().apply(ComponentBasePlugin.class);
 		val components = project.getExtensions().getByType(ComponentContainer.class);
 		components.registerFactory(DefaultObjectiveCppApplicationExtension.class, id -> {
-			val identifier = ComponentIdentifier.builder().withName(((ComponentIdentifier<?>)id).getName()).withProjectIdentifier(ProjectIdentifier.of(project)).withDisplayName("main native component").withType(DefaultNativeApplicationComponent.class).build();
+			val identifier = ComponentIdentifier.of(((ComponentIdentifier<?>)id).getName(), DefaultNativeApplicationComponent.class, ProjectIdentifier.of(project));
 			val component = store.register(identifier, DefaultNativeApplicationComponent.class, newFactory(getObjects(), new NamingSchemeFactory(project.getName())));
 			return getObjects().newInstance(DefaultObjectiveCppApplicationExtension.class, component.get());
 		});

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/plugins/ObjectiveCppLibraryPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/plugins/ObjectiveCppLibraryPlugin.java
@@ -43,7 +43,7 @@ public class ObjectiveCppLibraryPlugin implements Plugin<Project> {
 		project.getPluginManager().apply(ComponentBasePlugin.class);
 		val components = project.getExtensions().getByType(ComponentContainer.class);
 		components.registerFactory(DefaultObjectiveCppLibraryExtension.class, id -> {
-			val identifier = ComponentIdentifier.builder().withName(((ComponentIdentifier<?>)id).getName()).withProjectIdentifier(ProjectIdentifier.of(project)).withDisplayName("main native component").withType(DefaultNativeLibraryComponent.class).build();
+			val identifier = ComponentIdentifier.of(((ComponentIdentifier<?>)id).getName(), DefaultNativeLibraryComponent.class, ProjectIdentifier.of(project));
 			val component = store.register(identifier, DefaultNativeLibraryComponent.class, newFactory(getObjects(), new NamingSchemeFactory(project.getName())));
 			return getObjects().newInstance(DefaultObjectiveCppLibraryExtension.class, component.get());
 		});

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftApplicationPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftApplicationPlugin.java
@@ -43,7 +43,7 @@ public class SwiftApplicationPlugin implements Plugin<Project> {
 		project.getPluginManager().apply(ComponentBasePlugin.class);
 		val components = project.getExtensions().getByType(ComponentContainer.class);
 		components.registerFactory(DefaultSwiftApplicationExtension.class, id -> {
-			val identifier = ComponentIdentifier.builder().withName(((ComponentIdentifier<?>)id).getName()).withProjectIdentifier(ProjectIdentifier.of(project)).withDisplayName("main native component").withType(DefaultNativeApplicationComponent.class).build();
+			val identifier = ComponentIdentifier.of(((ComponentIdentifier<?>)id).getName(), DefaultNativeApplicationComponent.class, ProjectIdentifier.of(project));
 			val component = store.register(identifier, DefaultNativeApplicationComponent.class, newFactory(getObjects(), new NamingSchemeFactory(project.getName())));
 			return getObjects().newInstance(DefaultSwiftApplicationExtension.class, component.get());
 		});

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftLibraryPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftLibraryPlugin.java
@@ -44,7 +44,7 @@ public class SwiftLibraryPlugin implements Plugin<Project> {
 		project.getPluginManager().apply(ComponentBasePlugin.class);
 		val components = project.getExtensions().getByType(ComponentContainer.class);
 		components.registerFactory(DefaultSwiftLibraryExtension.class, id -> {
-			val identifier = ComponentIdentifier.builder().withName(((ComponentIdentifier<?>)id).getName()).withProjectIdentifier(ProjectIdentifier.of(project)).withDisplayName("main native component").withType(DefaultNativeLibraryComponent.class).build();
+			val identifier = ComponentIdentifier.of(((ComponentIdentifier<?>)id).getName(), DefaultNativeLibraryComponent.class, ProjectIdentifier.of(project));
 			val component = store.register(identifier, DefaultNativeLibraryComponent.class, newFactory(getObjects(), new NamingSchemeFactory(project.getName())));
 			return getObjects().newInstance(DefaultSwiftLibraryExtension.class, component.get());
 		});

--- a/subprojects/platform-native/src/test/groovy/dev/nokee/platform/nativebase/internal/rules/NativeDevelopmentBinaryConventionTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/dev/nokee/platform/nativebase/internal/rules/NativeDevelopmentBinaryConventionTest.groovy
@@ -1,0 +1,129 @@
+package dev.nokee.platform.nativebase.internal.rules
+
+import dev.nokee.platform.base.Binary
+import dev.nokee.platform.nativebase.ExecutableBinary
+import dev.nokee.platform.nativebase.SharedLibraryBinary
+import dev.nokee.platform.nativebase.StaticLibraryBinary
+import dev.nokee.platform.nativebase.internal.DefaultBinaryLinkage
+import dev.nokee.utils.ProviderUtils
+import spock.lang.Specification
+
+import static dev.nokee.platform.nativebase.internal.rules.NativeDevelopmentBinaryConvention.EXECUTABLE
+import static dev.nokee.platform.nativebase.internal.rules.NativeDevelopmentBinaryConvention.SHARED
+import static dev.nokee.platform.nativebase.internal.rules.NativeDevelopmentBinaryConvention.STATIC
+import static dev.nokee.platform.nativebase.internal.rules.NativeDevelopmentBinaryConvention.of
+
+class NativeDevelopmentBinaryConventionTest extends Specification {
+	def "select EXECUTABLE convention on executable linkage"() {
+		expect:
+		of(DefaultBinaryLinkage.EXECUTABLE) == EXECUTABLE
+	}
+
+	def "select SHARED convention on shared linkage"() {
+		expect:
+		of(DefaultBinaryLinkage.SHARED) == SHARED
+	}
+
+	def "select STATIC convention on static linkage"() {
+		expect:
+		of(DefaultBinaryLinkage.STATIC) == STATIC
+	}
+
+	def "throws exception for unsupported linkage"() {
+		when:
+		of(DefaultBinaryLinkage.BUNDLE)
+
+		then:
+		def ex = thrown(IllegalArgumentException)
+		ex.message == "Unsupported binary linkage 'bundle' for native development binary convention"
+	}
+}
+
+
+abstract class AbstractNativeDevelopmentBinaryConventionTest extends Specification {
+	protected abstract NativeDevelopmentBinaryConvention newSubject()
+	protected abstract Class<? extends Binary> getDevelopmentBinaryType()
+
+	def "returns undefined provider on empty list"() {
+		expect:
+		newSubject().transform([]) == ProviderUtils.notDefined()
+	}
+
+	def "throws exception when multiple development binaries"() {
+		when:
+		newSubject().transform([Stub(developmentBinaryType), Stub(developmentBinaryType)])
+
+		then:
+		def ex = thrown(IllegalArgumentException)
+		ex.message == "expected one element but was: <Mock for type '${developmentBinaryType.simpleName}', Mock for type '${developmentBinaryType.simpleName}'>"
+	}
+
+	def "returns a provider of the single development binary list"() {
+		given:
+		def binary = Stub(developmentBinaryType)
+
+		expect:
+		def result = newSubject().transform([binary])
+		result.present
+		result.get() == binary
+	}
+
+	def "returns a provider of a multi-binary list containing one development binary"() {
+		given:
+		def binary = Stub(developmentBinaryType)
+
+		expect:
+		def result1 = newSubject().transform([binary, Stub(Binary)])
+		result1.present
+		result1.get() == binary
+
+		and:
+		def result2 = newSubject().transform([Stub(Binary), binary])
+		result2.present
+		result2.get() == binary
+
+		and:
+		def result3 = newSubject().transform([Stub(Binary), binary, Stub(Binary)])
+		result3.present
+		result3.get() == binary
+	}
+}
+
+class NativeDevelopmentBinaryConventionExecutableTest extends AbstractNativeDevelopmentBinaryConventionTest {
+
+	@Override
+	protected NativeDevelopmentBinaryConvention newSubject() {
+		return EXECUTABLE
+	}
+
+	@Override
+	protected Class<? extends Binary> getDevelopmentBinaryType() {
+		return ExecutableBinary
+	}
+}
+
+class NativeDevelopmentBinaryConventionSharedTest extends AbstractNativeDevelopmentBinaryConventionTest {
+
+	@Override
+	protected NativeDevelopmentBinaryConvention newSubject() {
+		return NativeDevelopmentBinaryConvention.SHARED
+	}
+
+	@Override
+	protected Class<? extends Binary> getDevelopmentBinaryType() {
+		return SharedLibraryBinary
+	}
+}
+
+class NativeDevelopmentBinaryConventionStaticTest extends AbstractNativeDevelopmentBinaryConventionTest {
+
+	@Override
+	protected NativeDevelopmentBinaryConvention newSubject() {
+		return NativeDevelopmentBinaryConvention.STATIC
+	}
+
+	@Override
+	protected Class<? extends Binary> getDevelopmentBinaryType() {
+		return StaticLibraryBinary
+	}
+}

--- a/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteComponent.java
+++ b/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteComponent.java
@@ -140,10 +140,11 @@ public class DefaultNativeTestSuiteComponent extends BaseNativeComponent<Default
 	}
 
 	@Override
-	protected DefaultNativeTestSuiteVariant createVariant(VariantIdentifier<?> identifier, String name, BuildVariantInternal buildVariant, VariantComponentDependencies<?> variantDependencies) {
+	protected DefaultNativeTestSuiteVariant createVariant(VariantIdentifier<?> identifier, String name, VariantComponentDependencies<?> variantDependencies) {
+		val buildVariant = (BuildVariantInternal) identifier.getBuildVariant();
 		NamingScheme names = getNames().forBuildVariant(buildVariant, getBuildVariants().get());
 
-		val result = getObjects().newInstance(DefaultNativeTestSuiteVariant.class, identifier, name, names, buildVariant, variantDependencies);
+		val result = getObjects().newInstance(DefaultNativeTestSuiteVariant.class, identifier, name, names, variantDependencies);
 		return result;
 	}
 

--- a/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteComponent.java
+++ b/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteComponent.java
@@ -64,8 +64,8 @@ public class DefaultNativeTestSuiteComponent extends BaseNativeComponent<Default
 	private final TaskContainer tasks;
 
 	@Inject
-	public DefaultNativeTestSuiteComponent(NamingScheme names, ObjectFactory objects, ProviderFactory providers, TaskContainer tasks, ProjectLayout layout, ConfigurationContainer configurations, DependencyHandler dependencyHandler) {
-		super(names, DefaultNativeTestSuiteVariant.class, objects, providers, tasks, layout, configurations);
+	public DefaultNativeTestSuiteComponent(ComponentIdentifier<DefaultNativeTestSuiteComponent> identifier, NamingScheme names, ObjectFactory objects, ProviderFactory providers, TaskContainer tasks, ProjectLayout layout, ConfigurationContainer configurations, DependencyHandler dependencyHandler) {
+		super(identifier, names, DefaultNativeTestSuiteVariant.class, objects, providers, tasks, layout, configurations);
 		this.dependencyHandler = dependencyHandler;
 		this.tasks = tasks;
 

--- a/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteComponent.java
+++ b/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteComponent.java
@@ -140,10 +140,10 @@ public class DefaultNativeTestSuiteComponent extends BaseNativeComponent<Default
 	}
 
 	@Override
-	protected DefaultNativeTestSuiteVariant createVariant(String name, BuildVariantInternal buildVariant, VariantComponentDependencies<?> variantDependencies) {
+	protected DefaultNativeTestSuiteVariant createVariant(VariantIdentifier<?> identifier, String name, BuildVariantInternal buildVariant, VariantComponentDependencies<?> variantDependencies) {
 		NamingScheme names = getNames().forBuildVariant(buildVariant, getBuildVariants().get());
 
-		val result = getObjects().newInstance(DefaultNativeTestSuiteVariant.class, name, names, buildVariant, variantDependencies);
+		val result = getObjects().newInstance(DefaultNativeTestSuiteVariant.class, identifier, name, names, buildVariant, variantDependencies);
 		return result;
 	}
 

--- a/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteComponent.java
+++ b/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteComponent.java
@@ -140,11 +140,11 @@ public class DefaultNativeTestSuiteComponent extends BaseNativeComponent<Default
 	}
 
 	@Override
-	protected DefaultNativeTestSuiteVariant createVariant(VariantIdentifier<?> identifier, String name, VariantComponentDependencies<?> variantDependencies) {
+	protected DefaultNativeTestSuiteVariant createVariant(VariantIdentifier<?> identifier, VariantComponentDependencies<?> variantDependencies) {
 		val buildVariant = (BuildVariantInternal) identifier.getBuildVariant();
 		NamingScheme names = getNames().forBuildVariant(buildVariant, getBuildVariants().get());
 
-		val result = getObjects().newInstance(DefaultNativeTestSuiteVariant.class, identifier, name, names, variantDependencies);
+		val result = getObjects().newInstance(DefaultNativeTestSuiteVariant.class, identifier, names, variantDependencies);
 		return result;
 	}
 

--- a/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteVariant.java
+++ b/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteVariant.java
@@ -18,8 +18,8 @@ public class DefaultNativeTestSuiteVariant extends BaseNativeVariant implements 
 	@Getter private final ResolvableComponentDependencies resolvableDependencies;
 
 	@Inject
-	public DefaultNativeTestSuiteVariant(VariantIdentifier<DefaultNativeTestSuiteVariant> identifier, String name, NamingScheme names, VariantComponentDependencies<?> variantDependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
-		super(identifier, name, names, objects, tasks, providers);
+	public DefaultNativeTestSuiteVariant(VariantIdentifier<DefaultNativeTestSuiteVariant> identifier, NamingScheme names, VariantComponentDependencies<?> variantDependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
+		super(identifier, names, objects, tasks, providers);
 		this.resolvableDependencies = variantDependencies.getIncoming();
 	}
 }

--- a/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteVariant.java
+++ b/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteVariant.java
@@ -1,6 +1,5 @@
 package dev.nokee.testing.nativebase.internal;
 
-import dev.nokee.platform.base.internal.BuildVariantInternal;
 import dev.nokee.platform.base.internal.NamingScheme;
 import dev.nokee.platform.base.internal.VariantIdentifier;
 import dev.nokee.platform.base.internal.VariantInternal;
@@ -19,8 +18,8 @@ public class DefaultNativeTestSuiteVariant extends BaseNativeVariant implements 
 	@Getter private final ResolvableComponentDependencies resolvableDependencies;
 
 	@Inject
-	public DefaultNativeTestSuiteVariant(VariantIdentifier<DefaultNativeTestSuiteVariant> identifier, String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<?> variantDependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
-		super(identifier, name, names, buildVariant, objects, tasks, providers);
+	public DefaultNativeTestSuiteVariant(VariantIdentifier<DefaultNativeTestSuiteVariant> identifier, String name, NamingScheme names, VariantComponentDependencies<?> variantDependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
+		super(identifier, name, names, objects, tasks, providers);
 		this.resolvableDependencies = variantDependencies.getIncoming();
 	}
 }

--- a/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteVariant.java
+++ b/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteVariant.java
@@ -3,9 +3,11 @@ package dev.nokee.testing.nativebase.internal;
 import dev.nokee.platform.base.internal.BuildVariantInternal;
 import dev.nokee.platform.base.internal.NamingScheme;
 import dev.nokee.platform.base.internal.VariantInternal;
+import dev.nokee.platform.base.internal.dependencies.ResolvableComponentDependencies;
 import dev.nokee.platform.nativebase.internal.BaseNativeVariant;
 import dev.nokee.platform.nativebase.internal.dependencies.VariantComponentDependencies;
 import dev.nokee.testing.nativebase.NativeTestSuiteVariant;
+import lombok.Getter;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.TaskContainer;
@@ -13,8 +15,11 @@ import org.gradle.api.tasks.TaskContainer;
 import javax.inject.Inject;
 
 public class DefaultNativeTestSuiteVariant extends BaseNativeVariant implements NativeTestSuiteVariant, VariantInternal {
+	@Getter private final ResolvableComponentDependencies resolvableDependencies;
+
 	@Inject
 	public DefaultNativeTestSuiteVariant(String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<?> variantDependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
 		super(name, names, buildVariant, objects, tasks, providers);
+		this.resolvableDependencies = variantDependencies.getIncoming();
 	}
 }

--- a/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteVariant.java
+++ b/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteVariant.java
@@ -2,6 +2,7 @@ package dev.nokee.testing.nativebase.internal;
 
 import dev.nokee.platform.base.internal.BuildVariantInternal;
 import dev.nokee.platform.base.internal.NamingScheme;
+import dev.nokee.platform.base.internal.VariantIdentifier;
 import dev.nokee.platform.base.internal.VariantInternal;
 import dev.nokee.platform.base.internal.dependencies.ResolvableComponentDependencies;
 import dev.nokee.platform.nativebase.internal.BaseNativeVariant;
@@ -18,8 +19,8 @@ public class DefaultNativeTestSuiteVariant extends BaseNativeVariant implements 
 	@Getter private final ResolvableComponentDependencies resolvableDependencies;
 
 	@Inject
-	public DefaultNativeTestSuiteVariant(String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<?> variantDependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
-		super(name, names, buildVariant, objects, tasks, providers);
+	public DefaultNativeTestSuiteVariant(VariantIdentifier<DefaultNativeTestSuiteVariant> identifier, String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<?> variantDependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
+		super(identifier, name, names, buildVariant, objects, tasks, providers);
 		this.resolvableDependencies = variantDependencies.getIncoming();
 	}
 }

--- a/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/plugins/NativeUnitTestingPlugin.java
+++ b/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/plugins/NativeUnitTestingPlugin.java
@@ -5,7 +5,10 @@ import dev.nokee.language.cpp.internal.CppSourceSet;
 import dev.nokee.language.objectivec.internal.ObjectiveCSourceSet;
 import dev.nokee.language.objectivecpp.internal.ObjectiveCppSourceSet;
 import dev.nokee.language.swift.internal.SwiftSourceSet;
+import dev.nokee.platform.base.internal.ComponentIdentifier;
+import dev.nokee.platform.base.internal.ComponentName;
 import dev.nokee.platform.base.internal.NamingScheme;
+import dev.nokee.platform.base.internal.ProjectIdentifier;
 import dev.nokee.testing.base.TestSuiteContainer;
 import dev.nokee.testing.base.internal.DefaultTestSuiteContainer;
 import dev.nokee.testing.base.internal.plugins.TestingBasePlugin;
@@ -37,7 +40,9 @@ public class NativeUnitTestingPlugin implements Plugin<Project> {
 		project.getPluginManager().apply(TestingBasePlugin.class);
 
 		val extension = (DefaultTestSuiteContainer)project.getExtensions().getByType(TestSuiteContainer.class);
-		extension.registerFactory(NativeTestSuite.class, DefaultNativeTestSuiteComponent.class, this::createNativeTestSuite);
+		extension.registerFactory(NativeTestSuite.class, DefaultNativeTestSuiteComponent.class, name -> {
+			return createNativeTestSuite(ComponentIdentifier.of(ComponentName.of(name), DefaultNativeTestSuiteComponent.class, ProjectIdentifier.of(project)));
+		});
 
 		extension.whenElementKnown(DefaultNativeTestSuiteComponent.class, knownTestSuite -> {
 			knownTestSuite.configure(testSuite -> {
@@ -67,7 +72,7 @@ public class NativeUnitTestingPlugin implements Plugin<Project> {
 		});
 	}
 
-	private NativeTestSuite createNativeTestSuite(String name) {
-		return getObjects().newInstance(DefaultNativeTestSuiteComponent.class, NamingScheme.asComponent(name, name).withComponentDisplayName("Test Suite"));
+	private NativeTestSuite createNativeTestSuite(ComponentIdentifier<DefaultNativeTestSuiteComponent> identifier) {
+		return getObjects().newInstance(DefaultNativeTestSuiteComponent.class, identifier, NamingScheme.asComponent(identifier.getName().get(), identifier.getName().get()).withComponentDisplayName("Test Suite"));
 	}
 }

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/BaseXCTestTestSuiteComponent.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/BaseXCTestTestSuiteComponent.java
@@ -112,7 +112,7 @@ public class BaseXCTestTestSuiteComponent extends BaseNativeComponent<DefaultXCT
 	}
 
 	@Override
-	protected void onEachVariant(VariantIdentifier<DefaultXCTestTestSuiteVariant> variantIdentifier, VariantProvider<DefaultXCTestTestSuiteVariant> variant, NamingScheme names) {
+	protected void onEachVariant(KnownVariant<DefaultXCTestTestSuiteVariant> variant) {
 		variant.configure(testSuite -> {
 			testSuite.getBinaries().configureEach(BundleBinary.class, binary -> {
 				Provider<String> moduleName = getTestedComponent().map(it -> it.getNames().getBaseName().getAsCamelCase());
@@ -155,6 +155,7 @@ public class BaseXCTestTestSuiteComponent extends BaseNativeComponent<DefaultXCT
 
 	@Override
 	public void finalizeExtension(Project project) {
+		// TODO: Use component binary view instead once finish cleanup, it remove one level of indirection
 		getVariants().configureEach(variant -> {
 			variant.getBinaries().configureEach(BaseNativeBinary.class, binary -> {
 				binary.getBaseName().convention(GUtil.toCamelCase(project.getName()));

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/BaseXCTestTestSuiteComponent.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/BaseXCTestTestSuiteComponent.java
@@ -77,11 +77,11 @@ public class BaseXCTestTestSuiteComponent extends BaseNativeComponent<DefaultXCT
 	}
 
 	@Override
-	protected DefaultXCTestTestSuiteVariant createVariant(VariantIdentifier<?> identifier, String name, VariantComponentDependencies<?> variantDependencies) {
+	protected DefaultXCTestTestSuiteVariant createVariant(VariantIdentifier<?> identifier, VariantComponentDependencies<?> variantDependencies) {
 		val buildVariant = (BuildVariantInternal) identifier.getBuildVariant();
 		NamingScheme names = getNames().forBuildVariant(buildVariant, getBuildVariants().get());
 
-		DefaultXCTestTestSuiteVariant result = getObjects().newInstance(DefaultXCTestTestSuiteVariant.class, identifier, name, names, variantDependencies);
+		DefaultXCTestTestSuiteVariant result = getObjects().newInstance(DefaultXCTestTestSuiteVariant.class, identifier, names, variantDependencies);
 		return result;
 	}
 

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/BaseXCTestTestSuiteComponent.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/BaseXCTestTestSuiteComponent.java
@@ -50,8 +50,8 @@ public class BaseXCTestTestSuiteComponent extends BaseNativeComponent<DefaultXCT
 	@Getter(AccessLevel.PROTECTED) private final DependencyHandler dependencyHandler;
 
 	@Inject
-	public BaseXCTestTestSuiteComponent(NamingScheme names, ObjectFactory objects, ProviderFactory providers, TaskContainer tasks, ProjectLayout layout, ConfigurationContainer configurations, DependencyHandler dependencyHandler) {
-		super(names, DefaultXCTestTestSuiteVariant.class, objects, providers, tasks, layout, configurations);
+	public BaseXCTestTestSuiteComponent(ComponentIdentifier<?> identifier, NamingScheme names, ObjectFactory objects, ProviderFactory providers, TaskContainer tasks, ProjectLayout layout, ConfigurationContainer configurations, DependencyHandler dependencyHandler) {
+		super(identifier, names, DefaultXCTestTestSuiteVariant.class, objects, providers, tasks, layout, configurations);
 		this.dependencyHandler = dependencyHandler;
 		val dependencyContainer = objects.newInstance(DefaultComponentDependencies.class, names.getComponentDisplayName(), new FrameworkAwareDependencyBucketFactory(new DefaultDependencyBucketFactory(new ConfigurationFactories.Prefixing(new ConfigurationFactories.Creating(getConfigurations()), names::getConfigurationName), new DefaultDependencyFactory(getDependencyHandler()))));
 		this.dependencies = objects.newInstance(DefaultNativeComponentDependencies.class, dependencyContainer);

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/BaseXCTestTestSuiteComponent.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/BaseXCTestTestSuiteComponent.java
@@ -77,10 +77,11 @@ public class BaseXCTestTestSuiteComponent extends BaseNativeComponent<DefaultXCT
 	}
 
 	@Override
-	protected DefaultXCTestTestSuiteVariant createVariant(VariantIdentifier<?> identifier, String name, BuildVariantInternal buildVariant, VariantComponentDependencies<?> variantDependencies) {
+	protected DefaultXCTestTestSuiteVariant createVariant(VariantIdentifier<?> identifier, String name, VariantComponentDependencies<?> variantDependencies) {
+		val buildVariant = (BuildVariantInternal) identifier.getBuildVariant();
 		NamingScheme names = getNames().forBuildVariant(buildVariant, getBuildVariants().get());
 
-		DefaultXCTestTestSuiteVariant result = getObjects().newInstance(DefaultXCTestTestSuiteVariant.class, identifier, name, names, buildVariant, variantDependencies);
+		DefaultXCTestTestSuiteVariant result = getObjects().newInstance(DefaultXCTestTestSuiteVariant.class, identifier, name, names, variantDependencies);
 		return result;
 	}
 

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/BaseXCTestTestSuiteComponent.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/BaseXCTestTestSuiteComponent.java
@@ -77,10 +77,10 @@ public class BaseXCTestTestSuiteComponent extends BaseNativeComponent<DefaultXCT
 	}
 
 	@Override
-	protected DefaultXCTestTestSuiteVariant createVariant(String name, BuildVariantInternal buildVariant, VariantComponentDependencies<?> variantDependencies) {
+	protected DefaultXCTestTestSuiteVariant createVariant(VariantIdentifier<?> identifier, String name, BuildVariantInternal buildVariant, VariantComponentDependencies<?> variantDependencies) {
 		NamingScheme names = getNames().forBuildVariant(buildVariant, getBuildVariants().get());
 
-		DefaultXCTestTestSuiteVariant result = getObjects().newInstance(DefaultXCTestTestSuiteVariant.class, name, names, buildVariant, variantDependencies);
+		DefaultXCTestTestSuiteVariant result = getObjects().newInstance(DefaultXCTestTestSuiteVariant.class, identifier, name, names, buildVariant, variantDependencies);
 		return result;
 	}
 

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultUiTestXCTestTestSuiteComponent.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultUiTestXCTestTestSuiteComponent.java
@@ -40,8 +40,8 @@ public class DefaultUiTestXCTestTestSuiteComponent extends BaseXCTestTestSuiteCo
 	private final TaskRegistry taskRegistry;
 
 	@Inject
-	public DefaultUiTestXCTestTestSuiteComponent(NamingScheme names, ObjectFactory objects, ProviderFactory providers, TaskContainer tasks, ProjectLayout layout, ConfigurationContainer configurations, DependencyHandler dependencyHandler) {
-		super(names, objects, providers, tasks, layout, configurations, dependencyHandler);
+	public DefaultUiTestXCTestTestSuiteComponent(ComponentIdentifier<DefaultUiTestXCTestTestSuiteComponent> identifier, NamingScheme names, ObjectFactory objects, ProviderFactory providers, TaskContainer tasks, ProjectLayout layout, ConfigurationContainer configurations, DependencyHandler dependencyHandler) {
+		super(identifier, names, objects, providers, tasks, layout, configurations, dependencyHandler);
 		this.taskRegistry = new TaskRegistryImpl(tasks);
 	}
 
@@ -134,7 +134,7 @@ public class DefaultUiTestXCTestTestSuiteComponent extends BaseXCTestTestSuiteCo
 	public static DomainObjectFactory<DefaultUiTestXCTestTestSuiteComponent> newUiTestFactory(ObjectFactory objects, NamingSchemeFactory namingSchemeFactory) {
 		return identifier -> {
 			NamingScheme names = namingSchemeFactory.forMainComponent("uiTest").withComponentDisplayName("iOS UI test XCTest test suite");
-			return objects.newInstance(DefaultUiTestXCTestTestSuiteComponent.class, names);
+			return objects.newInstance(DefaultUiTestXCTestTestSuiteComponent.class, identifier, names);
 		};
 	}
 }

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultUiTestXCTestTestSuiteComponent.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultUiTestXCTestTestSuiteComponent.java
@@ -5,10 +5,9 @@ import dev.nokee.core.exec.CommandLineTool;
 import dev.nokee.core.exec.internal.PathAwareCommandLineTool;
 import dev.nokee.model.DomainObjectFactory;
 import dev.nokee.platform.base.Component;
-import dev.nokee.platform.base.internal.NamingScheme;
-import dev.nokee.platform.base.internal.NamingSchemeFactory;
-import dev.nokee.platform.base.internal.VariantIdentifier;
-import dev.nokee.platform.base.internal.VariantProvider;
+import dev.nokee.platform.base.internal.*;
+import dev.nokee.platform.base.internal.tasks.TaskIdentifier;
+import dev.nokee.platform.base.internal.tasks.TaskName;
 import dev.nokee.platform.base.internal.tasks.TaskRegistry;
 import dev.nokee.platform.base.internal.tasks.TaskRegistryImpl;
 import dev.nokee.platform.ios.internal.SignedIosApplicationBundleInternal;
@@ -47,12 +46,13 @@ public class DefaultUiTestXCTestTestSuiteComponent extends BaseXCTestTestSuiteCo
 	}
 
 	@Override
-	protected void onEachVariant(VariantIdentifier<DefaultXCTestTestSuiteVariant> variantIdentifier, VariantProvider<DefaultXCTestTestSuiteVariant> variant, NamingScheme names) {
-		super.onEachVariant(variantIdentifier, variant, names);
+	protected void onEachVariant(KnownVariant<DefaultXCTestTestSuiteVariant> variant) {
+		super.onEachVariant(variant);
+		val variantIdentifier = variant.getIdentifier();
 
 		variant.configure(testSuite -> {
 			testSuite.getBinaries().configureEach(BundleBinary.class, binary -> {
-				((BundleBinaryInternal)binary).getBaseName().set(names.getBaseName().getAsCamelCase());
+				((BundleBinaryInternal)binary).getBaseName().set(getNames().getBaseName().getAsCamelCase());
 			});
 			String moduleName = testSuite.getNames().getBaseName().getAsCamelCase();
 
@@ -96,7 +96,7 @@ public class DefaultUiTestXCTestTestSuiteComponent extends BaseXCTestTestSuiteCo
 			testSuite.getBinaryCollection().add(getObjects().newInstance(SignedIosApplicationBundleInternal.class, signTask));
 		});
 
-		TaskProvider<Task> bundle = taskRegistry.register(names.getTaskName("bundle"), task -> {
+		TaskProvider<Task> bundle = taskRegistry.register(TaskIdentifier.of(TaskName.of("bundle"), variantIdentifier), task -> {
 			task.dependsOn(variant.map(it -> it.getBinaries().withType(SignedIosApplicationBundleInternal.class).get()));
 		});
 	}

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultUnitTestXCTestTestSuiteComponent.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultUnitTestXCTestTestSuiteComponent.java
@@ -126,7 +126,7 @@ public class DefaultUnitTestXCTestTestSuiteComponent extends BaseXCTestTestSuite
 
 	public static DomainObjectFactory<DefaultUnitTestXCTestTestSuiteComponent> newUnitTestFactory(ObjectFactory objects, NamingSchemeFactory namingSchemeFactory) {
 		return identifier -> {
-			NamingScheme names = namingSchemeFactory.forMainComponent("unitTest").withComponentDisplayName("iOS unit test XCTest test suite");
+			NamingScheme names = namingSchemeFactory.forMainComponent("unitTest").withComponentDisplayName(((ComponentIdentifier<?>)identifier).getDisplayName());
 			return objects.newInstance(DefaultUnitTestXCTestTestSuiteComponent.class, identifier, names);
 		};
 	}

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultUnitTestXCTestTestSuiteComponent.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultUnitTestXCTestTestSuiteComponent.java
@@ -39,8 +39,8 @@ public class DefaultUnitTestXCTestTestSuiteComponent extends BaseXCTestTestSuite
 	private final TaskRegistry taskRegistry;
 
 	@Inject
-	public DefaultUnitTestXCTestTestSuiteComponent(NamingScheme names, ObjectFactory objects, ProviderFactory providers, TaskContainer tasks, ProjectLayout layout, ConfigurationContainer configurations, DependencyHandler dependencyHandler) {
-		super(names, objects, providers, tasks, layout, configurations, dependencyHandler);
+	public DefaultUnitTestXCTestTestSuiteComponent(ComponentIdentifier<DefaultUnitTestXCTestTestSuiteComponent> identifier, NamingScheme names, ObjectFactory objects, ProviderFactory providers, TaskContainer tasks, ProjectLayout layout, ConfigurationContainer configurations, DependencyHandler dependencyHandler) {
+		super(identifier, names, objects, providers, tasks, layout, configurations, dependencyHandler);
 		this.taskRegistry = new TaskRegistryImpl(tasks);
 	}
 
@@ -127,7 +127,7 @@ public class DefaultUnitTestXCTestTestSuiteComponent extends BaseXCTestTestSuite
 	public static DomainObjectFactory<DefaultUnitTestXCTestTestSuiteComponent> newUnitTestFactory(ObjectFactory objects, NamingSchemeFactory namingSchemeFactory) {
 		return identifier -> {
 			NamingScheme names = namingSchemeFactory.forMainComponent("unitTest").withComponentDisplayName("iOS unit test XCTest test suite");
-			return objects.newInstance(DefaultUnitTestXCTestTestSuiteComponent.class, names);
+			return objects.newInstance(DefaultUnitTestXCTestTestSuiteComponent.class, identifier, names);
 		};
 	}
 }

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultUnitTestXCTestTestSuiteComponent.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultUnitTestXCTestTestSuiteComponent.java
@@ -5,10 +5,7 @@ import dev.nokee.core.exec.CommandLineTool;
 import dev.nokee.core.exec.internal.PathAwareCommandLineTool;
 import dev.nokee.model.DomainObjectFactory;
 import dev.nokee.platform.base.Component;
-import dev.nokee.platform.base.internal.NamingScheme;
-import dev.nokee.platform.base.internal.NamingSchemeFactory;
-import dev.nokee.platform.base.internal.VariantIdentifier;
-import dev.nokee.platform.base.internal.VariantProvider;
+import dev.nokee.platform.base.internal.*;
 import dev.nokee.platform.base.internal.tasks.TaskIdentifier;
 import dev.nokee.platform.base.internal.tasks.TaskName;
 import dev.nokee.platform.base.internal.tasks.TaskRegistry;
@@ -48,12 +45,13 @@ public class DefaultUnitTestXCTestTestSuiteComponent extends BaseXCTestTestSuite
 	}
 
 	@Override
-	protected void onEachVariant(VariantIdentifier<DefaultXCTestTestSuiteVariant> variantIdentifier, VariantProvider<DefaultXCTestTestSuiteVariant> variant, NamingScheme names) {
-		super.onEachVariant(variantIdentifier, variant, names);
+	protected void onEachVariant(KnownVariant<DefaultXCTestTestSuiteVariant> variant) {
+		super.onEachVariant(variant);
+		val variantIdentifier = variant.getIdentifier();
 
 		variant.configure(testSuite -> {
 			testSuite.getBinaries().configureEach(BundleBinary.class, binary -> {
-				((BundleBinaryInternal)binary).getBaseName().set(names.getBaseName().getAsCamelCase());
+				((BundleBinaryInternal)binary).getBaseName().set(getNames().getBaseName().getAsCamelCase());
 			});
 			String moduleName = testSuite.getNames().getBaseName().getAsCamelCase();
 

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultXCTestTestSuiteVariant.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultXCTestTestSuiteVariant.java
@@ -25,8 +25,8 @@ public class DefaultXCTestTestSuiteVariant extends BaseNativeVariant implements 
 	@Getter private final ResolvableComponentDependencies resolvableDependencies;
 
 	@Inject
-	public DefaultXCTestTestSuiteVariant(VariantIdentifier<DefaultXCTestTestSuiteVariant> identifier, String name, NamingScheme names, VariantComponentDependencies<DefaultNativeComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
-		super(identifier, name, names, objects, tasks, providers);
+	public DefaultXCTestTestSuiteVariant(VariantIdentifier<DefaultXCTestTestSuiteVariant> identifier, NamingScheme names, VariantComponentDependencies<DefaultNativeComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
+		super(identifier, names, objects, tasks, providers);
 		this.dependencies = dependencies.getDependencies();
 		this.resolvableDependencies = dependencies.getIncoming();
 	}

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultXCTestTestSuiteVariant.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultXCTestTestSuiteVariant.java
@@ -2,7 +2,6 @@ package dev.nokee.testing.xctest.internal;
 
 import com.google.common.collect.ImmutableList;
 import dev.nokee.platform.base.Binary;
-import dev.nokee.platform.base.internal.BuildVariantInternal;
 import dev.nokee.platform.base.internal.NamingScheme;
 import dev.nokee.platform.base.internal.VariantIdentifier;
 import dev.nokee.platform.base.internal.VariantInternal;
@@ -26,8 +25,8 @@ public class DefaultXCTestTestSuiteVariant extends BaseNativeVariant implements 
 	@Getter private final ResolvableComponentDependencies resolvableDependencies;
 
 	@Inject
-	public DefaultXCTestTestSuiteVariant(VariantIdentifier<DefaultXCTestTestSuiteVariant> identifier, String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<DefaultNativeComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
-		super(identifier, name, names, buildVariant, objects, tasks, providers);
+	public DefaultXCTestTestSuiteVariant(VariantIdentifier<DefaultXCTestTestSuiteVariant> identifier, String name, NamingScheme names, VariantComponentDependencies<DefaultNativeComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
+		super(identifier, name, names, objects, tasks, providers);
 		this.dependencies = dependencies.getDependencies();
 		this.resolvableDependencies = dependencies.getIncoming();
 	}

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultXCTestTestSuiteVariant.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultXCTestTestSuiteVariant.java
@@ -5,13 +5,13 @@ import dev.nokee.platform.base.Binary;
 import dev.nokee.platform.base.internal.BuildVariantInternal;
 import dev.nokee.platform.base.internal.NamingScheme;
 import dev.nokee.platform.base.internal.VariantInternal;
+import dev.nokee.platform.base.internal.dependencies.ResolvableComponentDependencies;
 import dev.nokee.platform.ios.IosApplication;
 import dev.nokee.platform.ios.internal.SignedIosApplicationBundleInternal;
-import dev.nokee.platform.nativebase.NativeComponentDependencies;
 import dev.nokee.platform.nativebase.internal.BaseNativeVariant;
 import dev.nokee.platform.nativebase.internal.dependencies.DefaultNativeComponentDependencies;
 import dev.nokee.platform.nativebase.internal.dependencies.VariantComponentDependencies;
-import org.gradle.api.Action;
+import lombok.Getter;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
@@ -22,11 +22,13 @@ import java.util.List;
 
 public class DefaultXCTestTestSuiteVariant extends BaseNativeVariant implements IosApplication, VariantInternal {
 	private final DefaultNativeComponentDependencies dependencies;
+	@Getter private final ResolvableComponentDependencies resolvableDependencies;
 
 	@Inject
 	public DefaultXCTestTestSuiteVariant(String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<DefaultNativeComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
 		super(name, names, buildVariant, objects, tasks, providers);
 		this.dependencies = dependencies.getDependencies();
+		this.resolvableDependencies = dependencies.getIncoming();
 	}
 
 	@Override

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultXCTestTestSuiteVariant.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultXCTestTestSuiteVariant.java
@@ -1,24 +1,20 @@
 package dev.nokee.testing.xctest.internal;
 
-import com.google.common.collect.ImmutableList;
-import dev.nokee.platform.base.Binary;
 import dev.nokee.platform.base.internal.NamingScheme;
 import dev.nokee.platform.base.internal.VariantIdentifier;
 import dev.nokee.platform.base.internal.VariantInternal;
 import dev.nokee.platform.base.internal.dependencies.ResolvableComponentDependencies;
 import dev.nokee.platform.ios.IosApplication;
-import dev.nokee.platform.ios.internal.SignedIosApplicationBundleInternal;
+import dev.nokee.platform.ios.internal.rules.IosDevelopmentBinaryConvention;
 import dev.nokee.platform.nativebase.internal.BaseNativeVariant;
 import dev.nokee.platform.nativebase.internal.dependencies.DefaultNativeComponentDependencies;
 import dev.nokee.platform.nativebase.internal.dependencies.VariantComponentDependencies;
 import lombok.Getter;
 import org.gradle.api.model.ObjectFactory;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.TaskContainer;
 
 import javax.inject.Inject;
-import java.util.List;
 
 public class DefaultXCTestTestSuiteVariant extends BaseNativeVariant implements IosApplication, VariantInternal {
 	private final DefaultNativeComponentDependencies dependencies;
@@ -29,26 +25,12 @@ public class DefaultXCTestTestSuiteVariant extends BaseNativeVariant implements 
 		super(identifier, names, objects, tasks, providers);
 		this.dependencies = dependencies.getDependencies();
 		this.resolvableDependencies = dependencies.getIncoming();
+
+		getDevelopmentBinary().convention(getBinaries().getElements().flatMap(IosDevelopmentBinaryConvention.INSTANCE));
 	}
 
 	@Override
 	public DefaultNativeComponentDependencies getDependencies() {
 		return dependencies;
-	}
-
-	@Override
-	protected Provider<Binary> getDefaultBinary() {
-		return getProviders().provider(() -> {
-			List<? extends SignedIosApplicationBundleInternal> binaries = getBinaries().flatMap(it -> {
-				if (it instanceof SignedIosApplicationBundleInternal) {
-					return ImmutableList.of((SignedIosApplicationBundleInternal)it);
-				}
-				return ImmutableList.of();
-			}).get();
-			if (binaries.isEmpty()) {
-				return null;
-			}
-			return one(binaries);
-		});
 	}
 }

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultXCTestTestSuiteVariant.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultXCTestTestSuiteVariant.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import dev.nokee.platform.base.Binary;
 import dev.nokee.platform.base.internal.BuildVariantInternal;
 import dev.nokee.platform.base.internal.NamingScheme;
+import dev.nokee.platform.base.internal.VariantIdentifier;
 import dev.nokee.platform.base.internal.VariantInternal;
 import dev.nokee.platform.base.internal.dependencies.ResolvableComponentDependencies;
 import dev.nokee.platform.ios.IosApplication;
@@ -25,8 +26,8 @@ public class DefaultXCTestTestSuiteVariant extends BaseNativeVariant implements 
 	@Getter private final ResolvableComponentDependencies resolvableDependencies;
 
 	@Inject
-	public DefaultXCTestTestSuiteVariant(String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<DefaultNativeComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
-		super(name, names, buildVariant, objects, tasks, providers);
+	public DefaultXCTestTestSuiteVariant(VariantIdentifier<DefaultXCTestTestSuiteVariant> identifier, String name, NamingScheme names, BuildVariantInternal buildVariant, VariantComponentDependencies<DefaultNativeComponentDependencies> dependencies, ObjectFactory objects, TaskContainer tasks, ProviderFactory providers) {
+		super(identifier, name, names, buildVariant, objects, tasks, providers);
 		this.dependencies = dependencies.getDependencies();
 		this.resolvableDependencies = dependencies.getIncoming();
 	}

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/plugins/ObjectiveCXCTestTestSuitePlugin.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/plugins/ObjectiveCXCTestTestSuitePlugin.java
@@ -43,7 +43,7 @@ public class ObjectiveCXCTestTestSuitePlugin implements Plugin<Project> {
 			BaseNativeComponent<?> application = ((DefaultObjectiveCIosApplicationExtension) project.getExtensions().getByType(ObjectiveCIosApplicationExtension.class)).getComponent();
 			val store = project.getExtensions().getByType(DomainObjectStore.class);
 
-			val unitTestIdentifier = ComponentIdentifier.builder().withName(ComponentName.of("unitTest")).withProjectIdentifier(ProjectIdentifier.of(project)).withType(DefaultUnitTestXCTestTestSuiteComponent.class).withDisplayName("iOS unit test XCTest test suite").build();
+			val unitTestIdentifier = ComponentIdentifier.of(ComponentName.of("unitTest"), DefaultUnitTestXCTestTestSuiteComponent.class, ProjectIdentifier.of(project));
 			val unitTestComponent = store.register(unitTestIdentifier, DefaultUnitTestXCTestTestSuiteComponent.class, newUnitTestFactory(getObjects(), new NamingSchemeFactory(project.getName())));
 			unitTestComponent.configure(component -> {
 				component.getSourceCollection().add(getObjects().newInstance(ObjectiveCSourceSet.class, "objc").srcDir("src/unitTest/objc"));
@@ -55,7 +55,7 @@ public class ObjectiveCXCTestTestSuitePlugin implements Plugin<Project> {
 			});
 			unitTestComponent.get();
 
-			val uiTestIdentifier = ComponentIdentifier.builder().withName(ComponentName.of("uiTest")).withProjectIdentifier(ProjectIdentifier.of(project)).withType(DefaultUnitTestXCTestTestSuiteComponent.class).withDisplayName("iOS UI test XCTest test suite").build();
+			val uiTestIdentifier = ComponentIdentifier.of(ComponentName.of("uiTest"), DefaultUnitTestXCTestTestSuiteComponent.class, ProjectIdentifier.of(project));
 			val uiTestComponent = store.register(uiTestIdentifier, DefaultUiTestXCTestTestSuiteComponent.class, newUiTestFactory(getObjects(), new NamingSchemeFactory(project.getName())));
 			uiTestComponent.configure(component -> {
 				component.getSourceCollection().add(getObjects().newInstance(ObjectiveCSourceSet.class, "objc").srcDir("src/uiTest/objc"));


### PR DESCRIPTION
We started to unthread values that are unneeded:
 - Variant name => use build variant
 - Component display name => should just generate something based on the types
 - NamingScheme (aka names) => This is a bad idea this is being broken down into smaller pieces such as the identifiers, more work to be done so we can remove it completely
 - Polymorphism for selecting development binary from the BaseVariant => Convention classes for selecting development binary (and test coverage)
 - Identifiers for components and variants are passed to their respective instance