### PR TITLE
Move binary creation into its own modeling

### DIFF
--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryInternal.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryInternal.java
@@ -15,6 +15,7 @@ import dev.nokee.runtime.nativebase.internal.DefaultOperatingSystemFamily;
 import dev.nokee.runtime.nativebase.internal.DefaultTargetMachine;
 import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.val;
 import org.gradle.api.Action;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.Task;
@@ -71,7 +72,8 @@ public class JniLibraryInternal extends BaseVariant implements JniLibrary, Varia
 	}
 
 	public void registerSharedLibraryBinary(DomainObjectSet<GeneratedSourceSet> objectSourceSets, TaskProvider<LinkSharedLibraryTask> linkTask, boolean multipleVariants, NativeIncomingDependencies dependencies) {
-		SharedLibraryBinaryInternal sharedLibraryBinary = getObjects().newInstance(SharedLibraryBinaryInternal.class, names, sources, targetMachine, objectSourceSets, linkTask, dependencies);
+		val sharedLibraryBinary = getObjects().newInstance(SharedLibraryBinaryInternal.class, names, sources, targetMachine, objectSourceSets, linkTask);
+		sharedLibraryBinary.getDependencies().set(dependencies);
 		getNativeRuntimeFiles().from(linkTask.flatMap(AbstractLinkTask::getLinkedFile));
 		getNativeRuntimeFiles().from(sharedLibraryBinary.getRuntimeLibrariesDependencies());
 		this.sharedLibraryBinary = sharedLibraryBinary;

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeComponent.java
@@ -111,6 +111,15 @@ public abstract class BaseNativeComponent<T extends VariantInternal> extends Bas
 					task.getCompilerArgs().addAll(getProviders().provider(() -> incomingDependencies.getFrameworkSearchPaths().getFiles().stream().flatMap(BaseNativeBinary::toFrameworkSearchPathFlags).collect(Collectors.toList())));
 				});
 				binary.getBaseName().convention(getBaseName());
+				binary.getCompileTasks().configureEach(NativeSourceCompile.class, task -> {
+					val taskInternal = (AbstractNativeCompileTask) task;
+					getSourceCollection().withType(CHeaderSet.class).configureEach(sourceSet -> {
+						taskInternal.getIncludes().from(sourceSet.getSourceDirectorySet().getSourceDirectories());
+					});
+					getSourceCollection().withType(CppHeaderSet.class).configureEach(sourceSet -> {
+						taskInternal.getIncludes().from(sourceSet.getSourceDirectorySet().getSourceDirectories());
+					});
+				});
 			});
 
 
@@ -140,17 +149,6 @@ public abstract class BaseNativeComponent<T extends VariantInternal> extends Bas
 					variantInternal.getBinaryCollection().add(binary);
 				}
 			}
-			it.getBinaries().configureEach(NativeBinary.class, binary -> {
-				binary.getCompileTasks().configureEach(NativeSourceCompile.class, task -> {
-					val taskInternal = (AbstractNativeCompileTask) task;
-					getSourceCollection().withType(CHeaderSet.class).configureEach(sourceSet -> {
-						taskInternal.getIncludes().from(sourceSet.getSourceDirectorySet().getSourceDirectories());
-					});
-					getSourceCollection().withType(CppHeaderSet.class).configureEach(sourceSet -> {
-						taskInternal.getIncludes().from(sourceSet.getSourceDirectorySet().getSourceDirectories());
-					});
-				});
-			});
 		});
 	}
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeComponent.java
@@ -110,6 +110,7 @@ public abstract class BaseNativeComponent<T extends VariantInternal> extends Bas
 					task.getModules().from(incomingDependencies.getSwiftModules());
 					task.getCompilerArgs().addAll(getProviders().provider(() -> incomingDependencies.getFrameworkSearchPaths().getFiles().stream().flatMap(BaseNativeBinary::toFrameworkSearchPathFlags).collect(Collectors.toList())));
 				});
+				binary.getBaseName().convention(getBaseName());
 			});
 
 
@@ -122,25 +123,21 @@ public abstract class BaseNativeComponent<T extends VariantInternal> extends Bas
 					val linkTask = taskRegistry.register(TaskIdentifier.of(TaskName.of("link"), LinkExecutableTask.class, variantIdentifier));
 					val binary = getObjects().newInstance(ExecutableBinaryInternal.class, names, objectSourceSets, targetMachineInternal, linkTask);
 					variantInternal.getBinaryCollection().add(binary);
-					binary.getBaseName().convention(getBaseName());
 				} else if (linkage.equals(DefaultBinaryLinkage.SHARED)) {
 					val linkTask = taskRegistry.register(TaskIdentifier.of(TaskName.of("link"), LinkSharedLibraryTask.class, variantIdentifier));
 
 					val binary = getObjects().newInstance(SharedLibraryBinaryInternal.class, names, getObjects().domainObjectSet(LanguageSourceSetInternal.class), targetMachineInternal, objectSourceSets, linkTask);
 					variantInternal.getBinaryCollection().add(binary);
-					binary.getBaseName().convention(getBaseName());
 				} else if (linkage.equals(DefaultBinaryLinkage.BUNDLE)) {
 					val linkTask = taskRegistry.register(TaskIdentifier.of(TaskName.of("link"), LinkBundleTask.class, variantIdentifier));
 
 					val binary = getObjects().newInstance(BundleBinaryInternal.class, names, targetMachineInternal, objectSourceSets, linkTask);
 					variantInternal.getBinaryCollection().add(binary);
-					binary.getBaseName().convention(getBaseName());
 				} else if (linkage.equals(DefaultBinaryLinkage.STATIC)) {
 					val createTask = taskRegistry.register(TaskIdentifier.of(TaskName.of("create"), CreateStaticLibraryTask.class, variantIdentifier));
 
 					val binary = getObjects().newInstance(StaticLibraryBinaryInternal.class, names, objectSourceSets, targetMachineInternal, createTask);
 					variantInternal.getBinaryCollection().add(binary);
-					binary.getBaseName().convention(getBaseName());
 				}
 			}
 			it.getBinaries().configureEach(NativeBinary.class, binary -> {

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BundleBinaryInternal.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BundleBinaryInternal.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableSet;
 import dev.nokee.language.base.internal.GeneratedSourceSet;
 import dev.nokee.platform.base.internal.NamingScheme;
 import dev.nokee.platform.nativebase.BundleBinary;
-import dev.nokee.platform.nativebase.internal.dependencies.NativeIncomingDependencies;
 import dev.nokee.platform.nativebase.tasks.LinkBundle;
 import dev.nokee.platform.nativebase.tasks.internal.LinkBundleTask;
 import dev.nokee.platform.nativebase.tasks.internal.ObjectFilesToBinaryTask;
@@ -31,8 +30,8 @@ public class BundleBinaryInternal extends BaseNativeBinary implements BundleBina
 	@Getter(AccessLevel.PROTECTED) private final TaskContainer tasks;
 
 	@Inject
-	public BundleBinaryInternal(NamingScheme names, DefaultTargetMachine targetMachine, DomainObjectSet<GeneratedSourceSet> objectSourceSets, TaskProvider<LinkBundleTask> linkTask, NativeIncomingDependencies dependencies, ObjectFactory objects, ProjectLayout layout, ProviderFactory providers, ConfigurationContainer configurations, TaskContainer tasks) {
-		super(names, objectSourceSets, targetMachine, dependencies, objects, layout, providers, configurations);
+	public BundleBinaryInternal(NamingScheme names, DefaultTargetMachine targetMachine, DomainObjectSet<GeneratedSourceSet> objectSourceSets, TaskProvider<LinkBundleTask> linkTask, ObjectFactory objects, ProjectLayout layout, ProviderFactory providers, ConfigurationContainer configurations, TaskContainer tasks) {
+		super(names, objectSourceSets, targetMachine, objects, layout, providers, configurations);
 
 		this.linkTask = linkTask;
 		this.tasks = tasks;

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/StaticLibraryBinaryInternal.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/StaticLibraryBinaryInternal.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableSet;
 import dev.nokee.language.base.internal.GeneratedSourceSet;
 import dev.nokee.platform.base.internal.NamingScheme;
 import dev.nokee.platform.nativebase.StaticLibraryBinary;
-import dev.nokee.platform.nativebase.internal.dependencies.NativeIncomingDependencies;
 import dev.nokee.platform.nativebase.tasks.CreateStaticLibrary;
 import dev.nokee.platform.nativebase.tasks.internal.CreateStaticLibraryTask;
 import dev.nokee.platform.nativebase.tasks.internal.ObjectFilesToBinaryTask;
@@ -34,8 +33,8 @@ public class StaticLibraryBinaryInternal extends BaseNativeBinary implements Sta
 	@Getter(AccessLevel.PROTECTED) private final TaskContainer tasks;
 
 	@Inject
-	public StaticLibraryBinaryInternal(NamingScheme names, DomainObjectSet<GeneratedSourceSet> objectSourceSets, DefaultTargetMachine targetMachine, TaskProvider<CreateStaticLibraryTask> createTask, NativeIncomingDependencies dependencies, ObjectFactory objects, ProjectLayout layout, ProviderFactory providers, ConfigurationContainer configurations, TaskContainer tasks) {
-		super(names, objectSourceSets, targetMachine, dependencies, objects, layout, providers, configurations);
+	public StaticLibraryBinaryInternal(NamingScheme names, DomainObjectSet<GeneratedSourceSet> objectSourceSets, DefaultTargetMachine targetMachine, TaskProvider<CreateStaticLibraryTask> createTask, ObjectFactory objects, ProjectLayout layout, ProviderFactory providers, ConfigurationContainer configurations, TaskContainer tasks) {
+		super(names, objectSourceSets, targetMachine, objects, layout, providers, configurations);
 		this.createTask = createTask;
 		this.tasks = tasks;
 


### PR DESCRIPTION
This should fix the binary configuration regression. An added benefit to this PR is that all tasks are registered when variants are discovered. Following PRs will breakdown the base components further while moving toward more laziness. There is an important concept missing around domain object discovering so we can realize them when objects are missing.