### PR TITLE
Rename direct source set getter to include source language name

### DIFF
--- a/subprojects/ide-visual-studio/src/functionalTest/groovy/dev/nokee/ide/visualstudio/VisualStudioIdeCComponentFunctionalTest.groovy
+++ b/subprojects/ide-visual-studio/src/functionalTest/groovy/dev/nokee/ide/visualstudio/VisualStudioIdeCComponentFunctionalTest.groovy
@@ -28,7 +28,7 @@ class VisualStudioIdeCApplicationFunctionalTest extends AbstractVisualStudioIdeN
 	protected String configureCustomSourceLayout() {
 		return '''
 			application {
-				sources.from('srcs')
+				cSources.from('srcs')
 				privateHeaders.from('hdrs')
 			}
 		'''
@@ -113,7 +113,7 @@ class VisualStudioIdeCLibraryFunctionalTest extends AbstractVisualStudioIdeNativ
 	protected String configureCustomSourceLayout() {
 		return '''
 			library {
-				sources.from('srcs')
+				cSources.from('srcs')
 				publicHeaders.from('hdrs')
 			}
 		'''
@@ -162,7 +162,7 @@ class VisualStudioIdeCLibraryWithNativeTestSuiteFunctionalTest extends AbstractV
 		Assume.assumeTrue(false)
 		return '''
 			library {
-				sources.from('srcs')
+				cSources.from('srcs')
 				publicHeaders.from('hdrs')
 			}
 		'''

--- a/subprojects/ide-visual-studio/src/functionalTest/groovy/dev/nokee/ide/visualstudio/VisualStudioIdeCppComponentFunctionalTest.groovy
+++ b/subprojects/ide-visual-studio/src/functionalTest/groovy/dev/nokee/ide/visualstudio/VisualStudioIdeCppComponentFunctionalTest.groovy
@@ -29,7 +29,7 @@ class VisualStudioIdeCppApplicationFunctionalTest extends AbstractVisualStudioId
 	protected String configureCustomSourceLayout() {
 		return '''
 			application {
-				sources.from('srcs')
+				cppSources.from('srcs')
 				privateHeaders.from('hdrs')
 			}
 		'''
@@ -78,7 +78,7 @@ class VisualStudioIdeCppApplicationWithNativeTestSuiteFunctionalTest extends Abs
 		Assume.assumeTrue(false)
 		return '''
 			application {
-				sources.from('srcs')
+				cppSources.from('srcs')
 				privateHeaders.from('hdrs')
 			}
 		'''
@@ -115,7 +115,7 @@ class VisualStudioIdeCppLibraryFunctionalTest extends AbstractVisualStudioIdeNat
 	protected String configureCustomSourceLayout() {
 		return '''
 			library {
-				sources.from('srcs')
+				cppSources.from('srcs')
 				publicHeaders.from('hdrs')
 			}
 		'''
@@ -164,7 +164,7 @@ class VisualStudioIdeCppLibraryWithNativeTestSuiteFunctionalTest extends Abstrac
 		Assume.assumeTrue(false)
 		return '''
 			library {
-				sources.from('srcs')
+				cppSources.from('srcs')
 				privateHeaders.from('hdrs')
 			}
 		'''

--- a/subprojects/ide-xcode/src/functionalTest/groovy/dev/nokee/ide/xcode/AbstractXcodeIdeNativeComponentPluginFunctionalTest.groovy
+++ b/subprojects/ide-xcode/src/functionalTest/groovy/dev/nokee/ide/xcode/AbstractXcodeIdeNativeComponentPluginFunctionalTest.groovy
@@ -36,14 +36,29 @@ abstract class AbstractXcodeIdeNativeComponentPluginFunctionalTest extends Abstr
 	protected abstract SourceElement getComponentUnderTest();
 
 	protected String configureCustomSourceLayout() {
+		def className = this.class.simpleName
+
 		def componentUnderTestDsl = 'application'
-		if (this.class.simpleName.contains('Library')) {
+		if (className.contains('Library')) {
 			componentUnderTestDsl = 'library'
+		}
+
+		def languageName = ''
+		if (className.contains('ObjectiveCpp')) {
+			languageName = 'objectiveCpp'
+		} else if (className.contains('ObjectiveC')) {
+			languageName = 'objectiveC'
+		} else if (className.contains('Cpp')) {
+			languageName = 'cpp'
+		} else if (className.contains('c')) {
+			languageName = 'c'
+		} else if (className.contains('swift')) {
+			languageName = 'swift'
 		}
 
 		def result = """
 			${componentUnderTestDsl} {
-				sources.from('srcs')
+				${languageName}Sources.from('srcs')
 			}
 		"""
 

--- a/subprojects/platform-native/src/functionalTest/groovy/dev/nokee/platform/c/CLanguageSourceLayoutFunctionalTest.groovy
+++ b/subprojects/platform-native/src/functionalTest/groovy/dev/nokee/platform/c/CLanguageSourceLayoutFunctionalTest.groovy
@@ -35,7 +35,7 @@ class CApplicationNativeLanguageSourceLayoutFunctionalTest extends AbstractNativ
 			}
 
 			application {
-				sources.from('srcs')
+				cSources.from('srcs')
 				dependencies {
 					implementation project(':library')
 				}
@@ -47,7 +47,7 @@ class CApplicationNativeLanguageSourceLayoutFunctionalTest extends AbstractNativ
 			}
 
 			library {
-				sources.from('srcs')
+				cSources.from('srcs')
 				publicHeaders.from('includes')
 			}
 		'''
@@ -64,7 +64,7 @@ class CApplicationNativeLanguageSourceLayoutFunctionalTest extends AbstractNativ
 	protected String configureSourcesAsConvention() {
 		return """
 			application {
-				sources.from('srcs')
+				cSources.from('srcs')
 				privateHeaders.from('includes')
 			}
 		"""
@@ -74,7 +74,7 @@ class CApplicationNativeLanguageSourceLayoutFunctionalTest extends AbstractNativ
 	protected String configureSourcesAsExplicitFiles() {
 		return """
 			application {
-				${componentUnderTest.sources.files.collect { "sources.from('srcs/${it.name}')" }.join('\n')}
+				${componentUnderTest.sources.files.collect { "cSources.from('srcs/${it.name}')" }.join('\n')}
 				privateHeaders.from('includes')
 			}
 		"""
@@ -114,7 +114,7 @@ class CLibraryNativeLanguageSourceLayoutFunctionalTest extends AbstractNativeLan
 			}
 
 			library {
-				sources.from('srcs')
+				cSources.from('srcs')
 				privateHeaders.from('includes')
 				dependencies {
 					implementation project(':library')
@@ -127,7 +127,7 @@ class CLibraryNativeLanguageSourceLayoutFunctionalTest extends AbstractNativeLan
 			}
 
 			library {
-				sources.from('srcs')
+				cSources.from('srcs')
 				publicHeaders.from('includes')
 			}
 		'''
@@ -145,7 +145,7 @@ class CLibraryNativeLanguageSourceLayoutFunctionalTest extends AbstractNativeLan
 	protected String configureSourcesAsConvention() {
 		return """
 			library {
-				sources.from('srcs')
+				cSources.from('srcs')
 				privateHeaders.from('headers')
 				publicHeaders.from('includes')
 			}
@@ -156,7 +156,7 @@ class CLibraryNativeLanguageSourceLayoutFunctionalTest extends AbstractNativeLan
 	protected String configureSourcesAsExplicitFiles() {
 		return """
 			library {
-				${componentUnderTest.sources.files.collect { "sources.from('srcs/${it.name}')" }.join('\n')}
+				${componentUnderTest.sources.files.collect { "cSources.from('srcs/${it.name}')" }.join('\n')}
 				privateHeaders.from('headers')
 				publicHeaders.from('includes')
 			}

--- a/subprojects/platform-native/src/functionalTest/groovy/dev/nokee/platform/cpp/CppLanguageSourceLayoutFunctionalTest.groovy
+++ b/subprojects/platform-native/src/functionalTest/groovy/dev/nokee/platform/cpp/CppLanguageSourceLayoutFunctionalTest.groovy
@@ -35,7 +35,7 @@ class CppApplicationNativeLanguageSourceLayoutFunctionalTest extends AbstractNat
 			}
 
 			application {
-				sources.from('srcs')
+				cppSources.from('srcs')
 				dependencies {
 					implementation project(':library')
 				}
@@ -47,7 +47,7 @@ class CppApplicationNativeLanguageSourceLayoutFunctionalTest extends AbstractNat
 			}
 
 			library {
-				sources.from('srcs')
+				cppSources.from('srcs')
 				publicHeaders.from('includes')
 			}
 		'''
@@ -64,7 +64,7 @@ class CppApplicationNativeLanguageSourceLayoutFunctionalTest extends AbstractNat
 	protected String configureSourcesAsConvention() {
 		return """
 			application {
-				sources.from('srcs')
+				cppSources.from('srcs')
 				privateHeaders.from('includes')
 			}
 		"""
@@ -74,7 +74,7 @@ class CppApplicationNativeLanguageSourceLayoutFunctionalTest extends AbstractNat
 	protected String configureSourcesAsExplicitFiles() {
 		return """
 			application {
-				${componentUnderTest.sources.files.collect { "sources.from('srcs/${it.name}')" }.join('\n')}
+				${componentUnderTest.sources.files.collect { "cppSources.from('srcs/${it.name}')" }.join('\n')}
 				privateHeaders.from('includes')
 			}
 		"""
@@ -114,7 +114,7 @@ class CppLibraryNativeLanguageSourceLayoutFunctionalTest extends AbstractNativeL
 			}
 
 			library {
-				sources.from('srcs')
+				cppSources.from('srcs')
 				privateHeaders.from('includes')
 				dependencies {
 					implementation project(':library')
@@ -127,7 +127,7 @@ class CppLibraryNativeLanguageSourceLayoutFunctionalTest extends AbstractNativeL
 			}
 
 			library {
-				sources.from('srcs')
+				cppSources.from('srcs')
 				publicHeaders.from('includes')
 			}
 		'''
@@ -145,7 +145,7 @@ class CppLibraryNativeLanguageSourceLayoutFunctionalTest extends AbstractNativeL
 	protected String configureSourcesAsConvention() {
 		return """
 			library {
-				sources.from('srcs')
+				cppSources.from('srcs')
 				privateHeaders.from('headers')
 				publicHeaders.from('includes')
 			}
@@ -156,7 +156,7 @@ class CppLibraryNativeLanguageSourceLayoutFunctionalTest extends AbstractNativeL
 	protected String configureSourcesAsExplicitFiles() {
 		return """
 			library {
-				${componentUnderTest.sources.files.collect { "sources.from('srcs/${it.name}')" }.join('\n')}
+				${componentUnderTest.sources.files.collect { "cppSources.from('srcs/${it.name}')" }.join('\n')}
 				privateHeaders.from('headers')
 				publicHeaders.from('includes')
 			}

--- a/subprojects/platform-native/src/functionalTest/groovy/dev/nokee/platform/objectivec/ObjectiveCLanguageSourceLayoutFunctionalTest.groovy
+++ b/subprojects/platform-native/src/functionalTest/groovy/dev/nokee/platform/objectivec/ObjectiveCLanguageSourceLayoutFunctionalTest.groovy
@@ -45,7 +45,7 @@ class ObjectiveCApplicationNativeLanguageSourceLayoutFunctionalTest extends Abst
 			}
 
 			application {
-				sources.from('srcs')
+				objectiveCSources.from('srcs')
 				dependencies {
 					implementation project(':library')
 				}
@@ -61,7 +61,7 @@ class ObjectiveCApplicationNativeLanguageSourceLayoutFunctionalTest extends Abst
 			}
 
 			library {
-				sources.from('srcs')
+				objectiveCSources.from('srcs')
 				publicHeaders.from('includes')
 			}
 
@@ -82,7 +82,7 @@ class ObjectiveCApplicationNativeLanguageSourceLayoutFunctionalTest extends Abst
 	protected String configureSourcesAsConvention() {
 		return """
 			application {
-				sources.from('srcs')
+				objectiveCSources.from('srcs')
 				privateHeaders.from('includes')
 			}
 		"""
@@ -92,7 +92,7 @@ class ObjectiveCApplicationNativeLanguageSourceLayoutFunctionalTest extends Abst
 	protected String configureSourcesAsExplicitFiles() {
 		return """
 			application {
-				${componentUnderTest.sources.files.collect { "sources.from('srcs/${it.name}')" }.join('\n')}
+				${componentUnderTest.sources.files.collect { "objectiveCSources.from('srcs/${it.name}')" }.join('\n')}
 				privateHeaders.from('includes')
 			}
 		"""
@@ -138,7 +138,7 @@ class ObjectiveCLibraryNativeLanguageSourceLayoutFunctionalTest extends Abstract
 			}
 
 			library {
-				sources.from('srcs')
+				objectiveCSources.from('srcs')
 				privateHeaders.from('includes')
 				dependencies {
 					implementation project(':library')
@@ -155,7 +155,7 @@ class ObjectiveCLibraryNativeLanguageSourceLayoutFunctionalTest extends Abstract
 			}
 
 			library {
-				sources.from('srcs')
+				objectiveCSources.from('srcs')
 				publicHeaders.from('includes')
 			}
 
@@ -177,7 +177,7 @@ class ObjectiveCLibraryNativeLanguageSourceLayoutFunctionalTest extends Abstract
 	protected String configureSourcesAsConvention() {
 		return """
 			library {
-				sources.from('srcs')
+				objectiveCSources.from('srcs')
 				privateHeaders.from('headers')
 				publicHeaders.from('includes')
 			}
@@ -188,7 +188,7 @@ class ObjectiveCLibraryNativeLanguageSourceLayoutFunctionalTest extends Abstract
 	protected String configureSourcesAsExplicitFiles() {
 		return """
 			library {
-				${componentUnderTest.sources.files.collect { "sources.from('srcs/${it.name}')" }.join('\n')}
+				${componentUnderTest.sources.files.collect { "objectiveCSources.from('srcs/${it.name}')" }.join('\n')}
 				privateHeaders.from('headers')
 				publicHeaders.from('includes')
 			}

--- a/subprojects/platform-native/src/functionalTest/groovy/dev/nokee/platform/objectivecpp/ObjectiveCppLanguageSourceLayoutFunctionalTest.groovy
+++ b/subprojects/platform-native/src/functionalTest/groovy/dev/nokee/platform/objectivecpp/ObjectiveCppLanguageSourceLayoutFunctionalTest.groovy
@@ -45,7 +45,7 @@ class ObjectiveCppApplicationNativeLanguageSourceLayoutFunctionalTest extends Ab
 			}
 
 			application {
-				sources.from('srcs')
+				objectiveCppSources.from('srcs')
 				dependencies {
 					implementation project(':library')
 				}
@@ -61,7 +61,7 @@ class ObjectiveCppApplicationNativeLanguageSourceLayoutFunctionalTest extends Ab
 			}
 
 			library {
-				sources.from('srcs')
+				objectiveCppSources.from('srcs')
 				publicHeaders.from('includes')
 			}
 
@@ -82,7 +82,7 @@ class ObjectiveCppApplicationNativeLanguageSourceLayoutFunctionalTest extends Ab
 	protected String configureSourcesAsConvention() {
 		return """
 			application {
-				sources.from('srcs')
+				objectiveCppSources.from('srcs')
 				privateHeaders.from('includes')
 			}
 		"""
@@ -92,7 +92,7 @@ class ObjectiveCppApplicationNativeLanguageSourceLayoutFunctionalTest extends Ab
 	protected String configureSourcesAsExplicitFiles() {
 		return """
 			application {
-				${componentUnderTest.sources.files.collect { "sources.from('srcs/${it.name}')" }.join('\n')}
+				${componentUnderTest.sources.files.collect { "objectiveCppSources.from('srcs/${it.name}')" }.join('\n')}
 				privateHeaders.from('includes')
 			}
 		"""
@@ -138,7 +138,7 @@ class ObjectiveCppLibraryNativeLanguageSourceLayoutFunctionalTest extends Abstra
 			}
 
 			library {
-				sources.from('srcs')
+				objectiveCppSources.from('srcs')
 				privateHeaders.from('includes')
 				dependencies {
 					implementation project(':library')
@@ -155,7 +155,7 @@ class ObjectiveCppLibraryNativeLanguageSourceLayoutFunctionalTest extends Abstra
 			}
 
 			library {
-				sources.from('srcs')
+				objectiveCppSources.from('srcs')
 				publicHeaders.from('includes')
 			}
 
@@ -177,7 +177,7 @@ class ObjectiveCppLibraryNativeLanguageSourceLayoutFunctionalTest extends Abstra
 	protected String configureSourcesAsConvention() {
 		return """
 			library {
-				sources.from('srcs')
+				objectiveCppSources.from('srcs')
 				privateHeaders.from('headers')
 				publicHeaders.from('includes')
 			}
@@ -188,7 +188,7 @@ class ObjectiveCppLibraryNativeLanguageSourceLayoutFunctionalTest extends Abstra
 	protected String configureSourcesAsExplicitFiles() {
 		return """
 			library {
-				${componentUnderTest.sources.files.collect { "sources.from('srcs/${it.name}')" }.join('\n')}
+				${componentUnderTest.sources.files.collect { "objectiveCppSources.from('srcs/${it.name}')" }.join('\n')}
 				privateHeaders.from('headers')
 				publicHeaders.from('includes')
 			}

--- a/subprojects/platform-native/src/functionalTest/groovy/dev/nokee/platform/swift/SwiftLanguageSourceLayoutFunctionalTest.groovy
+++ b/subprojects/platform-native/src/functionalTest/groovy/dev/nokee/platform/swift/SwiftLanguageSourceLayoutFunctionalTest.groovy
@@ -35,7 +35,7 @@ class SwiftApplicationNativeLanguageSourceLayoutFunctionalTest extends AbstractN
 			}
 
 			application {
-				sources.from('srcs')
+				swiftSources.from('srcs')
 				dependencies {
 					implementation project(':library')
 				}
@@ -47,7 +47,7 @@ class SwiftApplicationNativeLanguageSourceLayoutFunctionalTest extends AbstractN
 			}
 
 			library {
-				sources.from('srcs')
+				swiftSources.from('srcs')
 			}
 		'''
 		def fixture = componentUnderTest.withImplementationAsSubproject('library')
@@ -62,7 +62,7 @@ class SwiftApplicationNativeLanguageSourceLayoutFunctionalTest extends AbstractN
 	protected String configureSourcesAsConvention() {
 		return """
 			application {
-				sources.from('srcs')
+				swiftSources.from('srcs')
 			}
 		"""
 	}
@@ -71,7 +71,7 @@ class SwiftApplicationNativeLanguageSourceLayoutFunctionalTest extends AbstractN
 	protected String configureSourcesAsExplicitFiles() {
 		return """
 			application {
-				${componentUnderTest.files.collect { "sources.from('srcs/${it.name}')" }.join('\n')}
+				${componentUnderTest.files.collect { "swiftSources.from('srcs/${it.name}')" }.join('\n')}
 			}
 		"""
 	}
@@ -104,7 +104,7 @@ class SwiftLibraryNativeLanguageSourceLayoutFunctionalTest extends AbstractNativ
 			}
 
 			library {
-				sources.from('srcs')
+				swiftSources.from('srcs')
 				dependencies {
 					implementation project(':library')
 				}
@@ -116,7 +116,7 @@ class SwiftLibraryNativeLanguageSourceLayoutFunctionalTest extends AbstractNativ
 			}
 
 			library {
-				sources.from('srcs')
+				swiftSources.from('srcs')
 			}
 		'''
 		def fixture = componentUnderTest.withImplementationAsSubproject('library')
@@ -131,7 +131,7 @@ class SwiftLibraryNativeLanguageSourceLayoutFunctionalTest extends AbstractNativ
 	protected String configureSourcesAsConvention() {
 		return """
 			library {
-				sources.from('srcs')
+				swiftSources.from('srcs')
 			}
 		"""
 	}
@@ -140,7 +140,7 @@ class SwiftLibraryNativeLanguageSourceLayoutFunctionalTest extends AbstractNativ
 	protected String configureSourcesAsExplicitFiles() {
 		return """
 			library {
-				${componentUnderTest.files.collect { "sources.from('srcs/${it.name}')" }.join('\n')}
+				${componentUnderTest.files.collect { "swiftSources.from('srcs/${it.name}')" }.join('\n')}
 			}
 		"""
 	}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/c/CApplicationExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/c/CApplicationExtension.java
@@ -26,7 +26,7 @@ public interface CApplicationExtension extends DependencyAwareComponent<NativeAp
 	 *
 	 * @since 0.5
 	 */
-	ConfigurableFileCollection getSources();
+	ConfigurableFileCollection getCSources();
 
 	/**
 	 * Defines the private headers search directories of this application.

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/c/CLibraryExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/c/CLibraryExtension.java
@@ -23,7 +23,7 @@ public interface CLibraryExtension extends DependencyAwareComponent<NativeLibrar
 	 *
 	 * @since 0.5
 	 */
-	ConfigurableFileCollection getSources();
+	ConfigurableFileCollection getCSources();
 
 	/**
 	 * Defines the private headers search directories of this library.

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/DefaultCApplicationExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/DefaultCApplicationExtension.java
@@ -22,7 +22,7 @@ import org.gradle.api.provider.SetProperty;
 import javax.inject.Inject;
 
 public class DefaultCApplicationExtension extends BaseNativeExtension<DefaultNativeApplicationComponent> implements CApplicationExtension, Component {
-	@Getter private final ConfigurableFileCollection sources;
+	@Getter private final ConfigurableFileCollection cSources;
 	@Getter private final ConfigurableFileCollection privateHeaders;
 	@Getter private final SetProperty<TargetMachine> targetMachines;
 	@Getter private final SetProperty<TargetBuildType> targetBuildTypes;
@@ -30,11 +30,11 @@ public class DefaultCApplicationExtension extends BaseNativeExtension<DefaultNat
 	@Inject
 	public DefaultCApplicationExtension(DefaultNativeApplicationComponent component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
 		super(component, objects, providers, layout);
-		this.sources = objects.fileCollection();
+		this.cSources = objects.fileCollection();
 		this.privateHeaders = objects.fileCollection();
 		this.targetMachines = objects.setProperty(TargetMachine.class);
 		this.targetBuildTypes = objects.setProperty(TargetBuildType.class);
-		getComponent().getSourceCollection().add(getObjects().newInstance(CSourceSet.class, "c").from(getSources().getElements().map(toIfEmpty("src/main/c"))));
+		getComponent().getSourceCollection().add(getObjects().newInstance(CSourceSet.class, "c").from(getCSources().getElements().map(toIfEmpty("src/main/c"))));
 		getComponent().getSourceCollection().add(getObjects().newInstance(CHeaderSet.class, "headers").srcDir(getPrivateHeaders().getElements().map(toIfEmpty("src/main/headers"))));
 	}
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/DefaultCApplicationExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/DefaultCApplicationExtension.java
@@ -22,7 +22,7 @@ import org.gradle.api.provider.SetProperty;
 import javax.inject.Inject;
 
 public class DefaultCApplicationExtension extends BaseNativeExtension<DefaultNativeApplicationComponent> implements CApplicationExtension, Component {
-	@Getter private final ConfigurableFileCollection cSources;
+	private final ConfigurableFileCollection cSources;
 	@Getter private final ConfigurableFileCollection privateHeaders;
 	@Getter private final SetProperty<TargetMachine> targetMachines;
 	@Getter private final SetProperty<TargetBuildType> targetBuildTypes;
@@ -34,8 +34,17 @@ public class DefaultCApplicationExtension extends BaseNativeExtension<DefaultNat
 		this.privateHeaders = objects.fileCollection();
 		this.targetMachines = objects.setProperty(TargetMachine.class);
 		this.targetBuildTypes = objects.setProperty(TargetBuildType.class);
-		getComponent().getSourceCollection().add(getObjects().newInstance(CSourceSet.class, "c").from(getCSources().getElements().map(toIfEmpty("src/main/c"))));
+		getComponent().getSourceCollection().add(getObjects().newInstance(CSourceSet.class, "c").from(cSources.getElements().map(toIfEmpty("src/main/c"))));
 		getComponent().getSourceCollection().add(getObjects().newInstance(CHeaderSet.class, "headers").srcDir(getPrivateHeaders().getElements().map(toIfEmpty("src/main/headers"))));
+	}
+
+	@Override
+	public ConfigurableFileCollection getCSources() {
+		return cSources;
+	}
+
+	public ConfigurableFileCollection getcSources() {
+		return cSources;
 	}
 
 	@Override

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/DefaultCLibraryExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/DefaultCLibraryExtension.java
@@ -23,7 +23,7 @@ import org.gradle.api.provider.SetProperty;
 import javax.inject.Inject;
 
 public class DefaultCLibraryExtension extends BaseNativeExtension<DefaultNativeLibraryComponent> implements CLibraryExtension, Component {
-	@Getter private final ConfigurableFileCollection cSources;
+	private final ConfigurableFileCollection cSources;
 	@Getter private final ConfigurableFileCollection privateHeaders;
 	@Getter private final ConfigurableFileCollection publicHeaders;
 	@Getter private final SetProperty<TargetLinkage> targetLinkages;
@@ -40,9 +40,18 @@ public class DefaultCLibraryExtension extends BaseNativeExtension<DefaultNativeL
 		this.targetMachines = objects.setProperty(TargetMachine.class);
 		this.targetBuildTypes = objects.setProperty(TargetBuildType.class);
 
-		getComponent().getSourceCollection().add(getObjects().newInstance(CSourceSet.class, "c").from(getCSources().getElements().map(toIfEmpty("src/main/c"))));
+		getComponent().getSourceCollection().add(getObjects().newInstance(CSourceSet.class, "c").from(cSources.getElements().map(toIfEmpty("src/main/c"))));
 		getComponent().getSourceCollection().add(getObjects().newInstance(CHeaderSet.class, "headers").srcDir(getPrivateHeaders().getElements().map(toIfEmpty("src/main/headers"))));
 		getComponent().getSourceCollection().add(getObjects().newInstance(CHeaderSet.class, "public").srcDir(getPublicHeaders().getElements().map(toIfEmpty("src/main/public"))));
+	}
+
+	@Override
+	public ConfigurableFileCollection getCSources() {
+		return cSources;
+	}
+
+	public ConfigurableFileCollection getcSources() {
+		return cSources;
 	}
 
 	@Override

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/DefaultCLibraryExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/c/internal/DefaultCLibraryExtension.java
@@ -23,7 +23,7 @@ import org.gradle.api.provider.SetProperty;
 import javax.inject.Inject;
 
 public class DefaultCLibraryExtension extends BaseNativeExtension<DefaultNativeLibraryComponent> implements CLibraryExtension, Component {
-	@Getter private final ConfigurableFileCollection sources;
+	@Getter private final ConfigurableFileCollection cSources;
 	@Getter private final ConfigurableFileCollection privateHeaders;
 	@Getter private final ConfigurableFileCollection publicHeaders;
 	@Getter private final SetProperty<TargetLinkage> targetLinkages;
@@ -33,14 +33,14 @@ public class DefaultCLibraryExtension extends BaseNativeExtension<DefaultNativeL
 	@Inject
 	public DefaultCLibraryExtension(DefaultNativeLibraryComponent component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
 		super(component, objects, providers, layout);
-		this.sources = objects.fileCollection();
+		this.cSources = objects.fileCollection();
 		this.privateHeaders = objects.fileCollection();
 		this.publicHeaders = objects.fileCollection();
 		this.targetLinkages = objects.setProperty(TargetLinkage.class);
 		this.targetMachines = objects.setProperty(TargetMachine.class);
 		this.targetBuildTypes = objects.setProperty(TargetBuildType.class);
 
-		getComponent().getSourceCollection().add(getObjects().newInstance(CSourceSet.class, "c").from(getSources().getElements().map(toIfEmpty("src/main/c"))));
+		getComponent().getSourceCollection().add(getObjects().newInstance(CSourceSet.class, "c").from(getCSources().getElements().map(toIfEmpty("src/main/c"))));
 		getComponent().getSourceCollection().add(getObjects().newInstance(CHeaderSet.class, "headers").srcDir(getPrivateHeaders().getElements().map(toIfEmpty("src/main/headers"))));
 		getComponent().getSourceCollection().add(getObjects().newInstance(CHeaderSet.class, "public").srcDir(getPublicHeaders().getElements().map(toIfEmpty("src/main/public"))));
 	}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/CppApplicationExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/CppApplicationExtension.java
@@ -23,7 +23,7 @@ public interface CppApplicationExtension extends DependencyAwareComponent<Native
 	 *
 	 * @since 0.5
 	 */
-	ConfigurableFileCollection getSources();
+	ConfigurableFileCollection getCppSources();
 
 	/**
 	 * Defines the private headers search directories of this application.

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/CppLibraryExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/CppLibraryExtension.java
@@ -23,7 +23,7 @@ public interface CppLibraryExtension extends DependencyAwareComponent<NativeLibr
 	 *
 	 * @since 0.5
 	 */
-	ConfigurableFileCollection getSources();
+	ConfigurableFileCollection getCppSources();
 
 	/**
 	 * Defines the private headers search directories of this library.

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/DefaultCppApplicationExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/DefaultCppApplicationExtension.java
@@ -22,7 +22,7 @@ import org.gradle.api.provider.SetProperty;
 import javax.inject.Inject;
 
 public class DefaultCppApplicationExtension extends BaseNativeExtension<DefaultNativeApplicationComponent> implements CppApplicationExtension, Component {
-	@Getter private final ConfigurableFileCollection sources;
+	@Getter private final ConfigurableFileCollection cppSources;
 	@Getter private final ConfigurableFileCollection privateHeaders;
 	@Getter private final SetProperty<TargetMachine> targetMachines;
 	@Getter private final SetProperty<TargetBuildType> targetBuildTypes;
@@ -30,12 +30,12 @@ public class DefaultCppApplicationExtension extends BaseNativeExtension<DefaultN
 	@Inject
 	public DefaultCppApplicationExtension(DefaultNativeApplicationComponent component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
 		super(component, objects, providers, layout);
-		this.sources = objects.fileCollection();
+		this.cppSources = objects.fileCollection();
 		this.privateHeaders = objects.fileCollection();
 		this.targetMachines = objects.setProperty(TargetMachine.class);
 		this.targetBuildTypes = objects.setProperty(TargetBuildType.class);
 
-		getComponent().getSourceCollection().add(getObjects().newInstance(CppSourceSet.class, "cpp").from(getSources().getElements().map(toIfEmpty("src/main/cpp"))));
+		getComponent().getSourceCollection().add(getObjects().newInstance(CppSourceSet.class, "cpp").from(this.getCppSources().getElements().map(toIfEmpty("src/main/cpp"))));
 		getComponent().getSourceCollection().add(getObjects().newInstance(CppHeaderSet.class, "headers").srcDir(getPrivateHeaders().getElements().map(toIfEmpty("src/main/headers"))));
 	}
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/DefaultCppLibraryExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/cpp/internal/DefaultCppLibraryExtension.java
@@ -23,7 +23,7 @@ import org.gradle.api.provider.SetProperty;
 import javax.inject.Inject;
 
 public class DefaultCppLibraryExtension extends BaseNativeExtension<DefaultNativeLibraryComponent> implements CppLibraryExtension, Component {
-	@Getter private final ConfigurableFileCollection sources;
+	@Getter private final ConfigurableFileCollection cppSources;
 	@Getter private final ConfigurableFileCollection privateHeaders;
 	@Getter private final ConfigurableFileCollection publicHeaders;
 	@Getter private final SetProperty<TargetLinkage> targetLinkages;
@@ -33,14 +33,14 @@ public class DefaultCppLibraryExtension extends BaseNativeExtension<DefaultNativ
 	@Inject
 	public DefaultCppLibraryExtension(DefaultNativeLibraryComponent component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
 		super(component, objects, providers, layout);
-		this.sources = objects.fileCollection();
+		this.cppSources = objects.fileCollection();
 		this.privateHeaders = objects.fileCollection();
 		this.publicHeaders = objects.fileCollection();
 		this.targetLinkages = objects.setProperty(TargetLinkage.class);
 		this.targetMachines = objects.setProperty(TargetMachine.class);
 		this.targetBuildTypes = objects.setProperty(TargetBuildType.class);
 
-		getComponent().getSourceCollection().add(getObjects().newInstance(CppSourceSet.class, "cpp").from(getSources().getElements().map(toIfEmpty("src/main/cpp"))));
+		getComponent().getSourceCollection().add(getObjects().newInstance(CppSourceSet.class, "cpp").from(this.getCppSources().getElements().map(toIfEmpty("src/main/cpp"))));
 		getComponent().getSourceCollection().add(getObjects().newInstance(CppHeaderSet.class, "headers").srcDir(getPrivateHeaders().getElements().map(toIfEmpty("src/main/headers"))));
 		getComponent().getSourceCollection().add(getObjects().newInstance(CppHeaderSet.class, "public").srcDir(getPublicHeaders().getElements().map(toIfEmpty("src/main/public"))));
 	}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/ObjectiveCApplicationExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/ObjectiveCApplicationExtension.java
@@ -26,7 +26,7 @@ public interface ObjectiveCApplicationExtension extends DependencyAwareComponent
 	 *
 	 * @since 0.5
 	 */
-	ConfigurableFileCollection getSources();
+	ConfigurableFileCollection getObjectiveCSources();
 
 	/**
 	 * Defines the private headers search directories of this application.

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/ObjectiveCLibraryExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/ObjectiveCLibraryExtension.java
@@ -23,7 +23,7 @@ public interface ObjectiveCLibraryExtension extends DependencyAwareComponent<Nat
 	 *
 	 * @since 0.5
 	 */
-	ConfigurableFileCollection getSources();
+	ConfigurableFileCollection getObjectiveCSources();
 
 	/**
 	 * Defines the private headers search directories of this library.

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/DefaultObjectiveCApplicationExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/DefaultObjectiveCApplicationExtension.java
@@ -22,7 +22,7 @@ import org.gradle.api.provider.SetProperty;
 import javax.inject.Inject;
 
 public class DefaultObjectiveCApplicationExtension extends BaseNativeExtension<DefaultNativeApplicationComponent> implements ObjectiveCApplicationExtension, Component {
-	@Getter private final ConfigurableFileCollection sources;
+	@Getter private final ConfigurableFileCollection objectiveCSources;
 	@Getter private final ConfigurableFileCollection privateHeaders;
 	@Getter private final SetProperty<TargetMachine> targetMachines;
 	@Getter private final SetProperty<TargetBuildType> targetBuildTypes;
@@ -30,12 +30,12 @@ public class DefaultObjectiveCApplicationExtension extends BaseNativeExtension<D
 	@Inject
 	public DefaultObjectiveCApplicationExtension(DefaultNativeApplicationComponent component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
 		super(component, objects, providers, layout);
-		this.sources = objects.fileCollection();
+		this.objectiveCSources = objects.fileCollection();
 		this.privateHeaders = objects.fileCollection();
 		this.targetMachines = objects.setProperty(TargetMachine.class);
 		this.targetBuildTypes = objects.setProperty(TargetBuildType.class);
 
-		getComponent().getSourceCollection().add(getObjects().newInstance(ObjectiveCSourceSet.class, "objc").from(getSources().getElements().map(toIfEmpty("src/main/objc"))));
+		getComponent().getSourceCollection().add(getObjects().newInstance(ObjectiveCSourceSet.class, "objc").from(this.getObjectiveCSources().getElements().map(toIfEmpty("src/main/objc"))));
 		getComponent().getSourceCollection().add(getObjects().newInstance(CHeaderSet.class, "headers").srcDir(getPrivateHeaders().getElements().map(toIfEmpty("src/main/headers"))));
 	}
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/DefaultObjectiveCLibraryExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivec/internal/DefaultObjectiveCLibraryExtension.java
@@ -23,7 +23,7 @@ import org.gradle.api.provider.SetProperty;
 import javax.inject.Inject;
 
 public class DefaultObjectiveCLibraryExtension extends BaseNativeExtension<DefaultNativeLibraryComponent> implements ObjectiveCLibraryExtension, Component {
-	@Getter private final ConfigurableFileCollection sources;
+	@Getter private final ConfigurableFileCollection objectiveCSources;
 	@Getter private final ConfigurableFileCollection privateHeaders;
 	@Getter private final ConfigurableFileCollection publicHeaders;
 	@Getter private final SetProperty<TargetLinkage> targetLinkages;
@@ -33,14 +33,14 @@ public class DefaultObjectiveCLibraryExtension extends BaseNativeExtension<Defau
 	@Inject
 	public DefaultObjectiveCLibraryExtension(DefaultNativeLibraryComponent component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
 		super(component, objects, providers, layout);
-		this.sources = objects.fileCollection();
+		this.objectiveCSources = objects.fileCollection();
 		this.privateHeaders = objects.fileCollection();
 		this.publicHeaders = objects.fileCollection();
 		this.targetLinkages = objects.setProperty(TargetLinkage.class);
 		this.targetMachines = objects.setProperty(TargetMachine.class);
 		this.targetBuildTypes = objects.setProperty(TargetBuildType.class);
 
-		getComponent().getSourceCollection().add(getObjects().newInstance(ObjectiveCSourceSet.class, "objc").from(getSources().getElements().map(toIfEmpty("src/main/objc"))));
+		getComponent().getSourceCollection().add(getObjects().newInstance(ObjectiveCSourceSet.class, "objc").from(this.getObjectiveCSources().getElements().map(toIfEmpty("src/main/objc"))));
 		getComponent().getSourceCollection().add(getObjects().newInstance(CHeaderSet.class, "headers").srcDir(getPrivateHeaders().getElements().map(toIfEmpty("src/main/headers"))));
 		getComponent().getSourceCollection().add(getObjects().newInstance(CHeaderSet.class, "public").srcDir(getPublicHeaders().getElements().map(toIfEmpty("src/main/public"))));
 	}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/ObjectiveCppApplicationExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/ObjectiveCppApplicationExtension.java
@@ -26,7 +26,7 @@ public interface ObjectiveCppApplicationExtension extends DependencyAwareCompone
 	 *
 	 * @since 0.5
 	 */
-	ConfigurableFileCollection getSources();
+	ConfigurableFileCollection getObjectiveCppSources();
 
 	/**
 	 * Defines the private headers search directories of this application.

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/ObjectiveCppLibraryExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/ObjectiveCppLibraryExtension.java
@@ -23,7 +23,7 @@ public interface ObjectiveCppLibraryExtension extends DependencyAwareComponent<N
 	 *
 	 * @since 0.5
 	 */
-	ConfigurableFileCollection getSources();
+	ConfigurableFileCollection getObjectiveCppSources();
 
 	/**
 	 * Defines the private headers search directories of this library.

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/DefaultObjectiveCppApplicationExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/DefaultObjectiveCppApplicationExtension.java
@@ -22,7 +22,7 @@ import org.gradle.api.provider.SetProperty;
 import javax.inject.Inject;
 
 public class DefaultObjectiveCppApplicationExtension extends BaseNativeExtension<DefaultNativeApplicationComponent> implements ObjectiveCppApplicationExtension, Component {
-	@Getter private final ConfigurableFileCollection sources;
+	@Getter private final ConfigurableFileCollection objectiveCppSources;
 	@Getter private final ConfigurableFileCollection privateHeaders;
 	@Getter private final SetProperty<TargetMachine> targetMachines;
 	@Getter private final SetProperty<TargetBuildType> targetBuildTypes;
@@ -30,12 +30,12 @@ public class DefaultObjectiveCppApplicationExtension extends BaseNativeExtension
 	@Inject
 	public DefaultObjectiveCppApplicationExtension(DefaultNativeApplicationComponent component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
 		super(component, objects, providers, layout);
-		this.sources = objects.fileCollection();
+		this.objectiveCppSources = objects.fileCollection();
 		this.privateHeaders = objects.fileCollection();
 		this.targetMachines = objects.setProperty(TargetMachine.class);
 		this.targetBuildTypes = objects.setProperty(TargetBuildType.class);
 
-		getComponent().getSourceCollection().add(getObjects().newInstance(ObjectiveCppSourceSet.class, "objcpp").from(getSources().getElements().map(toIfEmpty("src/main/objcpp"))));
+		getComponent().getSourceCollection().add(getObjects().newInstance(ObjectiveCppSourceSet.class, "objcpp").from(this.getObjectiveCppSources().getElements().map(toIfEmpty("src/main/objcpp"))));
 		getComponent().getSourceCollection().add(getObjects().newInstance(CppHeaderSet.class, "headers").srcDir(getPrivateHeaders().getElements().map(toIfEmpty("src/main/headers"))));
 	}
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/DefaultObjectiveCppLibraryExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/objectivecpp/internal/DefaultObjectiveCppLibraryExtension.java
@@ -23,7 +23,7 @@ import org.gradle.api.provider.SetProperty;
 import javax.inject.Inject;
 
 public class DefaultObjectiveCppLibraryExtension extends BaseNativeExtension<DefaultNativeLibraryComponent> implements ObjectiveCppLibraryExtension, Component {
-	@Getter private final ConfigurableFileCollection sources;
+	@Getter private final ConfigurableFileCollection objectiveCppSources;
 	@Getter private final ConfigurableFileCollection privateHeaders;
 	@Getter private final ConfigurableFileCollection publicHeaders;
 	@Getter private final SetProperty<TargetLinkage> targetLinkages;
@@ -33,14 +33,14 @@ public class DefaultObjectiveCppLibraryExtension extends BaseNativeExtension<Def
 	@Inject
 	public DefaultObjectiveCppLibraryExtension(DefaultNativeLibraryComponent component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
 		super(component, objects, providers, layout);
-		this.sources = objects.fileCollection();
+		this.objectiveCppSources = objects.fileCollection();
 		this.privateHeaders = objects.fileCollection();
 		this.publicHeaders = objects.fileCollection();
 		this.targetLinkages = objects.setProperty(TargetLinkage.class);
 		this.targetMachines = objects.setProperty(TargetMachine.class);
 		this.targetBuildTypes = objects.setProperty(TargetBuildType.class);
 
-		getComponent().getSourceCollection().add(getObjects().newInstance(ObjectiveCppSourceSet.class, "objcpp").from(getSources().getElements().map(toIfEmpty("src/main/objcpp"))));
+		getComponent().getSourceCollection().add(getObjects().newInstance(ObjectiveCppSourceSet.class, "objcpp").from(this.getObjectiveCppSources().getElements().map(toIfEmpty("src/main/objcpp"))));
 		getComponent().getSourceCollection().add(getObjects().newInstance(CppHeaderSet.class, "headers").srcDir(getPrivateHeaders().getElements().map(toIfEmpty("src/main/headers"))));
 		getComponent().getSourceCollection().add(getObjects().newInstance(CppHeaderSet.class, "public").srcDir(getPublicHeaders().getElements().map(toIfEmpty("src/main/public"))));
 	}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/SwiftApplicationExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/SwiftApplicationExtension.java
@@ -26,5 +26,5 @@ public interface SwiftApplicationExtension extends DependencyAwareComponent<Nati
 	 *
 	 * @since 0.5
 	 */
-	ConfigurableFileCollection getSources();
+	ConfigurableFileCollection getSwiftSources();
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/SwiftLibraryExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/SwiftLibraryExtension.java
@@ -23,5 +23,5 @@ public interface SwiftLibraryExtension extends DependencyAwareComponent<NativeLi
 	 *
 	 * @since 0.5
 	 */
-	ConfigurableFileCollection getSources();
+	ConfigurableFileCollection getSwiftSources();
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/DefaultSwiftApplicationExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/DefaultSwiftApplicationExtension.java
@@ -21,18 +21,18 @@ import org.gradle.api.provider.SetProperty;
 import javax.inject.Inject;
 
 public class DefaultSwiftApplicationExtension extends BaseNativeExtension<DefaultNativeApplicationComponent> implements SwiftApplicationExtension, Component {
-	@Getter private final ConfigurableFileCollection sources;
+	@Getter private final ConfigurableFileCollection swiftSources;
 	@Getter private final SetProperty<TargetMachine> targetMachines;
 	@Getter private final SetProperty<TargetBuildType> targetBuildTypes;
 
 	@Inject
 	public DefaultSwiftApplicationExtension(DefaultNativeApplicationComponent component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
 		super(component, objects, providers, layout);
-		this.sources = objects.fileCollection();
+		this.swiftSources = objects.fileCollection();
 		this.targetMachines = objects.setProperty(TargetMachine.class);
 		this.targetBuildTypes = objects.setProperty(TargetBuildType.class);
 
-		getComponent().getSourceCollection().add(getObjects().newInstance(SwiftSourceSet.class, "swift").from(getSources().getElements().map(toIfEmpty("src/main/swift"))));
+		getComponent().getSourceCollection().add(getObjects().newInstance(SwiftSourceSet.class, "swift").from(this.getSwiftSources().getElements().map(toIfEmpty("src/main/swift"))));
 	}
 
 	@Override

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/DefaultSwiftLibraryExtension.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/swift/internal/DefaultSwiftLibraryExtension.java
@@ -22,7 +22,7 @@ import org.gradle.api.provider.SetProperty;
 import javax.inject.Inject;
 
 public class DefaultSwiftLibraryExtension extends BaseNativeExtension<DefaultNativeLibraryComponent> implements SwiftLibraryExtension, Component {
-	@Getter private final ConfigurableFileCollection sources;
+	@Getter private final ConfigurableFileCollection swiftSources;
 	@Getter private final SetProperty<TargetLinkage> targetLinkages;
 	@Getter private final SetProperty<TargetMachine> targetMachines;
 	@Getter private final SetProperty<TargetBuildType> targetBuildTypes;
@@ -30,12 +30,12 @@ public class DefaultSwiftLibraryExtension extends BaseNativeExtension<DefaultNat
 	@Inject
 	public DefaultSwiftLibraryExtension(DefaultNativeLibraryComponent component, ObjectFactory objects, ProviderFactory providers, ProjectLayout layout) {
 		super(component, objects, providers, layout);
-		this.sources = objects.fileCollection();
+		this.swiftSources = objects.fileCollection();
 		this.targetLinkages = objects.setProperty(TargetLinkage.class);
 		this.targetMachines = objects.setProperty(TargetMachine.class);
 		this.targetBuildTypes = objects.setProperty(TargetBuildType.class);
 
-		getComponent().getSourceCollection().add(getObjects().newInstance(SwiftSourceSet.class, "swift").from(getSources().getElements().map(toIfEmpty("src/main/swift"))));
+		getComponent().getSourceCollection().add(getObjects().newInstance(SwiftSourceSet.class, "swift").from(this.getSwiftSources().getElements().map(toIfEmpty("src/main/swift"))));
 	}
 
 	@Override


### PR DESCRIPTION
The getSources() methods will be use for the source view of all the
sources available on a component.