### PR TITLE
Remove the custom code for attaching build scan to commit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,23 +22,6 @@ jobs:
                 env:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                     CI: true
-            -   name: Attach build scan to commit
-                if: ${{ always() }}
-                shell: bash
-                run: |
-                    curl \
-                    --silent \
-                    --show-error \
-                    --fail \
-                    --request POST \
-                    --url https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }} \
-                    --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-                    --header "Accept: application/vnd.github.v3+json" \
-                    --data '{
-                            "state":"${{ steps.gradle.outcome }}",
-                            "target_url": "${{ steps.gradle.outputs.build-scan-url }}",
-                            "context": "SCAN / assemble"
-                        }'
     deploy:
         needs: assemble
         runs-on: ubuntu-latest
@@ -59,23 +42,6 @@ jobs:
                     BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
                     BINTRAY_KEY: ${{ secrets.BINTRAY_KEY }}
                     CI: true
-            -   name: Attach build scan to commit
-                if: ${{ always() }}
-                shell: bash
-                run: |
-                    curl \
-                    --silent \
-                    --show-error \
-                    --fail \
-                    --request POST \
-                    --url https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }} \
-                    --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-                    --header "Accept: application/vnd.github.v3+json" \
-                    --data '{
-                            "state":"${{ steps.gradle.outcome }}",
-                            "target_url": "${{ steps.gradle.outputs.build-scan-url }}",
-                            "context": "SCAN / :distributions:publishToBintray"
-                        }'
     windows:
         needs: assemble
         runs-on: windows-latest
@@ -98,23 +64,6 @@ jobs:
                 env:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                     CI: true
-            -   name: Attach build scan to commit
-                if: ${{ always() }}
-                shell: bash
-                run: |
-                    curl \
-                    --silent \
-                    --show-error \
-                    --fail \
-                    --request POST \
-                    --url https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }} \
-                    --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-                    --header "Accept: application/vnd.github.v3+json" \
-                    --data '{
-                            "state":"${{ steps.gradle.outcome }}",
-                            "target_url": "${{ steps.gradle.outputs.build-scan-url }}",
-                            "context": "SCAN / ${{ runner.os }} (${{ matrix.checkTask }})"
-                        }'
 
     macos:
         needs: assemble
@@ -138,23 +87,6 @@ jobs:
                 env:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                     CI: true
-            -   name: Attach build scan to commit
-                if: ${{ always() }}
-                shell: bash
-                run: |
-                    curl \
-                    --silent \
-                    --show-error \
-                    --fail \
-                    --request POST \
-                    --url https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }} \
-                    --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-                    --header "Accept: application/vnd.github.v3+json" \
-                    --data '{
-                            "state":"${{ steps.gradle.outcome }}",
-                            "target_url": "${{ steps.gradle.outputs.build-scan-url }}",
-                            "context": "SCAN / ${{ runner.os }} (${{ matrix.checkTask }})"
-                        }'
 
     linux:
         needs: assemble
@@ -180,20 +112,3 @@ jobs:
                 env:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                     CI: true
-            -   name: Attach build scan to commit
-                if: ${{ always() }}
-                shell: bash
-                run: |
-                    curl \
-                    --silent \
-                    --show-error \
-                    --fail \
-                    --request POST \
-                    --url https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }} \
-                    --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-                    --header "Accept: application/vnd.github.v3+json" \
-                    --data '{
-                            "state":"${{ steps.gradle.outcome }}",
-                            "target_url": "${{ steps.gradle.outputs.build-scan-url }}",
-                            "context": "SCAN / ${{ runner.os }} (${{ matrix.checkTask }})"
-                        }'


### PR DESCRIPTION
A recent change to GitHub Action jump straight to the end of the build
log as well as rendering build scan as clickable links. This superseed
the fundamental issue we tried to address with this custom code. Also,
the code never worked properly as the GitHub Action for Gradle often
missed the build scan URL and didn't extract it properly.