### PR TITLE
Split domain object provider tests into testers

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,5 @@ spockVersion=1.2-groovy-2.5
 groovyVersion=2.5.8
 ddPlist=1.23
 junitVersion=5.7.0
+mockitoVersion=3.6.0
+hamcrestVersion=2.2

--- a/subprojects/core-model/core-model.gradle
+++ b/subprojects/core-model/core-model.gradle
@@ -13,12 +13,11 @@ repositories {
 }
 
 dependencies {
-	compileOnly "org.projectlombok:lombok:latest.release"
-	annotationProcessor "org.projectlombok:lombok:latest.release"
-
 	compileOnly gradleApi(minimumGradleVersion)
+	compileOnly "org.projectlombok:lombok:${lombokVersion}"
 	implementation project(':coreUtils')
 	implementation "com.google.guava:guava:${guavaVersion}"
+	annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 
 	testImplementation platform("org.spockframework:spock-bom:${spockVersion}")
 	testImplementation 'org.spockframework:spock-core'
@@ -27,9 +26,16 @@ dependencies {
 
 	testFixturesApi platform("org.spockframework:spock-bom:${spockVersion}")
 	testFixturesApi 'org.spockframework:spock-core'
-	testFixturesImplementation "org.apache.commons:commons-lang3:${commonsLangVersion}"
+	testFixturesApi "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
+	testFixturesCompileOnly "org.projectlombok:lombok:${lombokVersion}"
+	testFixturesImplementation project(':coreUtils')
 	testFixturesImplementation gradleApi(minimumGradleVersion)
+	testFixturesImplementation "org.mockito:mockito-core:${mockitoVersion}"
+	testFixturesImplementation "org.hamcrest:hamcrest:${hamcrestVersion}"
+	testFixturesImplementation "org.apache.commons:commons-lang3:${commonsLangVersion}"
 	testFixturesImplementation "com.google.guava:guava:${guavaVersion}"
+	testFixturesImplementation "com.google.guava:guava-testlib:${guavaVersion}"
+	testFixturesAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 }
 
 java {

--- a/subprojects/core-model/src/main/java/dev/nokee/model/DomainObjectProvider.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/DomainObjectProvider.java
@@ -1,8 +1,13 @@
 package dev.nokee.model;
 
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.provider.Provider;
+import org.gradle.util.ConfigureUtil;
+
+import static java.util.Objects.requireNonNull;
 
 public interface DomainObjectProvider<T> {
 	DomainObjectIdentifier getIdentifier();
@@ -10,6 +15,10 @@ public interface DomainObjectProvider<T> {
 	Class<T> getType();
 
 	void configure(Action<? super T> action);
+
+	default void configure(@DelegatesTo(type = "T", strategy = Closure.DELEGATE_FIRST) Closure<Void> closure) {
+		configure(ConfigureUtil.configureUsing(requireNonNull(closure)));
+	}
 
 	T get();
 

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/AbstractDomainObjectProvider.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/AbstractDomainObjectProvider.java
@@ -7,6 +7,8 @@ import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.provider.Provider;
 
+import static java.util.Objects.requireNonNull;
+
 @EqualsAndHashCode
 public abstract class AbstractDomainObjectProvider<TYPE, T extends TYPE> implements DomainObjectProvider<T> {
 	private final TypeAwareDomainObjectIdentifier<T> identifier;
@@ -31,7 +33,7 @@ public abstract class AbstractDomainObjectProvider<TYPE, T extends TYPE> impleme
 
 	@Override
 	public void configure(Action<? super T> action) {
-		configurer.configure(identifier, action);
+		configurer.configure(identifier, requireNonNull(action));
 	}
 
 	@Override
@@ -41,11 +43,11 @@ public abstract class AbstractDomainObjectProvider<TYPE, T extends TYPE> impleme
 
 	@Override
 	public <S> Provider<S> map(Transformer<? extends S, ? super T> transformer) {
-		return provider.map(transformer);
+		return provider.map(requireNonNull(transformer));
 	}
 
 	@Override
 	public <S> Provider<S> flatMap(Transformer<? extends Provider<? extends S>, ? super T> transformer) {
-		return provider.flatMap(transformer);
+		return provider.flatMap(requireNonNull(transformer));
 	}
 }

--- a/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/DomainObjectProviderTest.java
+++ b/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/DomainObjectProviderTest.java
@@ -1,0 +1,72 @@
+package dev.nokee.model;
+
+import dev.nokee.model.testers.*;
+import org.junit.jupiter.api.Nested;
+
+public abstract class DomainObjectProviderTest<T> {
+	protected abstract TestProviderGenerator<T> getSubjectGenerator();
+
+	@Nested
+	class ConfigureUsingAction extends DomainObjectProviderConfigureUsingActionTester<T> {
+		@Override
+		public TestProviderGenerator<T> getSubjectGenerator() {
+			return DomainObjectProviderTest.this.getSubjectGenerator();
+		}
+	}
+
+	@Nested
+	class ConfigureUsingClosure extends DomainObjectProviderConfigureUsingClosureTester<T> {
+		@Override
+		public TestProviderGenerator<T> getSubjectGenerator() {
+			return DomainObjectProviderTest.this.getSubjectGenerator();
+		}
+	}
+
+	@Nested
+	class GetType extends DomainObjectProviderGetTypeTester<T> {
+		@Override
+		public TestProviderGenerator<T> getSubjectGenerator() {
+			return DomainObjectProviderTest.this.getSubjectGenerator();
+		}
+	}
+
+	@Nested
+	class GetIdentifier extends DomainObjectProviderGetIdentifierTester<T> {
+		@Override
+		public TestProviderGenerator<T> getSubjectGenerator() {
+			return DomainObjectProviderTest.this.getSubjectGenerator();
+		}
+	}
+
+	@Nested
+	class Map extends DomainObjectProviderMapTester<T> {
+		@Override
+		public TestProviderGenerator<T> getSubjectGenerator() {
+			return DomainObjectProviderTest.this.getSubjectGenerator();
+		}
+	}
+
+	@Nested
+	class FlatMap extends DomainObjectProviderFlatMapTester<T> {
+		@Override
+		public TestProviderGenerator<T> getSubjectGenerator() {
+			return DomainObjectProviderTest.this.getSubjectGenerator();
+		}
+	}
+
+	@Nested
+	class Equals extends DomainObjectProviderEqualsTester<T> {
+		@Override
+		public TestProviderGenerator<T> getSubjectGenerator() {
+			return DomainObjectProviderTest.this.getSubjectGenerator();
+		}
+	}
+
+	@Nested
+	class Get extends DomainObjectProviderGetTester<T> {
+		@Override
+		public TestProviderGenerator<T> getSubjectGenerator() {
+			return DomainObjectProviderTest.this.getSubjectGenerator();
+		}
+	}
+}

--- a/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/testers/AbstractDomainObjectProviderConfigureTester.java
+++ b/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/testers/AbstractDomainObjectProviderConfigureTester.java
@@ -1,0 +1,50 @@
+package dev.nokee.model.testers;
+
+import dev.nokee.model.DomainObjectProvider;
+import lombok.val;
+import org.gradle.api.Action;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public abstract class AbstractDomainObjectProviderConfigureTester<T> extends AbstractDomainObjectProviderTester<T> {
+	protected abstract void configure(DomainObjectProvider<T> provider, Action<T> configurationAction);
+
+	@Test
+	void doesNotCallConfigurationActionImmediately() {
+		@SuppressWarnings("unchecked")
+		val action = (Action<T>) mock(Action.class);
+		configure(createSubject(), action);
+		verify(action, Mockito.never()).execute(any());
+	}
+
+	@Test
+	void callsConfigurationActionWhenProviderResolves() {
+		@SuppressWarnings("unchecked")
+		val action = (Action<T>) mock(Action.class);
+		val provider = createSubject();
+
+		when:
+		configure(provider, action);
+		resolve(provider);
+
+		then:
+		verify(action, times(1)).execute(any());
+	}
+
+	@Test
+	void callsConfigurationActionImmediatelyWhenProviderWasAlreadyResolved() {
+		@SuppressWarnings("unchecked")
+		val action = (Action<T>) mock(Action.class);
+		val provider = createSubject();
+
+		when:
+		resolve(provider);
+		configure(provider, action);
+
+		then:
+		verify(action, times(1)).execute(any());
+	}
+}

--- a/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/testers/AbstractDomainObjectProviderTester.java
+++ b/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/testers/AbstractDomainObjectProviderTester.java
@@ -1,0 +1,63 @@
+package dev.nokee.model.testers;
+
+import dev.nokee.model.DomainObjectProvider;
+import lombok.val;
+import org.gradle.api.Action;
+import org.gradle.api.provider.Provider;
+import org.junit.jupiter.api.BeforeEach;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public abstract class AbstractDomainObjectProviderTester<T> {
+	private SampleProviders<T> samples;
+
+	@BeforeEach
+	final void setUp() {
+		this.samples = getSubjectGenerator().samples();
+	}
+
+	protected abstract TestProviderGenerator<T> getSubjectGenerator();
+
+	protected final DomainObjectProvider<T> createSubject() {
+		return getSubjectGenerator().create();
+	}
+
+	protected final SampleProvider<T> p0() {
+		return samples.p0();
+	}
+
+	protected final SampleProvider<T> p1() {
+		return samples.p1();
+	}
+
+	protected final SampleProvider<T> p2() {
+		return samples.p2();
+	}
+
+	protected final Class<T> getSubjectType() {
+		return getSubjectGenerator().getType();
+	}
+
+	protected final void expectUnresolved(DomainObjectProvider<T> provider) {
+		@SuppressWarnings("unchecked")
+		val action = (Action<T>) mock(Action.class);
+		provider.configure(action);
+		verify(action, never()).execute(any());
+	}
+
+	protected final void expectResolved(DomainObjectProvider<T> provider) {
+		@SuppressWarnings("unchecked")
+		val action = (Action<T>) mock(Action.class);
+		provider.configure(action);
+		verify(action, times(1)).execute(any());
+	}
+
+	protected final <S> S resolve(DomainObjectProvider<S> provider) {
+		return provider.get();
+	}
+
+	protected final void resolve(Provider<?> provider) {
+		provider.get();
+	}
+}

--- a/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/testers/AbstractDomainObjectProviderTransformTester.java
+++ b/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/testers/AbstractDomainObjectProviderTransformTester.java
@@ -1,0 +1,50 @@
+package dev.nokee.model.testers;
+
+import dev.nokee.model.DomainObjectProvider;
+import lombok.val;
+import org.gradle.api.Transformer;
+import org.gradle.api.provider.Provider;
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.utils.TransformerUtils.noOpTransformer;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public abstract class AbstractDomainObjectProviderTransformTester<T> extends AbstractDomainObjectProviderTester<T> {
+	protected abstract <S> Provider<S> transform(DomainObjectProvider<T> provider, Transformer<S, T> mapper);
+
+	@Test
+	void doesNotResolveProvider() {
+		@SuppressWarnings("unchecked")
+		val mapper = (Transformer<?, T>) mock(Transformer.class);
+		val provider = createSubject();
+		transform(provider, mapper);
+		expectUnresolved(provider);
+	}
+
+	@Test
+	void doesNotCallTransformerWhenResolvingBaseProvider() {
+		@SuppressWarnings("unchecked")
+		val mapper = (Transformer<?, T>) mock(Transformer.class);
+		val provider = createSubject();
+		transform(provider, mapper);
+
+		when:
+		resolve(provider);
+
+		then:
+		verify(mapper, never()).transform(any());
+	}
+
+	@Test
+	void resolvesBaseProviderWhenResolvingMappedProvider() {
+		val provider = createSubject();
+		val mappedProvider = transform(provider, noOpTransformer());
+
+		when:
+		resolve(mappedProvider);
+
+		then:
+		expectResolved(provider);
+	}
+}

--- a/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/testers/DomainObjectProviderConfigureUsingActionTester.java
+++ b/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/testers/DomainObjectProviderConfigureUsingActionTester.java
@@ -1,0 +1,19 @@
+package dev.nokee.model.testers;
+
+import dev.nokee.model.DomainObjectProvider;
+import org.gradle.api.Action;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public abstract class DomainObjectProviderConfigureUsingActionTester<T> extends AbstractDomainObjectProviderConfigureTester<T> {
+	@Override
+	protected void configure(DomainObjectProvider<T> provider, Action<T> configurationAction) {
+		provider.configure(configurationAction);
+	}
+
+	@Test
+	void throwsExceptionIfConfigurationActionIsNull() {
+		assertThrows(NullPointerException.class, () -> createSubject().configure((Action<T>) null));
+	}
+}

--- a/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/testers/DomainObjectProviderConfigureUsingClosureTester.java
+++ b/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/testers/DomainObjectProviderConfigureUsingClosureTester.java
@@ -1,0 +1,82 @@
+package dev.nokee.model.testers;
+
+import dev.nokee.model.DomainObjectProvider;
+import groovy.lang.Closure;
+import lombok.val;
+import org.gradle.api.Action;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+public abstract class DomainObjectProviderConfigureUsingClosureTester<T> extends AbstractDomainObjectProviderConfigureTester<T> {
+	@Override
+	protected void configure(DomainObjectProvider<T> provider, Action<T> configurationAction) {
+		provider.configure(new ClosureActionAdapter<T>(this) {
+			@Override
+			public void doCall(T t) {
+				configurationAction.execute(t);
+			}
+		});
+	}
+
+	private static abstract class ClosureActionAdapter<T> extends groovy.lang.Closure<Void> {
+
+		public ClosureActionAdapter(Object owner, Object thisObject) {
+			super(owner, thisObject);
+		}
+
+		public ClosureActionAdapter(Object owner) {
+			super(owner);
+		}
+
+		public abstract void doCall(T t);
+	}
+
+	private interface CapturedValue {
+		void capture(Object value);
+	}
+
+	@Test
+	void throwsExceptionIfConfigurationClosureIsNull() {
+		assertThrows(NullPointerException.class, () -> createSubject().configure((Closure<Void>) null));
+	}
+
+	@Test
+	void configuresDelegateFirstResolveStrategy() {
+		val captor = mock(CapturedValue.class);
+		val closure = new ClosureActionAdapter<T>(this) {
+			@Override
+			public void doCall(Object o) {
+				captor.capture(getResolveStrategy());
+			}
+		};
+		val provider = createSubject();
+
+		when:
+		provider.configure(closure);
+		resolve(provider);
+
+		then:
+		verify(captor, times(1)).capture(Closure.DELEGATE_FIRST);
+	}
+
+	@Test
+	void configuresDelegateToProviderValue() {
+		val captor = mock(CapturedValue.class);
+		val closure = new ClosureActionAdapter<T>(this) {
+			@Override
+			public void doCall(T t) {
+				captor.capture(getDelegate());
+			}
+		};
+		val provider = createSubject();
+
+		when:
+		provider.configure(closure);
+		val value = resolve(provider);
+
+		then:
+		verify(captor, times(1)).capture(value);
+	}
+}

--- a/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/testers/DomainObjectProviderEqualsTester.java
+++ b/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/testers/DomainObjectProviderEqualsTester.java
@@ -1,0 +1,15 @@
+package dev.nokee.model.testers;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.jupiter.api.Test;
+
+public abstract class DomainObjectProviderEqualsTester<T> extends AbstractDomainObjectProviderTester<T> {
+	@Test
+	void canEquals() {
+		new EqualsTester()
+			.addEqualityGroup(p0(), p0())
+			.addEqualityGroup(p1())
+			.addEqualityGroup(p2())
+			.testEquals();
+	}
+}

--- a/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/testers/DomainObjectProviderFlatMapTester.java
+++ b/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/testers/DomainObjectProviderFlatMapTester.java
@@ -1,0 +1,21 @@
+package dev.nokee.model.testers;
+
+import dev.nokee.model.DomainObjectProvider;
+import dev.nokee.utils.ProviderUtils;
+import org.gradle.api.Transformer;
+import org.gradle.api.provider.Provider;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public abstract class DomainObjectProviderFlatMapTester<T> extends AbstractDomainObjectProviderTransformTester<T> {
+	@Override
+	protected <S> Provider<S> transform(DomainObjectProvider<T> provider, Transformer<S, T> mapper) {
+		return provider.flatMap(it -> ProviderUtils.fixed(mapper.transform(it)));
+	}
+
+	@Test
+	void throwsExceptionIfTransformerIsNull() {
+		assertThrows(NullPointerException.class, () -> createSubject().flatMap(null));
+	}
+}

--- a/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/testers/DomainObjectProviderGetIdentifierTester.java
+++ b/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/testers/DomainObjectProviderGetIdentifierTester.java
@@ -1,0 +1,17 @@
+package dev.nokee.model.testers;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public abstract class DomainObjectProviderGetIdentifierTester<T> extends AbstractDomainObjectProviderTester<T> {
+	@Test
+	void canGetProviderIdentifier() {
+		Assertions.assertAll(() -> {
+			assertEquals(p0().p().getIdentifier(), p0().id());
+			assertEquals(p1().p().getIdentifier(), p1().id());
+			assertEquals(p2().p().getIdentifier(), p2().id());
+		});
+	}
+}

--- a/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/testers/DomainObjectProviderGetTester.java
+++ b/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/testers/DomainObjectProviderGetTester.java
@@ -1,0 +1,21 @@
+package dev.nokee.model.testers;
+
+import lombok.val;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isA;
+
+public abstract class DomainObjectProviderGetTester<T> extends AbstractDomainObjectProviderTester<T> {
+	@Test
+	void resolvesProviderWhenQueried() {
+		val provider = createSubject();
+		provider.get();
+		expectResolved(provider);
+	}
+
+	@Test
+	void returnsProviderValueWhenQueried() {
+		assertThat(createSubject().get(), isA(getSubjectType()));
+	}
+}

--- a/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/testers/DomainObjectProviderGetTypeTester.java
+++ b/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/testers/DomainObjectProviderGetTypeTester.java
@@ -1,0 +1,17 @@
+package dev.nokee.model.testers;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public abstract class DomainObjectProviderGetTypeTester<T> extends AbstractDomainObjectProviderTester<T> {
+	@Test
+	void canGetProviderType() {
+		Assertions.assertAll(() -> {
+			assertEquals(p0().p().getType(), p0().type());
+			assertEquals(p1().p().getType(), p1().type());
+			assertEquals(p2().p().getType(), p2().type());
+		});
+	}
+}

--- a/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/testers/DomainObjectProviderMapTester.java
+++ b/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/testers/DomainObjectProviderMapTester.java
@@ -1,0 +1,20 @@
+package dev.nokee.model.testers;
+
+import dev.nokee.model.DomainObjectProvider;
+import org.gradle.api.Transformer;
+import org.gradle.api.provider.Provider;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public abstract class DomainObjectProviderMapTester<T> extends AbstractDomainObjectProviderTransformTester<T> {
+	@Override
+	protected <S> Provider<S> transform(DomainObjectProvider<T> provider, Transformer<S, T> mapper) {
+		return provider.map(mapper);
+	}
+
+	@Test
+	void throwsExceptionIfTransformerIsNull() {
+		assertThrows(NullPointerException.class, () -> createSubject().map(null));
+	}
+}

--- a/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/testers/SampleProvider.java
+++ b/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/testers/SampleProvider.java
@@ -1,0 +1,28 @@
+package dev.nokee.model.testers;
+
+import dev.nokee.model.DomainObjectIdentifier;
+import dev.nokee.model.DomainObjectProvider;
+
+public final class SampleProvider<T> {
+	private final DomainObjectProvider<T> p;
+	private final Class<T> type;
+	private final DomainObjectIdentifier id;
+
+	public SampleProvider(DomainObjectProvider<T> p, Class<T> type, DomainObjectIdentifier id) {
+		this.p = p;
+		this.type = type;
+		this.id = id;
+	}
+
+	public DomainObjectProvider<T> p() {
+		return p;
+	}
+
+	public Class<T> type() {
+		return type;
+	}
+
+	public DomainObjectIdentifier id() {
+		return id;
+	}
+}

--- a/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/testers/SampleProviders.java
+++ b/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/testers/SampleProviders.java
@@ -1,0 +1,26 @@
+package dev.nokee.model.testers;
+
+public final class SampleProviders<T> {
+	private final SampleProvider<T> p0;
+	private final SampleProvider<T> p1;
+	private final SampleProvider<T> p2;
+
+
+	public SampleProviders(SampleProvider<T> p0, SampleProvider<T> p1, SampleProvider<T> p2) {
+		this.p0 = p0;
+		this.p1 = p1;
+		this.p2 = p2;
+	}
+
+	public SampleProvider<T> p0() {
+		return p0;
+	}
+
+	public SampleProvider<T> p1() {
+		return p1;
+	}
+
+	public SampleProvider<T> p2() {
+		return p2;
+	}
+}

--- a/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/testers/TestProviderGenerator.java
+++ b/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/testers/TestProviderGenerator.java
@@ -1,0 +1,11 @@
+package dev.nokee.model.testers;
+
+import dev.nokee.model.DomainObjectProvider;
+
+public interface TestProviderGenerator<T> {
+	SampleProviders<T> samples();
+
+	DomainObjectProvider<T> create();
+
+	Class<T> getType();
+}

--- a/subprojects/platform-base/platform-base.gradle
+++ b/subprojects/platform-base/platform-base.gradle
@@ -30,6 +30,8 @@ dependencies {
 	testImplementation "dev.gradleplugins:gradle-fixtures-well-behaving-plugins:latest.release"
 	testImplementation testFixtures(project(':coreModel'))
 	testImplementation project(':testingBase')
+	testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
+	testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junitVersion}"
 
 	testFixturesApi testFixtures(project(':languageNative'))
 	testFixturesCompileOnly "org.projectlombok:lombok:${lombokVersion}"
@@ -38,6 +40,8 @@ dependencies {
 	testFixturesImplementation gradleFixtures()
 	testFixturesImplementation "dev.gradleplugins:gradle-fixtures-source-elements:latest.release"
 }
+
+tasks.withType(Test).configureEach { it.useJUnitPlatform() }
 
 java {
 	sourceCompatibility = minimumJavaVersionFor(minimumGradleVersion)

--- a/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/components/ComponentProviderTest.groovy
+++ b/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/components/ComponentProviderTest.groovy
@@ -1,8 +1,108 @@
 package dev.nokee.platform.base.internal.components
 
-import dev.nokee.model.internal.AbstractDomainObjectProviderTest
+import dev.nokee.model.DomainObjectFactory
+import dev.nokee.model.DomainObjectIdentifier
+import dev.nokee.model.DomainObjectProvider
+import dev.nokee.model.DomainObjectProviderTest
+import dev.nokee.model.internal.*
+import dev.nokee.model.testers.SampleProvider
+import dev.nokee.model.testers.SampleProviders
+import dev.nokee.model.testers.TestProviderGenerator
 import dev.nokee.platform.base.Component
-import spock.lang.Subject
+import dev.nokee.platform.base.internal.ComponentIdentifier
+import dev.nokee.platform.base.internal.ComponentName
+import org.apache.commons.lang3.RandomStringUtils
+import org.gradle.api.Project
+import org.gradle.api.model.ObjectFactory
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.BeforeAll
 
-@Subject(ComponentProvider)
-class ComponentProviderTest extends AbstractDomainObjectProviderTest<Component> implements ComponentFixture {}
+class ComponentProviderTest extends DomainObjectProviderTest<Component> {
+	private static TestProviderGenerator<Component> subjectGenerator;
+
+	@BeforeAll
+	static void setUp() {
+		subjectGenerator = new TestComponentProviderGenerator();
+	}
+
+	@Override
+	protected TestProviderGenerator<Component> getSubjectGenerator() {
+		return subjectGenerator
+	}
+
+	private static class TestComponentGenerator {
+		protected final Project project = ProjectBuilder.builder().build()
+		protected final DomainObjectEventPublisher eventPublisher = new DomainObjectEventPublisherImpl()
+		private final ComponentConfigurer configurer = new ComponentConfigurer(eventPublisher)
+		private final RealizableDomainObjectRealizer realizer = new RealizableDomainObjectRealizerImpl(eventPublisher)
+		private final ComponentRepository repository = new ComponentRepository(eventPublisher, realizer, project.getProviders())
+		protected final ComponentProviderFactory providerFactory = new ComponentProviderFactory(repository, configurer)
+		protected final ComponentInstantiator instantiator = new ComponentInstantiator("test component")
+
+		protected <T extends Component> ComponentIdentifier<T> identifier(String name, Class<T> type) {
+			return ComponentIdentifier.of(ComponentName.of(name), type, ProjectIdentifier.of(project))
+		}
+	}
+
+	private static final class TestComponentProviderGenerator extends TestComponentGenerator implements TestProviderGenerator<Component> {
+		private final SampleProviders<Component> samples
+
+		TestComponentProviderGenerator() {
+			this.samples = new SampleProviders<Component>(
+				sample('main', Type0),
+				sample('test', Type1),
+				sample('common', Type2))
+		}
+
+		@Override
+		SampleProviders<Component> samples() {
+			return samples
+		}
+
+		private SampleProvider<Component> sample(String name, Class<? extends Component> type) {
+			def entity = project.objects.newInstance(type)
+			def identifier = identifier(name, type)
+			eventPublisher.publish(new DomainObjectDiscovered<>(identifier))
+			eventPublisher.publish(new RealizableDomainObjectDiscovered(identifier, {
+				eventPublisher.publish(new DomainObjectCreated<>(identifier, entity))
+			}))
+			def provider = providerFactory.create(identifier)
+			return new SampleProvider<Component>(provider, type, identifier)
+		}
+
+		@Override
+		DomainObjectProvider<Component> create() {
+			def identifier = identifier(newLowerCamelRandomString(), Type0)
+			eventPublisher.publish(new DomainObjectDiscovered<>(identifier))
+			eventPublisher.publish(new RealizableDomainObjectDiscovered(identifier, {
+				eventPublisher.publish(new DomainObjectCreated<>(identifier, project.objects.newInstance(Type0)))
+			}))
+			return providerFactory.create(identifier)
+		}
+
+		Class<Component> getType() {
+			return Type0
+		}
+
+		protected static String newLowerCamelRandomString() {
+			return 'a' + RandomStringUtils.randomAlphanumeric(12)
+		}
+
+		private static final class ObjectFactoryFactory<T> implements DomainObjectFactory<T> {
+			private final ObjectFactory objectFactory
+
+			public ObjectFactoryFactory(ObjectFactory objectFactory) {
+				this.objectFactory = objectFactory
+			}
+
+			@Override
+			T create(DomainObjectIdentifier identifier) {
+				return objectFactory.newInstance(((TypeAwareDomainObjectIdentifier<T>) identifier).getType());
+			}
+		}
+
+		private interface Type0 extends Component {}
+		private interface Type1 extends Component {}
+		private interface Type2 extends Component {}
+	}
+}


### PR DESCRIPTION
The concept is borrowed from Guava testlib which makes it much simpler to compose and share tests. We may also start switching toward JUnit 5 instead of Spock mostly for the nested feature.

(We also need to build some expertise with JUnit 5 as there is a high likelihood it will be used as our general purpose multi-test library runner).