### PR TITLE
Introduce a programmatic API for "default importing" type in build script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                checkTask: [':buildAdapterCmake:check', ':coreUtils:check', ':ideBase:check', ':ideVisualStudio:check', ':ideXcode:check', ':languageBase:check', ':languageC:check', ':languageCpp:check', ':languageNative:check', ':languageObjectiveC:check', ':languageObjectiveCpp:check', ':languageSwift:check', ':platformBase:check', ':platformIos:check', ':platformJni:check', ':platformNative:check', ':runtimeBase:check', ':runtimeDarwin:check', ':runtimeNative:check', ':testingBase:check', ':testingNative:check', ':testingXctest:check']
+                checkTask: [':buildAdapterCmake:check', ':coreScript:check', ':coreUtils:check', ':ideBase:check', ':ideVisualStudio:check', ':ideXcode:check', ':languageBase:check', ':languageC:check', ':languageCpp:check', ':languageNative:check', ':languageObjectiveC:check', ':languageObjectiveCpp:check', ':languageSwift:check', ':platformBase:check', ':platformIos:check', ':platformJni:check', ':platformNative:check', ':runtimeBase:check', ':runtimeDarwin:check', ':runtimeNative:check', ':testingBase:check', ':testingNative:check', ':testingXctest:check']
         steps:
             -   uses: actions/checkout@v2
             -   uses: actions/setup-java@v1
@@ -71,7 +71,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                checkTask: [':buildAdapterCmake:check', ':coreUtils:check', ':ideBase:check', ':ideVisualStudio:check', ':ideXcode:check', ':languageBase:check', ':languageC:check', ':languageCpp:check', ':languageNative:check', ':languageObjectiveC:check', ':languageObjectiveCpp:check', ':languageSwift:check', ':platformBase:check', ':platformIos:check', ':platformJni:check', ':platformNative:check', ':runtimeBase:check', ':runtimeDarwin:check', ':runtimeNative:check', ':testingBase:check', ':testingNative:check', ':testingXctest:check']
+                checkTask: [':buildAdapterCmake:check', ':coreScript:check', ':coreUtils:check', ':ideBase:check', ':ideVisualStudio:check', ':ideXcode:check', ':languageBase:check', ':languageC:check', ':languageCpp:check', ':languageNative:check', ':languageObjectiveC:check', ':languageObjectiveCpp:check', ':languageSwift:check', ':platformBase:check', ':platformIos:check', ':platformJni:check', ':platformNative:check', ':runtimeBase:check', ':runtimeDarwin:check', ':runtimeNative:check', ':testingBase:check', ':testingNative:check', ':testingXctest:check']
         steps:
             -   uses: actions/checkout@v2
             -   uses: actions/setup-java@v1
@@ -94,7 +94,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                checkTask: [':buildAdapterCmake:check', ':coreUtils:check', ':ideBase:check', ':ideVisualStudio:check', ':ideXcode:check', ':languageBase:check', ':languageC:check', ':languageCpp:check', ':languageNative:check', ':languageObjectiveC:check', ':languageObjectiveCpp:check', ':languageSwift:check', ':platformBase:check', ':platformIos:check', ':platformJni:check', ':platformNative:check', ':runtimeBase:check', ':runtimeDarwin:check', ':runtimeNative:check', ':testingBase:check', ':testingNative:check', ':testingXctest:check']
+                checkTask: [':buildAdapterCmake:check', ':coreScript:check', ':coreUtils:check', ':ideBase:check', ':ideVisualStudio:check', ':ideXcode:check', ':languageBase:check', ':languageC:check', ':languageCpp:check', ':languageNative:check', ':languageObjectiveC:check', ':languageObjectiveCpp:check', ':languageSwift:check', ':platformBase:check', ':platformIos:check', ':platformJni:check', ':platformNative:check', ':runtimeBase:check', ':runtimeDarwin:check', ':runtimeNative:check', ':testingBase:check', ':testingNative:check', ':testingXctest:check']
         steps:
             -   uses: actions/checkout@v2
             -   uses: actions/setup-java@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,30 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                checkTask: [':buildAdapterCmake:check', ':coreScript:check', ':coreUtils:check', ':ideBase:check', ':ideVisualStudio:check', ':ideXcode:check', ':languageBase:check', ':languageC:check', ':languageCpp:check', ':languageNative:check', ':languageObjectiveC:check', ':languageObjectiveCpp:check', ':languageSwift:check', ':platformBase:check', ':platformIos:check', ':platformJni:check', ':platformNative:check', ':runtimeBase:check', ':runtimeDarwin:check', ':runtimeNative:check', ':testingBase:check', ':testingNative:check', ':testingXctest:check']
+                checkTask: [
+                    ':buildAdapterCmake:check',
+                    ':coreScript:check',
+                    ':coreUtils:check',
+                    ':ideBase:check',
+                    ':ideVisualStudio:check',
+                    ':ideXcode:check',
+                    ':languageBase:check',
+                    ':languageC:check',
+                    ':languageCpp:check',
+                    ':languageNative:check',
+                    ':languageObjectiveC:check',
+                    ':languageObjectiveCpp:check',
+                    ':languageSwift:check',
+                    ':platformBase:check',
+                    ':platformIos:check',
+                    ':platformJni:check',
+                    ':platformNative:check',
+                    ':runtimeBase:check',
+                    ':runtimeDarwin:check',
+                    ':runtimeNative:check',
+                    ':testingBase:check',
+                    ':testingNative:check',
+                    ':testingXctest:check']
         steps:
             -   uses: actions/checkout@v2
             -   uses: actions/setup-java@v1
@@ -71,7 +94,30 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                checkTask: [':buildAdapterCmake:check', ':coreScript:check', ':coreUtils:check', ':ideBase:check', ':ideVisualStudio:check', ':ideXcode:check', ':languageBase:check', ':languageC:check', ':languageCpp:check', ':languageNative:check', ':languageObjectiveC:check', ':languageObjectiveCpp:check', ':languageSwift:check', ':platformBase:check', ':platformIos:check', ':platformJni:check', ':platformNative:check', ':runtimeBase:check', ':runtimeDarwin:check', ':runtimeNative:check', ':testingBase:check', ':testingNative:check', ':testingXctest:check']
+                checkTask: [
+                    ':buildAdapterCmake:check',
+                    ':coreScript:check',
+                    ':coreUtils:check',
+                    ':ideBase:check',
+                    ':ideVisualStudio:check',
+                    ':ideXcode:check',
+                    ':languageBase:check',
+                    ':languageC:check',
+                    ':languageCpp:check',
+                    ':languageNative:check',
+                    ':languageObjectiveC:check',
+                    ':languageObjectiveCpp:check',
+                    ':languageSwift:check',
+                    ':platformBase:check',
+                    ':platformIos:check',
+                    ':platformJni:check',
+                    ':platformNative:check',
+                    ':runtimeBase:check',
+                    ':runtimeDarwin:check',
+                    ':runtimeNative:check',
+                    ':testingBase:check',
+                    ':testingNative:check',
+                    ':testingXctest:check']
         steps:
             -   uses: actions/checkout@v2
             -   uses: actions/setup-java@v1
@@ -94,7 +140,30 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                checkTask: [':buildAdapterCmake:check', ':coreScript:check', ':coreUtils:check', ':ideBase:check', ':ideVisualStudio:check', ':ideXcode:check', ':languageBase:check', ':languageC:check', ':languageCpp:check', ':languageNative:check', ':languageObjectiveC:check', ':languageObjectiveCpp:check', ':languageSwift:check', ':platformBase:check', ':platformIos:check', ':platformJni:check', ':platformNative:check', ':runtimeBase:check', ':runtimeDarwin:check', ':runtimeNative:check', ':testingBase:check', ':testingNative:check', ':testingXctest:check']
+                checkTask: [
+                    ':buildAdapterCmake:check',
+                    ':coreScript:check',
+                    ':coreUtils:check',
+                    ':ideBase:check',
+                    ':ideVisualStudio:check',
+                    ':ideXcode:check',
+                    ':languageBase:check',
+                    ':languageC:check',
+                    ':languageCpp:check',
+                    ':languageNative:check',
+                    ':languageObjectiveC:check',
+                    ':languageObjectiveCpp:check',
+                    ':languageSwift:check',
+                    ':platformBase:check',
+                    ':platformIos:check',
+                    ':platformJni:check',
+                    ':platformNative:check',
+                    ':runtimeBase:check',
+                    ':runtimeDarwin:check',
+                    ':runtimeNative:check',
+                    ':testingBase:check',
+                    ':testingNative:check',
+                    ':testingXctest:check']
         steps:
             -   uses: actions/checkout@v2
             -   uses: actions/setup-java@v1

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,4 @@ spockVersion=1.2-groovy-2.5
 groovyVersion=2.5.8
 ddPlist=1.23
 junitVersion=5.7.0
+hamcrestVersion=2.2

--- a/settings.gradle
+++ b/settings.gradle
@@ -54,6 +54,10 @@ include 'coreModel'
 project(':coreModel').projectDir = file('subprojects/core-model')
 project(':coreModel').buildFileName = 'core-model.gradle'
 
+include 'coreScript'
+project(':coreScript').projectDir = file('subprojects/core-script')
+project(':coreScript').buildFileName = 'core-script.gradle'
+
 include 'coreUtils'
 project(':coreUtils').projectDir = file('subprojects/core-utils')
 project(':coreUtils').buildFileName = 'core-utils.gradle'

--- a/subprojects/core-script/core-script.gradle
+++ b/subprojects/core-script/core-script.gradle
@@ -1,0 +1,20 @@
+plugins {
+	id 'java-library'
+	id 'groovy-base'
+}
+
+repositories {
+	jcenter()
+	gradlePluginDevelopment()
+}
+
+dependencies {
+	compileOnly gradleApi(minimumGradleVersion)
+	compileOnly "org.projectlombok:lombok:${lombokVersion}"
+	annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+
+	testImplementation gradleApi(minimumGradleVersion)
+	testImplementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
+	testImplementation "org.hamcrest:hamcrest:${hamcrestVersion}"
+	testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
+}

--- a/subprojects/core-script/src/main/java/dev/nokee/scripts/DefaultImporter.java
+++ b/subprojects/core-script/src/main/java/dev/nokee/scripts/DefaultImporter.java
@@ -1,0 +1,65 @@
+package dev.nokee.scripts;
+
+import lombok.val;
+import org.gradle.api.Project;
+import org.gradle.api.plugins.ExtensionContainer;
+import org.gradle.api.plugins.ExtensionsSchema;
+import org.gradle.api.reflect.TypeOf;
+
+import java.util.function.Predicate;
+import java.util.stream.StreamSupport;
+
+/**
+ * Programmatically import types in a project build script scope.
+ * The "default imports" Gradle feature is internal and isn't available to plugin authors.
+ * To workaround this limitation, we fake a default import by registering the type as an extension.
+ * We can then access the type via the normal delegation process for Groovy DSL and Kotlin DSL.
+ */
+public final class DefaultImporter {
+	private final ExtensionContainer extensionContainer;
+
+	private DefaultImporter(ExtensionContainer extensionContainer) {
+		this.extensionContainer = extensionContainer;
+	}
+
+	/**
+	 * Returns the default importer for the specified {@link Project}.
+	 *
+	 * @param project  the project to import types
+	 * @return the default importer for the specified project, never null.
+	 */
+	public static DefaultImporter forProject(Project project) {
+		return new DefaultImporter(project.getExtensions());
+	}
+
+	/**
+	 * Imports the specified type in the current project.
+	 *
+	 * @param type  the type to import
+	 * @param <T>  the type to import
+	 * @return this default importer, never null.
+	 */
+	public <T> DefaultImporter defaultImport(Class<T> type) {
+		val defaultImportExtensionType = new TypeOf<Class<T>>() {};
+		try {
+			extensionContainer.add(defaultImportExtensionType, type.getSimpleName(), type);
+		} catch (Throwable ex) {
+			if (!hasExtension(ofName(type.getSimpleName()).and(ofType(defaultImportExtensionType)))) {
+				throw new IllegalArgumentException(String.format("Could not default import type '%s'.", type.getCanonicalName()));
+			}
+		}
+		return this;
+	}
+
+	private Predicate<ExtensionsSchema.ExtensionSchema> ofName(String typeSimpleName) {
+		return extensionSchema -> extensionSchema.getName().equals(typeSimpleName);
+	}
+
+	private Predicate<ExtensionsSchema.ExtensionSchema> ofType(TypeOf<?> publicType) {
+		return extensionSchema -> extensionSchema.getPublicType().equals(publicType);
+	}
+
+	private boolean hasExtension(Predicate<ExtensionsSchema.ExtensionSchema> predicate) {
+		return StreamSupport.stream(extensionContainer.getExtensionsSchema().getElements().spliterator(), false).anyMatch(predicate);
+	}
+}

--- a/subprojects/core-script/src/test/groovy/dev/nokee/scripts/DefaultImporterTest.groovy
+++ b/subprojects/core-script/src/test/groovy/dev/nokee/scripts/DefaultImporterTest.groovy
@@ -1,0 +1,55 @@
+package dev.nokee.scripts
+
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.function.Executable
+
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.equalTo
+import static org.junit.jupiter.api.Assertions.*
+
+class DefaultImporterTest {
+	def project = ProjectBuilder.builder().build()
+
+	@BeforeEach
+	void "import some types"() {
+		project.extensions.add(TypeCollidingWithExtension.simpleName, project.objects.newInstance(TypeCollidingWithExtension))
+		dev.nokee.platform.base.internal.DefaultImporter.forProject(project)
+			.defaultImport(DefaultImportedType0)
+			.defaultImport(DefaultImportedType1)
+			.defaultImport(DefaultImportedType2)
+	}
+
+	@Test
+	void "can access default import"() {
+		assertAll({
+			assertThat(project.DefaultImportedType0, equalTo(DefaultImportedType0))
+			assertThat(project.DefaultImportedType1, equalTo(DefaultImportedType1))
+			assertThat(project.DefaultImportedType2, equalTo(DefaultImportedType2))
+		} as Executable)
+	}
+
+	@Test
+	void "cannot access non imported type"() {
+		def ex = assertThrows(MissingPropertyException, { project.NonImportedType })
+		assertEquals("Could not get unknown property 'NonImportedType' for root project 'test' of type org.gradle.api.Project.", ex.message)
+	}
+
+	@Test
+	void "do nothing when duplicate default import"() {
+		assertDoesNotThrow({ dev.nokee.platform.base.internal.DefaultImporter.forProject(project).defaultImport(DefaultImportedType0) } as Executable)
+	}
+
+	@Test
+	void "throws exception when default import collide with an extension"() {
+		def ex = assertThrows(IllegalArgumentException, { dev.nokee.platform.base.internal.DefaultImporter.forProject(project).defaultImport(TypeCollidingWithExtension) })
+		assertEquals("Could not default import type '${TypeCollidingWithExtension.canonicalName}'.".toString(), ex.message)
+	}
+
+	interface DefaultImportedType0 {}
+	interface DefaultImportedType1 {}
+	interface DefaultImportedType2 {}
+	interface NonImportedType {}
+	interface TypeCollidingWithExtension {}
+}


### PR DESCRIPTION
We will use this capability to make the native language source set easier to use. The downside of this approach is the pollution of the extension container. Meh, that is a Gradle build tool problem. It's a missing feature for plugin authors. Until it gets fixed, this is a good enough approximation that works for both Groovy and Kotlin DSL.