### PR TITLE
Fix performance regression when comparing with Gradle core

### DIFF
--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/dependencies/DefaultNativeComponentDependencies.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/dependencies/DefaultNativeComponentDependencies.java
@@ -31,15 +31,12 @@ public class DefaultNativeComponentDependencies extends BaseComponentDependencie
 	}
 
 	private void configureCompileOnlyConfiguration(Configuration configuration) {
-		configuration.extendsFrom(implementation.getAsConfiguration());
 	}
 
 	private void configureLinkOnlyConfiguration(Configuration configuration) {
-		configuration.extendsFrom(implementation.getAsConfiguration());
 	}
 
 	private void configureRuntimeOnlyConfiguration(Configuration configuration) {
-		configuration.extendsFrom(implementation.getAsConfiguration());
 	}
 
 	@Override

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/dependencies/NativeLibraryOutgoingDependencies.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/dependencies/NativeLibraryOutgoingDependencies.java
@@ -23,7 +23,8 @@ public class NativeLibraryOutgoingDependencies extends AbstractNativeLibraryOutg
 		val configurationRegistry = new ConfigurationBucketRegistryImpl(configurationContainer);
 		val identifier = DependencyBucketIdentifier.of(DependencyBucketName.of("apiElements"),
 			ConsumableDependencyBucket.class, ownerIdentifier);
-		val apiElements = configurationRegistry.createIfAbsent(identifier.getConfigurationName(), ConfigurationBucketType.CONSUMABLE, builder.asOutgoingHeaderSearchPathFrom(dependencies.getApi().getAsConfiguration(), dependencies.getCompileOnly().getAsConfiguration()).withVariant(buildVariant).withDescription(identifier.getDisplayName()));
+		// TODO: Introduce compileOnlyApi which apiElements should extends from
+		val apiElements = configurationRegistry.createIfAbsent(identifier.getConfigurationName(), ConfigurationBucketType.CONSUMABLE, builder.asOutgoingHeaderSearchPathFrom(dependencies.getApi().getAsConfiguration()).withVariant(buildVariant).withDescription(identifier.getDisplayName()));
 
 		// See https://github.com/gradle/gradle/issues/15146 to learn more about splitting the implicit dependencies
 		apiElements.getOutgoing().artifact(getExportedHeaders().getElements().flatMap(it -> ProviderUtils.fixed(Iterables.getOnlyElement(it))), it -> it.builtBy(getExportedHeaders()));

--- a/subprojects/platform-native/src/test/groovy/dev/nokee/platform/nativebase/internal/dependencies/DefaultNativeApplicationComponentDependenciesTests.groovy
+++ b/subprojects/platform-native/src/test/groovy/dev/nokee/platform/nativebase/internal/dependencies/DefaultNativeApplicationComponentDependenciesTests.groovy
@@ -47,15 +47,12 @@ class DefaultNativeApplicationComponentDependenciesTest extends AbstractComponen
 		0 * configurations.implementation._
 
 		and:
-		1 * configurations.compileOnly.extendsFrom(configurations.implementation)
 		0 * configurations.compileOnly._
 
 		and:
-		1 * configurations.linkOnly.extendsFrom(configurations.implementation)
 		0 * configurations.linkOnly._
 
 		and:
-		1 * configurations.runtimeOnly.extendsFrom(configurations.implementation)
 		0 * configurations.runtimeOnly._
 	}
 }

--- a/subprojects/platform-native/src/test/groovy/dev/nokee/platform/nativebase/internal/dependencies/DefaultNativeComponentDependenciesTests.groovy
+++ b/subprojects/platform-native/src/test/groovy/dev/nokee/platform/nativebase/internal/dependencies/DefaultNativeComponentDependenciesTests.groovy
@@ -48,15 +48,12 @@ class DefaultNativeComponentDependenciesTest extends AbstractComponentDependenci
 		0 * configurations.implementation._
 
 		and:
-		1 * configurations.compileOnly.extendsFrom(configurations.implementation)
 		0 * configurations.compileOnly._
 
 		and:
-		1 * configurations.linkOnly.extendsFrom(configurations.implementation)
 		0 * configurations.linkOnly._
 
 		and:
-		1 * configurations.runtimeOnly.extendsFrom(configurations.implementation)
 		0 * configurations.runtimeOnly._
 	}
 }

--- a/subprojects/platform-native/src/test/groovy/dev/nokee/platform/nativebase/internal/dependencies/DefaultNativeLibraryComponentDependenciesTests.groovy
+++ b/subprojects/platform-native/src/test/groovy/dev/nokee/platform/nativebase/internal/dependencies/DefaultNativeLibraryComponentDependenciesTests.groovy
@@ -52,15 +52,12 @@ class DefaultNativeLibraryComponentDependenciesTest extends AbstractComponentDep
 		0 * configurations.implementation._
 
 		and:
-		1 * configurations.compileOnly.extendsFrom(configurations.implementation)
 		0 * configurations.compileOnly._
 
 		and:
-		1 * configurations.linkOnly.extendsFrom(configurations.implementation)
 		0 * configurations.linkOnly._
 
 		and:
-		1 * configurations.runtimeOnly.extendsFrom(configurations.implementation)
 		0 * configurations.runtimeOnly._
 	}
 }


### PR DESCRIPTION
The performance is assumed to be the same as Gradle core given it reuses the execution infrastructure. The configuration model is different from the Gradle core plugins which execute less work during configuration. At a later time, the execution infrastructure will be migrated to Nokee but it's not a priority right now.