### PR TITLE
Install objc/objc++ 9 & fix deprecation warning

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -97,7 +97,7 @@ jobs:
                 run: sudo apt-get update && sudo apt-get -y install graphviz asciinema imagemagick gifsicle ffmpeg tree && sudo npm --global install asciicast2gif giflossy --unsafe-perm
             -   name: (linux) Install gcc dependencies
                 if: matrix.os == 'ubuntu-latest'
-                run: sudo apt-get update && sudo apt-get -y install gobjc-8-multilib gobjc++-8-multilib gcc-8-multilib g++-8-multilib libpthread-stubs0-dev
+                run: sudo apt-get update && sudo apt-get -y install gobjc-8-multilib gobjc++-8-multilib gcc-8-multilib g++-8-multilib gobjc-9-multilib gobjc++-9-multilib gcc-9-multilib g++-9-multilib libpthread-stubs0-dev
             -   name: (macos) Install documentation dependencies
                 if: matrix.os == 'macos-latest'
                 run: brew install tree

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,8 +169,8 @@ jobs:
             -   uses: actions/setup-java@v1
                 with:
                     java-version: '8'
-            -   name: Install gobjc-8, gobjc++-8 and pthread
-                run: sudo apt-get update && sudo apt-get -y install gobjc-8-multilib gobjc++-8-multilib gcc-8-multilib g++-8-multilib libpthread-stubs0-dev
+            -   name: Install gcc dependencies
+                run: sudo apt-get update && sudo apt-get -y install gobjc-8-multilib gobjc++-8-multilib gcc-8-multilib g++-8-multilib gobjc-9-multilib gobjc++-9-multilib gcc-9-multilib g++-9-multilib libpthread-stubs0-dev
             -   name: Run all tests
                 id: gradle
                 uses: eskatos/gradle-command-action@v1

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationComponent.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationComponent.java
@@ -157,6 +157,7 @@ public class DefaultIosApplicationComponent extends BaseNativeComponent<DefaultI
 		});
 
 		val processPropertyListTask = taskRegistry.register("processPropertyList", ProcessPropertyListTask.class, task -> {
+			task.dependsOn(resources.getSourceDirectories());
 			task.getIdentifier().set(identifier);
 			task.getModule().set(moduleName);
 			task.getSources().from(providers.provider(() -> {

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeBinary.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeBinary.java
@@ -206,7 +206,7 @@ public abstract class BaseNativeBinary implements Binary, NativeBinary {
 	}
 
 	private Provider<RegularFile> toSwiftModuleFile(String moduleName) {
-		return getLayout().getBuildDirectory().file("modules/main/" + moduleName + ".swiftmodule");
+		return getLayout().getBuildDirectory().file(identifier.getOutputDirectoryBase("modules") + "/" + moduleName + ".swiftmodule");
 	}
 
 	Provider<NativeToolChain> selectNativeToolChain(TargetMachine targetMachine) {


### PR DESCRIPTION
Fixes: https://github.com/nokeedev/gradle-native/issues/218 & https://github.com/nokeedev/gradle-native/issues/219

GitHub action Linux agent switched to 9.3 as the default GCC which still doesn't have ObjC/C++ runtime installed. Gradle core doesn't gracefully support part of GCC missing.