### PR TITLE
Use direct dependency on JavaNativeFoundation

### DIFF
--- a/subprojects/docs/src/docs/samples/jni-library-with-framework-dependencies/groovy-dsl/build.gradle
+++ b/subprojects/docs/src/docs/samples/jni-library-with-framework-dependencies/groovy-dsl/build.gradle
@@ -7,14 +7,17 @@ plugins {
 library {
 	targetMachines = [machines.macOS]
 	dependencies {
-		nativeImplementation 'dev.nokee.framework:Cocoa:latest.release'         // <1>
+		nativeImplementation 'dev.nokee.framework:Cocoa:latest.release'         		// <1>
 
+		nativeImplementation 'dev.nokee.framework:JavaNativeFoundation:latest.release'	// <2>
+		/* When using Xcode 12.1 and lower, use the following instead:
 		nativeImplementation 'dev.nokee.framework:JavaVM:latest.release'
 		nativeImplementation('dev.nokee.framework:JavaVM:latest.release') {
 			capabilities {
-				requireCapability 'JavaVM:JavaNativeFoundation:latest.release'  // <2>
+				requireCapability 'JavaVM:JavaNativeFoundation:latest.release'
 			}
 		}
+		*/
 	}
 }
 

--- a/subprojects/docs/src/docs/samples/jni-library-with-framework-dependencies/kotlin-dsl/build.gradle.kts
+++ b/subprojects/docs/src/docs/samples/jni-library-with-framework-dependencies/kotlin-dsl/build.gradle.kts
@@ -7,14 +7,17 @@ plugins {
 library {
 	targetMachines.set(listOf(machines.macOS))
 	dependencies {
-		nativeImplementation("dev.nokee.framework:Cocoa:latest.release")        // <1>
+		nativeImplementation("dev.nokee.framework:Cocoa:latest.release")        		// <1>
 
+		nativeImplementation("dev.nokee.framework:JavaNativeFoundation:latest.release") // <2>
+		/* When using Xcode 12.1 and lower, use the following instead:
 		nativeImplementation("dev.nokee.framework:JavaVM:latest.release")
 		nativeImplementation("dev.nokee.framework:JavaVM:latest.release") {
 			capabilities {
-				requireCapability("JavaVM:JavaNativeFoundation:latest.release") // <2>
+				requireCapability("JavaVM:JavaNativeFoundation:latest.release")
 			}
 		}
+		*/
 	}
 }
 


### PR DESCRIPTION
Xcode 12.2 and later removed the long deprecated JavaVM framework.
JavaNativeFoundation framework used to be a subframework of JavaVM. Now,
the framework is a top-level framework.