### PR TITLE
Increase backoff/retry configuration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,10 @@ org.gradle.jvmargs=-Xmx2500m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemor
 org.gradle.caching=true
 org.gradle.parallel=true
 
+# See https://github.com/gradle/gradle/pull/7333
+systemProp.org.gradle.internal.repository.max.tentatives=5
+systemProp.org.gradle.internal.repository.initial.backoff=500
+
 lombokVersion=1.18.12
 minimumGradleVersion=6.2.1
 toolboxVersion=1.1.32


### PR DESCRIPTION
On GitHub CI, we are seeing quite a few connection reset. There is quite
a few reason why those may be happening. The current feeling is JCenter
is a bit flaky from time to time and we are failing builds because of
it. A better solution would be to have a on-site cache but GitHub Action
don't allow them so we are going to try some backoff and retry
configuration.