### PR TITLE
Move GitHub pages publish from old documentation repo

### DIFF
--- a/subprojects/docs/documentation-kit/build-language-reference/build.gradle
+++ b/subprojects/docs/documentation-kit/build-language-reference/build.gradle
@@ -14,9 +14,6 @@ repositories {
 dependencies {
 	implementation platform('dev.nokee:nokee-gradle-plugins:0.5.0-1616a33a')
 
-	compileOnly "org.projectlombok:lombok:${lombokVersion}"
-	annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
-
 	implementation "com.google.guava:guava:${guavaVersion}"
 	implementation "commons-io:commons-io:${commonsIoVersion}"
 	implementation "org.apache.commons:commons-lang3:${commonsLangVersion}"

--- a/subprojects/docs/documentation-kit/build.gradle
+++ b/subprojects/docs/documentation-kit/build.gradle
@@ -1,3 +1,12 @@
+buildscript {
+	repositories {
+		maven { url = 'https://dl.bintray.com/nokeedev/distributions-snapshots' }
+	}
+	dependencies {
+		classpath 'dev.nokee:experimentalPublishingBintray:0.5.0-a7907c13'
+	}
+}
+
 plugins {
 	id 'java-library'
 }
@@ -8,7 +17,7 @@ dependencies {
 
 allprojects {
 	group = 'dev.gradleplugins'
-	version = '1.0'
+	version = '1.0.2'
 }
 
 // Unit test configuration
@@ -32,6 +41,20 @@ subprojects {
 		sourceSets.configureEach {
 			dependencies.add(annotationProcessorConfigurationName, "org.projectlombok:lombok:${lombokVersion}")
 			dependencies.add(compileOnlyConfigurationName, "org.projectlombok:lombok:${lombokVersion}")
+		}
+	}
+}
+
+// Publish to Bintray
+subprojects {
+	apply plugin: 'dev.nokee.experimental.bintray-publish'
+	publishing {
+		repositories {
+			maven {
+				name = 'Bintray'
+				url = 'https://dl.bintray.com/gradle-plugins/distributions'
+				ext.packageName = 'dev.gradleplugins:documentation-kit'
+			}
 		}
 	}
 }

--- a/subprojects/docs/documentation-kit/build.gradle
+++ b/subprojects/docs/documentation-kit/build.gradle
@@ -10,3 +10,28 @@ allprojects {
 	group = 'dev.gradleplugins'
 	version = '1.0'
 }
+
+// Unit test configuration
+subprojects {
+	configurations.matching { it.name == 'testImplementation' }.all { Configuration testImplementation ->
+		testImplementation.dependencies.add(project.dependencies.create("org.junit.jupiter:junit-jupiter:${junitVersion}"))
+		testImplementation.dependencies.add(project.dependencies.create("org.junit.vintage:junit-vintage-engine:${junitVersion}"))
+		testImplementation.dependencies.add(project.dependencies.create("org.junit-pioneer:junit-pioneer:1.2.0"))
+		testImplementation.dependencies.add(project.dependencies.create("org.hamcrest:hamcrest:${hamcrestVersion}"))
+	}
+	configurations.matching { it.name == 'functionalTestImplementation' }.all { Configuration functionalTestImplementation ->
+		functionalTestImplementation.dependencies.add(project.dependencies.create("org.junit.jupiter:junit-jupiter:${junitVersion}"))
+		functionalTestImplementation.dependencies.add(project.dependencies.create("org.junit.vintage:junit-vintage-engine:${junitVersion}"))
+	}
+	tasks.withType(Test).configureEach { useJUnitPlatform() }
+}
+
+// Lombok configuration
+subprojects {
+	pluginManager.withPlugin('java-base') {
+		sourceSets.configureEach {
+			dependencies.add(annotationProcessorConfigurationName, "org.projectlombok:lombok:${lombokVersion}")
+			dependencies.add(compileOnlyConfigurationName, "org.projectlombok:lombok:${lombokVersion}")
+		}
+	}
+}

--- a/subprojects/docs/documentation-kit/gradle.properties
+++ b/subprojects/docs/documentation-kit/gradle.properties
@@ -4,3 +4,5 @@ toolboxVersion=1.1.32
 guavaVersion=28.2-jre
 commonsLangVersion=3.9
 commonsIoVersion=2.6
+junitVersion=5.7.0
+hamcrestVersion=2.2

--- a/subprojects/docs/documentation-kit/publishing-github-pages/build.gradle
+++ b/subprojects/docs/documentation-kit/publishing-github-pages/build.gradle
@@ -1,0 +1,41 @@
+plugins {
+	id 'dev.gradleplugins.java-gradle-plugin'
+	id 'dev.gradleplugins.gradle-plugin-unit-test'
+	id 'dev.gradleplugins.gradle-plugin-functional-test'
+}
+
+repositories {
+	jcenter()
+}
+
+dependencies {
+	implementation 'org.eclipse.jgit:org.eclipse.jgit:5.8.0.202006091008-r'
+	implementation "com.google.guava:guava:${guavaVersion}"
+	implementation "org.apache.commons:commons-lang3:${commonsLangVersion}"
+}
+
+gradlePlugin {
+	plugins {
+		gitHubPagesPublish {
+			id = 'dev.gradleplugins.documentation.github-pages-publish'
+			implementationClass = 'dev.gradleplugins.documentationkit.publish.githubpages.internal.GitHubPagesPublishPlugin'
+		}
+	}
+	compatibility {
+		minimumGradleVersion = project.minimumGradleVersion
+	}
+}
+
+test {
+	dependencies {
+		implementation 'dev.gradleplugins:gradle-fixtures-version-control-system:latest.integration'
+		implementation "commons-io:commons-io:${commonsIoVersion}"
+	}
+}
+
+functionalTest {
+	dependencies {
+		implementation spockFramework()
+		implementation gradleFixtures()
+	}
+}

--- a/subprojects/docs/documentation-kit/publishing-github-pages/src/functionalTest/groovy/dev/gradleplugins/documentationkit/publish/githubpages/GitHubPagesPublishPluginFunctionalTest.groovy
+++ b/subprojects/docs/documentation-kit/publishing-github-pages/src/functionalTest/groovy/dev/gradleplugins/documentationkit/publish/githubpages/GitHubPagesPublishPluginFunctionalTest.groovy
@@ -1,0 +1,21 @@
+package dev.gradleplugins.documentationkit.publish.githubpages
+
+import dev.gradleplugins.documentationkit.publish.githubpages.internal.GitHubPagesPublishPlugin
+import dev.gradleplugins.integtests.fixtures.AbstractGradleSpecification
+import spock.lang.Subject
+
+@Subject(GitHubPagesPublishPlugin)
+class GitHubPagesPublishPluginFunctionalTest extends AbstractGradleSpecification {
+	def "has default import for task type"() {
+		buildFile << '''
+			plugins {
+				id 'dev.gradleplugins.documentation.github-pages-publish'
+			}
+
+			tasks.named('publishToGitHubPages', PublishToGitHubPages)
+		'''
+
+		expect:
+		succeeds('tasks')
+	}
+}

--- a/subprojects/docs/documentation-kit/publishing-github-pages/src/main/java/PublishToGitHubPages.java
+++ b/subprojects/docs/documentation-kit/publishing-github-pages/src/main/java/PublishToGitHubPages.java
@@ -1,0 +1,1 @@
+public abstract class PublishToGitHubPages extends dev.gradleplugins.documentationkit.publish.githubpages.tasks.PublishToGitHubPages {}

--- a/subprojects/docs/documentation-kit/publishing-github-pages/src/main/java/dev/gradleplugins/documentationkit/publish/githubpages/GitHubCredentials.java
+++ b/subprojects/docs/documentation-kit/publishing-github-pages/src/main/java/dev/gradleplugins/documentationkit/publish/githubpages/GitHubCredentials.java
@@ -1,0 +1,33 @@
+package dev.gradleplugins.documentationkit.publish.githubpages;
+
+import lombok.EqualsAndHashCode;
+import org.gradle.api.tasks.Input;
+
+import java.util.function.Supplier;
+
+import static com.google.common.base.Suppliers.ofInstance;
+
+@EqualsAndHashCode
+public final class GitHubCredentials {
+	private final Supplier<String> keySupplier;
+	private final Supplier<String> tokenSupplier;
+
+	public GitHubCredentials(Supplier<String> keySupplier, Supplier<String> tokenSupplier) {
+		this.keySupplier = keySupplier;
+		this.tokenSupplier = tokenSupplier;
+	}
+
+	@Input
+	public String getGitHubKey() {
+		return keySupplier.get();
+	}
+
+	@Input
+	public String getGitHubToken() {
+		return tokenSupplier.get();
+	}
+
+	public static GitHubCredentials of(String key, String token) {
+		return new GitHubCredentials(ofInstance(key), ofInstance(token));
+	}
+}

--- a/subprojects/docs/documentation-kit/publishing-github-pages/src/main/java/dev/gradleplugins/documentationkit/publish/githubpages/internal/GitHubCredentialsFactory.java
+++ b/subprojects/docs/documentation-kit/publishing-github-pages/src/main/java/dev/gradleplugins/documentationkit/publish/githubpages/internal/GitHubCredentialsFactory.java
@@ -1,0 +1,16 @@
+package dev.gradleplugins.documentationkit.publish.githubpages.internal;
+
+import dev.gradleplugins.documentationkit.publish.githubpages.GitHubCredentials;
+import org.gradle.api.provider.ProviderFactory;
+
+public final class GitHubCredentialsFactory {
+	private final ProviderFactory providerFactory;
+
+	public GitHubCredentialsFactory(ProviderFactory providerFactory) {
+		this.providerFactory = providerFactory;
+	}
+
+	public GitHubCredentials fromEnvironmentVariable() {
+		return new GitHubCredentials(providerFactory.environmentVariable("GITHUB_KEY")::getOrNull, providerFactory.environmentVariable("GITHUB_TOKEN")::getOrNull);
+	}
+}

--- a/subprojects/docs/documentation-kit/publishing-github-pages/src/main/java/dev/gradleplugins/documentationkit/publish/githubpages/internal/GitHubPagesPublishPlugin.java
+++ b/subprojects/docs/documentation-kit/publishing-github-pages/src/main/java/dev/gradleplugins/documentationkit/publish/githubpages/internal/GitHubPagesPublishPlugin.java
@@ -1,0 +1,29 @@
+package dev.gradleplugins.documentationkit.publish.githubpages.internal;
+
+import dev.gradleplugins.documentationkit.publish.githubpages.tasks.PublishToGitHubPages;
+import lombok.SneakyThrows;
+import lombok.val;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.publish.plugins.PublishingPlugin;
+
+public class GitHubPagesPublishPlugin implements Plugin<Project> {
+	@Override
+	public void apply(Project project) {
+		project.getPluginManager().apply(PublishingPlugin.class);
+		val credentialsFactory = new GitHubCredentialsFactory(project.getProviders());
+		val publishTask = project.getTasks().register("publishToGitHubPages", defaultClass(PublishToGitHubPages.class), task -> {
+			task.setGroup(PublishingPlugin.PUBLISH_TASK_GROUP);
+			task.setDescription("Publishes site produced by this project to GitHub pages.");
+			task.getCredentials().convention(credentialsFactory.fromEnvironmentVariable());
+			task.getUri().convention(project.provider(() -> GitHubRepositoryUtils.inferGitHubHttpRepositoryUri(project.getRootDir())));
+		});
+		project.getTasks().named(PublishingPlugin.PUBLISH_LIFECYCLE_TASK_NAME, task -> task.dependsOn(publishTask));
+	}
+
+	@SneakyThrows
+	@SuppressWarnings("unchecked")
+	private static <T> Class<T> defaultClass(Class<T> tClass) {
+		return (Class<T>) Class.forName(tClass.getName());
+	}
+}

--- a/subprojects/docs/documentation-kit/publishing-github-pages/src/main/java/dev/gradleplugins/documentationkit/publish/githubpages/internal/GitHubRepositoryUtils.java
+++ b/subprojects/docs/documentation-kit/publishing-github-pages/src/main/java/dev/gradleplugins/documentationkit/publish/githubpages/internal/GitHubRepositoryUtils.java
@@ -1,0 +1,101 @@
+package dev.gradleplugins.documentationkit.publish.githubpages.internal;
+
+import dev.gradleplugins.documentationkit.publish.githubpages.GitHubCredentials;
+import lombok.val;
+import lombok.var;
+import org.eclipse.jgit.api.CreateBranchCommand;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.ResetCommand;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.internal.storage.file.FileRepository;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.transport.URIish;
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collection;
+import java.util.Optional;
+
+import static org.apache.commons.lang3.exception.ExceptionUtils.rethrow;
+
+public final class GitHubRepositoryUtils {
+	private GitHubRepositoryUtils() {}
+
+	public static void createOrFetchOrClone(File repositoryDirectory, URI repositoryUri) throws IOException, GitAPIException {
+		if (isGitRepository(repositoryDirectory)) {
+			try (Git git = Git.open(repositoryDirectory)) {
+				cleanRepository(git);
+				if (hasGitHubPagesBranch(repositoryUri)) {
+					git.fetch().call();
+					git.checkout().setName("gh-pages").setUpstreamMode(CreateBranchCommand.SetupUpstreamMode.TRACK).setStartPoint("origin/gh-pages").call();
+					git.reset().setMode(ResetCommand.ResetType.HARD).setRef("origin/gh-pages").call();
+				}
+			}
+		} else {
+			try (Git git = Git.cloneRepository().setDirectory(repositoryDirectory).setURI(repositoryUri.toString()).setNoCheckout(true).setNoTags().call()) {
+				if (hasGitHubPagesBranch(repositoryUri)) {
+					git.checkout().setCreateBranch(true).setName("gh-pages").setUpstreamMode(CreateBranchCommand.SetupUpstreamMode.TRACK).setStartPoint("origin/gh-pages").call();
+				} else {
+					git.checkout().setOrphan(true).setName("gh-pages").call();
+					git.remoteAdd().setName("origin").setUri(new URIish(repositoryDirectory.toString())).call();
+				}
+			} catch (URISyntaxException e) {
+				rethrow(e);
+			}
+		}
+	}
+
+	private static void cleanRepository(Git git) throws GitAPIException {
+		git.reset().setMode(ResetCommand.ResetType.HARD).call();
+		git.clean().setCleanDirectories(true).setForce(true).call();
+	}
+
+	public static void commitAndPushAllFiles(File repositoryDirectory, Optional<GitHubCredentials> credentialsProvider) throws IOException, GitAPIException {
+		try (Git git = Git.open(repositoryDirectory)) {
+			git.add().addFilepattern(".").call();
+			git.commit().setAuthor("nokeedevbot", "bot@nokee.dev").setMessage("Publish by nokeedevbot").setAll(true).call();
+
+			var pushCommand = git.push();
+			credentialsProvider.ifPresent(credentials -> {
+				pushCommand.setCredentialsProvider(new UsernamePasswordCredentialsProvider(credentials.getGitHubKey(), credentials.getGitHubToken()));
+			});
+			pushCommand.call();
+		}
+	}
+
+	private static boolean hasGitHubPagesBranch(URI repositoryUri) throws GitAPIException {
+		Collection<Ref> refs = Git.lsRemoteRepository().setHeads(true).setTags(false).setRemote(repositoryUri.toString()).call();
+		return refs.stream().anyMatch(it -> it.getName().equals("refs/heads/gh-pages"));
+	}
+
+	private static boolean isGitRepository(File repositoryDirectory) {
+		try (Repository repository = new FileRepository(new File(repositoryDirectory, ".git"))) {
+			return repository.getObjectDatabase().exists();
+		} catch (IOException e) {
+			return false;
+		}
+	}
+
+	public static URI inferGitHubHttpRepositoryUri(File repositoryDirectory) throws IOException, GitAPIException {
+		try (val git = Git.open(repositoryDirectory)) {
+			val remotes = git.remoteList().call();
+			if (remotes.isEmpty()) {
+				throw new RuntimeException(String.format("Unable to infer GitHub HTTP repository URI at '%s' because no remotes are available.", repositoryDirectory.getAbsolutePath()));
+			}
+			val uris = remotes.iterator().next().getURIs();
+			if (uris.isEmpty()) {
+				throw new RuntimeException(String.format("Unable to infer GitHub HTTP repository URI at '%s' because no remotes are available.", repositoryDirectory.getAbsolutePath()));
+			}
+			val uri = uris.iterator().next();
+			try {
+				return new URI(uri.toASCIIString());
+			} catch (URISyntaxException e) {
+				throw new RuntimeException(String.format("Unable to infer GitHub HTTP repository URI at '%s' because we couldn't parse the remote URI: '%s'.", repositoryDirectory.getAbsolutePath(), uri.toString()), e);
+			}
+		}
+	}
+}

--- a/subprojects/docs/documentation-kit/publishing-github-pages/src/main/java/dev/gradleplugins/documentationkit/publish/githubpages/tasks/PublishToGitHubPages.java
+++ b/subprojects/docs/documentation-kit/publishing-github-pages/src/main/java/dev/gradleplugins/documentationkit/publish/githubpages/tasks/PublishToGitHubPages.java
@@ -1,0 +1,52 @@
+package dev.gradleplugins.documentationkit.publish.githubpages.tasks;
+
+import com.google.common.hash.Hashing;
+import dev.gradleplugins.documentationkit.publish.githubpages.GitHubCredentials;
+import dev.gradleplugins.documentationkit.publish.githubpages.internal.GitHubRepositoryUtils;
+import lombok.val;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.FileSystemOperations;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.TaskAction;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+import java.util.Optional;
+
+public abstract class PublishToGitHubPages extends DefaultTask {
+	@InputDirectory
+	public abstract DirectoryProperty getPublishDirectory();
+
+	@Nested
+	public abstract Property<GitHubCredentials> getCredentials();
+
+	@Input
+	public abstract Property<URI> getUri();
+
+	@Inject
+	protected abstract FileSystemOperations getFileOperations();
+
+	@TaskAction
+	private void doPublish() throws GitAPIException, IOException, URISyntaxException {
+		val repositoryDirectory = new File(getTemporaryDir(), BigInteger.valueOf(Hashing.md5().hashString(getUri().get().toString(), Charset.defaultCharset()).asLong()).toString(36));
+		repositoryDirectory.mkdirs();
+		GitHubRepositoryUtils.createOrFetchOrClone(repositoryDirectory, getUri().get());
+
+		getFileOperations().sync(spec -> {
+			spec.into(repositoryDirectory);
+			spec.from(getPublishDirectory());
+		});
+
+		GitHubRepositoryUtils.commitAndPushAllFiles(repositoryDirectory, Optional.ofNullable(getCredentials().getOrNull()));
+	}
+}

--- a/subprojects/docs/documentation-kit/publishing-github-pages/src/test/groovy/dev/gradleplugins/documentationkit/publish/githubpages/internal/GitHubCredentialsEnvironmentVariableTest.java
+++ b/subprojects/docs/documentation-kit/publishing-github-pages/src/test/groovy/dev/gradleplugins/documentationkit/publish/githubpages/internal/GitHubCredentialsEnvironmentVariableTest.java
@@ -1,0 +1,35 @@
+package dev.gradleplugins.documentationkit.publish.githubpages.internal;
+
+import lombok.val;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
+import spock.lang.Subject;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+@Subject(GitHubCredentialsFactory.class)
+class GitHubCredentialsEnvironmentVariableTest {
+	@Test
+	@SetEnvironmentVariable(key = "GITHUB_KEY", value = "test-key")
+	@SetEnvironmentVariable(key = "GITHUB_TOKEN", value = "test-token")
+	void canCreateCredentialsFromGitHubKeyAndTokenEnvironmentVariables() {
+		val credentials = new GitHubCredentialsFactory(providerFactory()).fromEnvironmentVariable();
+		assertThat(credentials.getGitHubKey(), equalTo("test-key"));
+		assertThat(credentials.getGitHubToken(), equalTo("test-token"));
+	}
+
+	@Test
+	void returnsNullForMissingEnvironmentVariables() {
+		val credentials = new GitHubCredentialsFactory(providerFactory()).fromEnvironmentVariable();
+		assertThat(credentials.getGitHubKey(), nullValue());
+		assertThat(credentials.getGitHubToken(), nullValue());
+	}
+
+	private static ProviderFactory providerFactory() {
+		return ProjectBuilder.builder().build().getProviders();
+	}
+}

--- a/subprojects/docs/documentation-kit/publishing-github-pages/src/test/groovy/dev/gradleplugins/documentationkit/publish/githubpages/internal/GitHubPagesPublishPluginIntegrationTest.java
+++ b/subprojects/docs/documentation-kit/publishing-github-pages/src/test/groovy/dev/gradleplugins/documentationkit/publish/githubpages/internal/GitHubPagesPublishPluginIntegrationTest.java
@@ -1,0 +1,72 @@
+package dev.gradleplugins.documentationkit.publish.githubpages.internal;
+
+import com.google.common.collect.ImmutableMap;
+import dev.gradleplugins.documentationkit.publish.githubpages.tasks.PublishToGitHubPages;
+import lombok.val;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.publish.plugins.PublishingPlugin;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.Test;
+import spock.lang.Subject;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+
+@Subject(GitHubPagesPublishPlugin.class)
+class GitHubPagesPublishPluginIntegrationTest {
+	private final Project project = ProjectBuilder.builder().build();
+
+	private Project applyPluginUnderTest() {
+		project.apply(ImmutableMap.of("plugin", "dev.gradleplugins.documentation.github-pages-publish"));
+		return project;
+	}
+
+	@Test
+	void createPublishTask() {
+		val publishToGitHubPages = applyPluginUnderTest().getTasks().withType(PublishToGitHubPages.class).findByName("publishToGitHubPages");
+		assertThat(publishToGitHubPages.getGroup(), equalTo("publishing"));
+		assertThat(publishToGitHubPages.getDescription(), equalTo("Publishes site produced by this project to GitHub pages."));
+		assertThat(publishToGitHubPages.getCredentials().isPresent(), equalTo(true));
+	}
+
+	@Test
+	void appliesPublishingPlugin() {
+		assertThat(applyPluginUnderTest().getPlugins().hasPlugin(PublishingPlugin.class), equalTo(true));
+	}
+
+	@Test
+	void addsDependencyFromPublishLifecycleTaskToGitHubPagesPublishTask() {
+		assertThat(applyPluginUnderTest().getTasks().getByName("publish"), dependsOn(":publishToGitHubPages"));
+	}
+
+	private static Matcher<Task> dependsOn(String taskPath) {
+		return new FeatureMatcher<Task, Set<String>>(hasItem(taskPath), "", "") {
+			@Override
+			protected Set<String> featureValueOf(Task actual) {
+				return actual.getDependsOn().stream().map(it -> {
+					if (it instanceof TaskProvider) {
+						// TODO: Account for non-root project
+						return actual.getProject().getPath() + ((TaskProvider<?>) it).getName();
+					} else if (it instanceof String) {
+						// TODO: Account for non-root project
+						return actual.getProject().getPath() + it;
+					} else if (it instanceof Task) {
+						return ((Task) it).getPath();
+					}
+					// TODO: missing list of all the same
+					// TODO: Callable
+					// TODO: Provider
+					throw new UnsupportedOperationException();
+				}).collect(Collectors.toSet());
+			}
+		};
+	}
+}

--- a/subprojects/docs/documentation-kit/publishing-github-pages/src/test/groovy/dev/gradleplugins/documentationkit/publish/githubpages/internal/GitHubRepositoryUtilsTest.java
+++ b/subprojects/docs/documentation-kit/publishing-github-pages/src/test/groovy/dev/gradleplugins/documentationkit/publish/githubpages/internal/GitHubRepositoryUtilsTest.java
@@ -1,0 +1,232 @@
+package dev.gradleplugins.documentationkit.publish.githubpages.internal;
+
+import dev.gradleplugins.fixtures.vcs.GitFileRepository;
+import lombok.SneakyThrows;
+import lombok.val;
+import org.apache.commons.io.FileUtils;
+import org.eclipse.jgit.api.ResetCommand;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.api.errors.InvalidRemoteException;
+import org.eclipse.jgit.errors.NoRemoteRepositoryException;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import spock.lang.Subject;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import static dev.gradleplugins.documentationkit.publish.githubpages.internal.GitHubRepositoryUtils.commitAndPushAllFiles;
+import static dev.gradleplugins.documentationkit.publish.githubpages.internal.GitHubRepositoryUtils.createOrFetchOrClone;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.Files.createDirectories;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.io.FileMatchers.aFileNamed;
+import static org.hamcrest.io.FileMatchers.anExistingFile;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Subject(GitHubRepositoryUtils.class)
+class GitHubRepositoryUtilsTest {
+	GitFileRepository repo;
+	@TempDir
+	Path testDirectory;
+
+	@BeforeEach
+	void setUpGitRepository() throws GitAPIException, IOException {
+		repo = GitFileRepository.init(testDirectory.resolve("repo").toFile());
+		initialCommit(repo);
+	}
+
+	private static void initialCommit(GitFileRepository repo) throws IOException, GitAPIException {
+		repo.file("foo.txt").createNewFile();
+		repo.file("bar.txt").createNewFile();
+		repo.commit("Initial commit", "foo.txt", "bar.txt");
+	}
+
+	private static void initialGitHubPagesBranch(GitFileRepository repo) throws IOException, GitAPIException {
+		repo.createBranch("gh-pages");
+		repo.checkout("gh-pages");
+		repo.file(".nojekyll").createNewFile();
+		repo.commit("No jekyll");
+	}
+
+	private static void pollute(GitFileRepository repo) throws IOException {
+		repo.file("foo.html").createNewFile();
+		repo.file("foo.txt").delete();
+		FileUtils.write(repo.file("bar.txt"), "new content", UTF_8);
+	}
+
+	@AfterEach
+	void tearDownGitRepository() {
+		repo.close();
+	}
+
+	@Nested
+	class MissingGitHubPagesBranch {
+		private GitFileRepository localRepo;
+
+		@BeforeEach
+		void initializeRepo() throws GitAPIException, IOException {
+			File localRepoDirectory = testDirectory.resolve("temp").toFile();
+			createOrFetchOrClone(localRepoDirectory, repo.getUrl());
+			localRepo = GitFileRepository.open(localRepoDirectory);
+		}
+
+		@AfterEach
+		void closeLocalRepo() {
+			localRepo.close();
+		}
+
+		@Test
+		void createsNewEmptyGitHubPagesBranchWhenMissing() throws GitAPIException, URISyntaxException, IOException {
+			assertThat("repository remotes points to source repository", localRepo.getRemotes().get(0), equalTo(repo.getUrl()));
+			assertThat("repository head points at gh-pages branch", localRepo, hasHeadRef("refs/heads/gh-pages"));
+			assertThat("no files are checked out", localRepo.getWorkTree().listFiles(withoutHiddenFiles()), emptyArray());
+		}
+
+		@Test
+		void canPushAllFilesWithoutPriorGitHubPagesBranches() throws IOException, GitAPIException {
+			repo.file("foo.html").createNewFile();
+			commitAndPushAllFiles(localRepo.getWorkTree(), Optional.empty());
+
+			repo.checkout("gh-pages");
+			assertThat(repo.getWorkTree().listFiles(withoutHiddenFiles()),
+				hasItemInArray(aFileNamed(equalTo("foo.html"))));
+		}
+	}
+
+	@Nested
+	class ExistingRemoteGitHubPagesBranch {
+		private GitFileRepository localRepo;
+
+		@BeforeEach
+		void initializeRepo() throws GitAPIException, IOException {
+			initialGitHubPagesBranch(repo);
+
+			File localRepoDirectory = testDirectory.resolve("temp").toFile();
+			createOrFetchOrClone(localRepoDirectory, repo.getUrl());
+			localRepo = GitFileRepository.open(localRepoDirectory);
+		}
+
+		@AfterEach
+		void closeLocalRepo() {
+			localRepo.close();
+		}
+
+		@Test
+		void checksOutGitHubPagesBranchFromClone() {
+			assertThat("repository head points at gh-pages branch", localRepo, hasHeadRef("refs/heads/gh-pages"));
+			assertThat("files are checked out", localRepo.file(".nojekyll"), anExistingFile());
+		}
+
+		@Test
+		void canPushAllFilesOnCheckedOutGitHubPagesBranchFromClone() throws IOException, GitAPIException {
+			pollute(localRepo);
+			commitAndPushAllFiles(localRepo.getWorkTree(), Optional.empty());
+
+			repo.getGit().reset().setMode(ResetCommand.ResetType.HARD).call();
+			assertThat(repo.getWorkTree().listFiles(withoutHiddenFiles()),
+				arrayContainingInAnyOrder(aFileNamed(equalTo("foo.html")), aFileNamed(equalTo("bar.txt"))));
+			assertThat(FileUtils.readFileToString(repo.file("bar.txt"), UTF_8), equalTo("new content"));
+		}
+
+		@Nested
+		class RemoteGitHubPagesBranchHasChanged {
+			@BeforeEach
+			void addNewFilesOnRemoteBranch() throws GitAPIException, IOException {
+				repo.checkout("gh-pages");
+				repo.file("bar.txt").createNewFile();
+				repo.commit("New files");
+
+				createOrFetchOrClone(localRepo.getWorkTree(), repo.getUrl());
+			}
+
+
+			@Test
+			void resetsGitHubPagesBranchToLatestWhenAlreadyExists() {
+				assertThat("repository head points at gh-pages branch", localRepo, hasHeadRef("refs/heads/gh-pages"));
+				assertThat("old files are checked out", localRepo.file(".nojekyll"), anExistingFile());
+				assertThat("new files are checked out", localRepo.file("bar.txt"), anExistingFile());
+			}
+		}
+
+		@Nested
+		class DirtyLocalGitHubPagesBranch {
+			@BeforeEach
+			void makeLocalRepoDirty() throws IOException, GitAPIException {
+				pollute(localRepo);
+				createOrFetchOrClone(localRepo.getWorkTree(), repo.getUrl());
+			}
+
+			@Test
+			void hardResetCloneWhenDirty() throws IOException {
+				assertThat("local file is removed", localRepo.file("foo.html"), not(anExistingFile()));
+				assertThat("file is restored", localRepo.file("foo.txt"), anExistingFile());
+				assertThat("local file content is reset", FileUtils.readFileToString(localRepo.file("bar.txt"), UTF_8), emptyString());
+				assertThat("repository head points at gh-pages branch", localRepo, hasHeadRef("refs/heads/gh-pages"));
+			}
+		}
+	}
+
+	@Nested
+	class DirtyLocalWithMissingRemoteGitHubPagesBranch {
+		private GitFileRepository localRepo;
+
+		@BeforeEach
+		void initializeRepo() throws GitAPIException, IOException {
+			File localRepoDirectory = testDirectory.resolve("temp").toFile();
+			createOrFetchOrClone(localRepoDirectory, repo.getUrl());
+			localRepo = GitFileRepository.open(localRepoDirectory);
+
+			pollute(localRepo);
+			createOrFetchOrClone(localRepoDirectory, repo.getUrl());
+		}
+
+		@AfterEach
+		void closeLocalRepo() {
+			localRepo.close();
+		}
+
+		@Test
+		void hardResetNewBranchWhenDirty() throws GitAPIException, URISyntaxException, IOException {
+			assertThat("new gh-pages branch should be empty", localRepo.file("foo.html"), not(anExistingFile()));
+			assertThat("new gh-pages branch should be empty", localRepo.file("foo.txt"), not(anExistingFile()));
+			assertThat("new gh-pages branch should be empty", localRepo.file("bar.txt"), not(anExistingFile()));
+			assertThat("repository head points at gh-pages branch", localRepo, hasHeadRef("refs/heads/gh-pages"));
+		}
+	}
+
+	@Test
+	void throwsExceptionWhenRepositoryIsMissing() throws IOException {
+		val localRepo = createDirectories(testDirectory.resolve("temp")).toFile();
+		val remoteRepo = testDirectory.resolve("missing").toFile().toURI();
+
+		val ex = assertThrows(InvalidRemoteException.class, () -> GitHubRepositoryUtils.createOrFetchOrClone(localRepo, remoteRepo));
+		assertThat(ex.getMessage(), equalTo("Invalid remote: origin"));
+		assertThat(ex.getCause(), isA(NoRemoteRepositoryException.class));
+		assertThat(ex.getCause().getMessage().replace("file:///", "file:/"), equalTo(remoteRepo + ": not found."));
+	}
+
+	private static FilenameFilter withoutHiddenFiles() {
+		return (dir, name) -> !name.startsWith(".");
+	}
+
+	private static Matcher<GitFileRepository> hasHeadRef(String ref) {
+		return new FeatureMatcher<GitFileRepository, String>(equalTo(ref), "", "") {
+			@SneakyThrows
+			@Override
+			protected String featureValueOf(GitFileRepository actual) {
+				return actual.getHead().getTarget().getName();
+			}
+		};
+	}
+}

--- a/subprojects/docs/documentation-kit/settings.gradle
+++ b/subprojects/docs/documentation-kit/settings.gradle
@@ -5,3 +5,4 @@ plugins {
 rootProject.name = 'documentation-kit'
 
 include 'build-language-reference'
+include 'publishing-github-pages'


### PR DESCRIPTION
The decision is to centralize all of Nokee's documentation needs under the Documentation Kit which will later be moved under Gradle Plugin Development organization.