### PR TITLE
Introduce a GitHub Pages site plugin

### DIFF
--- a/subprojects/docs/documentation-kit/build.gradle
+++ b/subprojects/docs/documentation-kit/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
 allprojects {
 	group = 'dev.gradleplugins'
-	version = '1.0.2'
+	version = '1.0.3'
 }
 
 // Unit test configuration

--- a/subprojects/docs/documentation-kit/publishing-github-pages/src/main/java/dev/gradleplugins/documentationkit/publish/githubpages/internal/GitHubPagesPublishPlugin.java
+++ b/subprojects/docs/documentation-kit/publishing-github-pages/src/main/java/dev/gradleplugins/documentationkit/publish/githubpages/internal/GitHubPagesPublishPlugin.java
@@ -8,11 +8,13 @@ import org.gradle.api.Project;
 import org.gradle.api.publish.plugins.PublishingPlugin;
 
 public class GitHubPagesPublishPlugin implements Plugin<Project> {
+	public static final String PUBLISH_GITHUB_PAGES_LIFECYCLE_TASK_NAME = "publishToGitHubPages";
+
 	@Override
 	public void apply(Project project) {
 		project.getPluginManager().apply(PublishingPlugin.class);
 		val credentialsFactory = new GitHubCredentialsFactory(project.getProviders());
-		val publishTask = project.getTasks().register("publishToGitHubPages", defaultClass(PublishToGitHubPages.class), task -> {
+		val publishTask = project.getTasks().register(PUBLISH_GITHUB_PAGES_LIFECYCLE_TASK_NAME, defaultClass(PublishToGitHubPages.class), task -> {
 			task.setGroup(PublishingPlugin.PUBLISH_TASK_GROUP);
 			task.setDescription("Publishes site produced by this project to GitHub pages.");
 			task.getCredentials().convention(credentialsFactory.fromEnvironmentVariable());

--- a/subprojects/docs/documentation-kit/settings.gradle
+++ b/subprojects/docs/documentation-kit/settings.gradle
@@ -6,3 +6,4 @@ rootProject.name = 'documentation-kit'
 
 include 'build-language-reference'
 include 'publishing-github-pages'
+include 'site-github-pages'

--- a/subprojects/docs/documentation-kit/site-github-pages/build.gradle
+++ b/subprojects/docs/documentation-kit/site-github-pages/build.gradle
@@ -1,0 +1,39 @@
+plugins {
+	id 'dev.gradleplugins.java-gradle-plugin'
+	id 'dev.gradleplugins.gradle-plugin-unit-test'
+	id 'dev.gradleplugins.gradle-plugin-functional-test'
+}
+
+repositories {
+	jcenter()
+}
+
+dependencies {
+	implementation project(':publishing-github-pages')
+	implementation "commons-io:commons-io:${commonsIoVersion}"
+}
+
+gradlePlugin {
+	plugins {
+		gitHubPagesSite {
+			id = 'dev.gradleplugins.documentation.github-pages-site'
+			implementationClass = 'dev.gradleplugins.documentationkit.site.githubpages.internal.GitHubPagesSitePlugin'
+		}
+	}
+	compatibility {
+		minimumGradleVersion = project.minimumGradleVersion
+	}
+}
+
+test {
+	dependencies {
+		implementation "com.google.guava:guava:${guavaVersion}"
+	}
+}
+
+functionalTest {
+	dependencies {
+		implementation spockFramework()
+		implementation gradleFixtures()
+	}
+}

--- a/subprojects/docs/documentation-kit/site-github-pages/src/functionalTest/groovy/dev/gradleplugins/documentationkit/site/githubpages/GitHubPagesSitePluginFunctionalTest.groovy
+++ b/subprojects/docs/documentation-kit/site-github-pages/src/functionalTest/groovy/dev/gradleplugins/documentationkit/site/githubpages/GitHubPagesSitePluginFunctionalTest.groovy
@@ -1,0 +1,36 @@
+package dev.gradleplugins.documentationkit.site.githubpages
+
+import dev.gradleplugins.documentationkit.site.githubpages.internal.GitHubPagesSitePlugin
+import dev.gradleplugins.integtests.fixtures.AbstractGradleSpecification
+import spock.lang.Subject
+
+@Subject(GitHubPagesSitePlugin)
+class GitHubPagesSitePluginFunctionalTest extends AbstractGradleSpecification {
+	def "generate CNAME in site"() {
+		buildFile << '''
+			plugins {
+				id 'dev.gradleplugins.documentation.github-pages-site'
+			}
+
+			site {
+				customDomain = subdomain('foo.example.com')
+			}
+		'''
+
+		expect:
+		succeeds('site')
+		file('build/site/CNAME').text == 'foo.example.com'
+	}
+
+	def "generate .nojekyll in site"() {
+		buildFile << '''
+			plugins {
+				id 'dev.gradleplugins.documentation.github-pages-site'
+			}
+		'''
+
+		expect:
+		succeeds('site')
+		file('build/site/.nojekyll').exists()
+	}
+}

--- a/subprojects/docs/documentation-kit/site-github-pages/src/main/java/dev/gradleplugins/documentationkit/site/githubpages/GitHubPagesCustomDomain.java
+++ b/subprojects/docs/documentation-kit/site-github-pages/src/main/java/dev/gradleplugins/documentationkit/site/githubpages/GitHubPagesCustomDomain.java
@@ -1,0 +1,20 @@
+package dev.gradleplugins.documentationkit.site.githubpages;
+
+import java.io.Serializable;
+
+public final class GitHubPagesCustomDomain implements Serializable {
+	private final String customDomain;
+
+	private GitHubPagesCustomDomain(String customDomain) {
+		this.customDomain = customDomain;
+	}
+
+	public String get() {
+		return customDomain;
+	}
+
+	public static GitHubPagesCustomDomain subdomain(String customSubdomain) {
+		// TODO: Assert valid custom subdomain.
+		return new GitHubPagesCustomDomain(customSubdomain);
+	}
+}

--- a/subprojects/docs/documentation-kit/site-github-pages/src/main/java/dev/gradleplugins/documentationkit/site/githubpages/GitHubPagesSite.java
+++ b/subprojects/docs/documentation-kit/site-github-pages/src/main/java/dev/gradleplugins/documentationkit/site/githubpages/GitHubPagesSite.java
@@ -1,0 +1,12 @@
+package dev.gradleplugins.documentationkit.site.githubpages;
+
+import org.gradle.api.provider.Property;
+
+public interface GitHubPagesSite {
+	Property<GitHubPagesCustomDomain> getCustomDomain();
+	Property<String> getRepositorySlug();
+
+	static GitHubPagesCustomDomain subdomain(String customSubdomain) {
+		return GitHubPagesCustomDomain.subdomain(customSubdomain);
+	}
+}

--- a/subprojects/docs/documentation-kit/site-github-pages/src/main/java/dev/gradleplugins/documentationkit/site/githubpages/internal/GitHubPagesSitePlugin.java
+++ b/subprojects/docs/documentation-kit/site-github-pages/src/main/java/dev/gradleplugins/documentationkit/site/githubpages/internal/GitHubPagesSitePlugin.java
@@ -1,0 +1,43 @@
+package dev.gradleplugins.documentationkit.site.githubpages.internal;
+
+import dev.gradleplugins.documentationkit.publish.githubpages.tasks.PublishToGitHubPages;
+import dev.gradleplugins.documentationkit.site.githubpages.GitHubPagesSite;
+import dev.gradleplugins.documentationkit.site.githubpages.tasks.GenerateGitHubPagesCustomDomainCanonicalNameRecord;
+import dev.gradleplugins.documentationkit.site.githubpages.tasks.GenerateGitHubPagesNoJekyll;
+import lombok.val;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.Sync;
+
+import static dev.gradleplugins.documentationkit.publish.githubpages.internal.GitHubPagesPublishPlugin.PUBLISH_GITHUB_PAGES_LIFECYCLE_TASK_NAME;
+
+public class GitHubPagesSitePlugin implements Plugin<Project> {
+	@Override
+	public void apply(Project project) {
+		val site = project.getExtensions().create("site", GitHubPagesSite.class);
+
+		val customDomainTask = project.getTasks().register("generateCustomDomainAlias", GenerateGitHubPagesCustomDomainCanonicalNameRecord.class, task -> {
+			task.getOutputFile().value(project.getLayout().getBuildDirectory().file("CNAME")).disallowChanges();
+			task.getCustomDomain().convention(site.getCustomDomain());
+		});
+
+		val noJekyllTask = project.getTasks().register("generateNoJekyll", GenerateGitHubPagesNoJekyll.class);
+
+		val stageSiteTask = project.getTasks().register("stageSite", Sync.class, task -> {
+			task.from(customDomainTask.map(GenerateGitHubPagesCustomDomainCanonicalNameRecord::getOutputFile));
+			task.from(noJekyllTask.map(GenerateGitHubPagesNoJekyll::getOutputFile));
+			task.setDestinationDir(project.getLayout().getBuildDirectory().dir("site").get().getAsFile());
+		});
+
+		project.getTasks().register("site", task -> {
+			task.dependsOn(stageSiteTask);
+		});
+
+		project.getPluginManager().apply("dev.gradleplugins.documentation.github-pages-publish");
+
+		project.getTasks().named(PUBLISH_GITHUB_PAGES_LIFECYCLE_TASK_NAME, PublishToGitHubPages.class, task -> {
+			task.getUri().convention(site.getRepositorySlug().map(it -> project.uri("https://github.com/" + it + ".git")));
+			task.getPublishDirectory().fileProvider(stageSiteTask.map(Sync::getDestinationDir));
+		});
+	}
+}

--- a/subprojects/docs/documentation-kit/site-github-pages/src/main/java/dev/gradleplugins/documentationkit/site/githubpages/tasks/GenerateGitHubPagesCustomDomainCanonicalNameRecord.java
+++ b/subprojects/docs/documentation-kit/site-github-pages/src/main/java/dev/gradleplugins/documentationkit/site/githubpages/tasks/GenerateGitHubPagesCustomDomainCanonicalNameRecord.java
@@ -1,0 +1,36 @@
+package dev.gradleplugins.documentationkit.site.githubpages.tasks;
+
+import dev.gradleplugins.documentationkit.site.githubpages.GitHubPagesCustomDomain;
+import org.apache.commons.io.FileUtils;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+/**
+ * Generate a CNAME file for the specified custom domain.
+ */
+public abstract class GenerateGitHubPagesCustomDomainCanonicalNameRecord extends DefaultTask {
+	@Input
+	@Optional
+	public abstract Property<GitHubPagesCustomDomain> getCustomDomain();
+
+	@OutputFile
+	public abstract RegularFileProperty getOutputFile();
+
+	@TaskAction
+	private void doGenerate() throws IOException {
+		if (!getCustomDomain().isPresent()) {
+			setDidWork(false);
+			return;
+		}
+
+		FileUtils.write(getOutputFile().get().getAsFile(), getCustomDomain().get().get(), Charset.defaultCharset());
+	}
+}

--- a/subprojects/docs/documentation-kit/site-github-pages/src/main/java/dev/gradleplugins/documentationkit/site/githubpages/tasks/GenerateGitHubPagesNoJekyll.java
+++ b/subprojects/docs/documentation-kit/site-github-pages/src/main/java/dev/gradleplugins/documentationkit/site/githubpages/tasks/GenerateGitHubPagesNoJekyll.java
@@ -1,0 +1,28 @@
+package dev.gradleplugins.documentationkit.site.githubpages.tasks;
+
+import org.apache.commons.io.FileUtils;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+
+import javax.inject.Inject;
+import java.io.IOException;
+
+public abstract class GenerateGitHubPagesNoJekyll extends DefaultTask {
+	@OutputFile
+	public abstract RegularFileProperty getOutputFile();
+
+	@Inject
+	protected abstract ProjectLayout getLayout();
+
+	public GenerateGitHubPagesNoJekyll() {
+		getOutputFile().value(getLayout().getBuildDirectory().file("tmp/" + getName() + "/.nojekyll")).disallowChanges();
+	}
+
+	@TaskAction
+	private void doGenerate() throws IOException {
+		FileUtils.touch(getOutputFile().get().getAsFile());
+	}
+}

--- a/subprojects/docs/documentation-kit/site-github-pages/src/test/java/dev/gradleplugins/documentationkit/site/githubpages/internal/GitHubPagesSitePluginTest.java
+++ b/subprojects/docs/documentation-kit/site-github-pages/src/test/java/dev/gradleplugins/documentationkit/site/githubpages/internal/GitHubPagesSitePluginTest.java
@@ -1,0 +1,34 @@
+package dev.gradleplugins.documentationkit.site.githubpages.internal;
+
+import com.google.common.collect.ImmutableMap;
+import dev.gradleplugins.documentationkit.publish.githubpages.tasks.PublishToGitHubPages;
+import dev.gradleplugins.documentationkit.site.githubpages.GitHubPagesSite;
+import lombok.val;
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasToString;
+
+class GitHubPagesSitePluginTest {
+	@Test
+	void applyGitHubPagesPublishPlugin() {
+		assertThat(applyPluginUnderTest().getPluginManager().hasPlugin("dev.gradleplugins.documentation.github-pages-publish"), equalTo(true));
+	}
+
+	@Test
+	void configuresGitHubPagesPublishUriWithRepositorySlug() {
+		val project = applyPluginUnderTest();
+		project.getExtensions().getByType(GitHubPagesSite.class).getRepositorySlug().set("foo/bar");
+		assertThat(project.getTasks().withType(PublishToGitHubPages.class).getByName("publishToGitHubPages").getUri().get(),
+			hasToString("https://github.com/foo/bar.git"));
+	}
+
+	private static Project applyPluginUnderTest() {
+		val project = ProjectBuilder.builder().build();
+		project.apply(ImmutableMap.of("plugin", "dev.gradleplugins.documentation.github-pages-site"));
+		return project;
+	}
+}


### PR DESCRIPTION
This plugin is one step further then where we want to be. There should
be a site-base/site plugin that take cares of the lifecycle task. The
GitHub Pages site plugin simple handle the publishing and assembling of
the site. Rendering of the site should be handle by another plugin.