### PR TITLE
Improvements to domain collection utilities

### DIFF
--- a/subprojects/core-utils/src/main/java/dev/nokee/utils/NamedDomainObjectCollectionUtils.java
+++ b/subprojects/core-utils/src/main/java/dev/nokee/utils/NamedDomainObjectCollectionUtils.java
@@ -95,6 +95,12 @@ public final class NamedDomainObjectCollectionUtils {
 	}
 	//endregion
 
+	//region getType
+	public static <T> Class<?> getType(NamedDomainObjectCollection<T> self) {
+		return ((DefaultNamedDomainObjectCollection<T>) self).getType();
+	}
+	//endregion
+
 	@EqualsAndHashCode
 	public static final class ElementInfo<T> {
 		private final String name;

--- a/subprojects/core-utils/src/main/java/dev/nokee/utils/NamedDomainObjectCollectionUtils.java
+++ b/subprojects/core-utils/src/main/java/dev/nokee/utils/NamedDomainObjectCollectionUtils.java
@@ -5,12 +5,12 @@ import lombok.val;
 import org.gradle.api.*;
 import org.gradle.api.internal.DefaultNamedDomainObjectCollection;
 
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
-
-import static dev.nokee.utils.ActionUtils.compose;
 
 public final class NamedDomainObjectCollectionUtils {
 	private NamedDomainObjectCollectionUtils() {}
@@ -51,6 +51,14 @@ public final class NamedDomainObjectCollectionUtils {
 	}
 
 	//region registerIfAbsent
+	public static <T> NamedDomainObjectProvider<T> registerIfAbsent(NamedDomainObjectContainer<T> self, String name) {
+		if (hasElementWithName(self, name)) {
+			return self.named(name);
+		}
+
+		return self.register(name);
+	}
+
 	public static <T> NamedDomainObjectProvider<T> registerIfAbsent(NamedDomainObjectContainer<T> self, String name, Action<? super T> action) {
 		if (hasElementWithName(self, name)) {
 			// TODO: Wire in assertable
@@ -60,6 +68,16 @@ public final class NamedDomainObjectCollectionUtils {
 		return self.register(name, action);
 	}
 
+	public static <U extends T, T> NamedDomainObjectProvider<U> registerIfAbsent(PolymorphicDomainObjectContainer<T> self, String name, Class<U> type) {
+		if (hasElementWithName(self, name)) {
+			// TODO: Assert type is correct one, be careful with Task and DefaultTask for TaskContainer
+			return self.named(name, type);
+		}
+
+		return self.register(name, type);
+	}
+
+	// TODO: The action here should force to be assertable to make the contract clear that when you registerIfAbsent, the action should match the base configuration of the existing element
 	public static <U extends T, T> NamedDomainObjectProvider<U> registerIfAbsent(PolymorphicDomainObjectContainer<T> self, String name, Class<U> type, Action<? super U> action) {
 		if (hasElementWithName(self, name)) {
 			// TODO: Wire in assertable

--- a/subprojects/core-utils/src/test/groovy/dev/nokee/utils/NamedDomainObjectCollectionUtils_GetElementTypeTest.java
+++ b/subprojects/core-utils/src/test/groovy/dev/nokee/utils/NamedDomainObjectCollectionUtils_GetElementTypeTest.java
@@ -3,35 +3,33 @@ package dev.nokee.utils;
 import lombok.val;
 import org.gradle.api.Named;
 import org.gradle.api.Task;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static dev.gradleplugins.grava.testing.util.ProjectTestUtils.objectFactory;
 import static dev.gradleplugins.grava.testing.util.ProjectTestUtils.rootProject;
-import static dev.nokee.utils.NamedDomainObjectCollectionUtils.getType;
+import static dev.nokee.utils.NamedDomainObjectCollectionUtils.getElementType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
-class NamedDomainObjectCollectionUtils_GetTypeTest {
+class NamedDomainObjectCollectionUtils_GetElementTypeTest {
 	@Test
 	void canGetTypeOnTaskContainer() {
-		val type = assertDoesNotThrow(() -> getType(rootProject().getTasks()));
+		val type = assertDoesNotThrow(() -> getElementType(rootProject().getTasks()));
 		assertThat(type, is(Task.class));
 	}
 
 	@Test
 	void canGetTypeOnNamedContainer() {
 		val container = objectFactory().domainObjectContainer(Bean.class);
-		val type = assertDoesNotThrow(() -> getType(container));
+		val type = assertDoesNotThrow(() -> getElementType(container));
 		assertThat(type, is(Bean.class));
 	}
 
 	@Test
 	void canGetTypeOnPolymorphicContainer() {
 		val container = objectFactory().polymorphicDomainObjectContainer(Bean.class);
-		val type = assertDoesNotThrow(() -> getType(container));
+		val type = assertDoesNotThrow(() -> getElementType(container));
 		assertThat(type, is(Bean.class));
 	}
 

--- a/subprojects/core-utils/src/test/groovy/dev/nokee/utils/NamedDomainObjectCollectionUtils_GetTypeTest.java
+++ b/subprojects/core-utils/src/test/groovy/dev/nokee/utils/NamedDomainObjectCollectionUtils_GetTypeTest.java
@@ -1,0 +1,39 @@
+package dev.nokee.utils;
+
+import lombok.val;
+import org.gradle.api.Named;
+import org.gradle.api.Task;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static dev.gradleplugins.grava.testing.util.ProjectTestUtils.objectFactory;
+import static dev.gradleplugins.grava.testing.util.ProjectTestUtils.rootProject;
+import static dev.nokee.utils.NamedDomainObjectCollectionUtils.getType;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class NamedDomainObjectCollectionUtils_GetTypeTest {
+	@Test
+	void canGetTypeOnTaskContainer() {
+		val type = assertDoesNotThrow(() -> getType(rootProject().getTasks()));
+		assertThat(type, is(Task.class));
+	}
+
+	@Test
+	void canGetTypeOnNamedContainer() {
+		val container = objectFactory().domainObjectContainer(Bean.class);
+		val type = assertDoesNotThrow(() -> getType(container));
+		assertThat(type, is(Bean.class));
+	}
+
+	@Test
+	void canGetTypeOnPolymorphicContainer() {
+		val container = objectFactory().polymorphicDomainObjectContainer(Bean.class);
+		val type = assertDoesNotThrow(() -> getType(container));
+		assertThat(type, is(Bean.class));
+	}
+
+	interface Bean extends Named {}
+}

--- a/subprojects/core-utils/src/test/groovy/dev/nokee/utils/NamedDomainObjectCollectionUtils_WhenElementKnownTest.java
+++ b/subprojects/core-utils/src/test/groovy/dev/nokee/utils/NamedDomainObjectCollectionUtils_WhenElementKnownTest.java
@@ -31,14 +31,14 @@ class NamedDomainObjectCollectionUtils_WhenElementKnownTest {
 
 	@Test
 	void doesNotCallActionOnEmptyCollection() {
-		Action<NamedDomainObjectCollectionUtils.ElementInfo<Element>> action = uncheckedCastBecauseOfTypeErasure(Mockito.mock(Action.class));
+		Action<KnownElement<Element>> action = uncheckedCastBecauseOfTypeErasure(Mockito.mock(Action.class));
 		whenElementKnown(anEmptyContainer(), action);
 		verify(action, never()).execute(any());
 	}
 
 	@Test
 	void callActionOnAnyElementSubsequentlyCreated() {
-		Action<NamedDomainObjectCollectionUtils.ElementInfo<Element>> action = uncheckedCastBecauseOfTypeErasure(Mockito.mock(Action.class));
+		Action<KnownElement<Element>> action = uncheckedCastBecauseOfTypeErasure(Mockito.mock(Action.class));
 		val container = anEmptyContainer();
 		whenElementKnown(container, action);
 		container.create("e0");
@@ -49,7 +49,7 @@ class NamedDomainObjectCollectionUtils_WhenElementKnownTest {
 
 	@Test
 	void callActionOnAnyElementSubsequentlyRegistered() {
-		Action<NamedDomainObjectCollectionUtils.ElementInfo<Element>> action = uncheckedCastBecauseOfTypeErasure(Mockito.mock(Action.class));
+		Action<KnownElement<Element>> action = uncheckedCastBecauseOfTypeErasure(Mockito.mock(Action.class));
 		val container = anEmptyContainer();
 		whenElementKnown(container, action);
 		container.register("e0");
@@ -60,7 +60,7 @@ class NamedDomainObjectCollectionUtils_WhenElementKnownTest {
 
 	@Test
 	void callActionOnAnyElementPreviouslyRegistered() {
-		Action<NamedDomainObjectCollectionUtils.ElementInfo<Element>> action = uncheckedCastBecauseOfTypeErasure(Mockito.mock(Action.class));
+		Action<KnownElement<Element>> action = uncheckedCastBecauseOfTypeErasure(Mockito.mock(Action.class));
 		val container = anEmptyContainer();
 		container.register("e0");
 		container.register("e1", Element.class);
@@ -71,7 +71,7 @@ class NamedDomainObjectCollectionUtils_WhenElementKnownTest {
 
 	@Test
 	void callActionOnAnyElementPreviouslyCreated() {
-		Action<NamedDomainObjectCollectionUtils.ElementInfo<Element>> action = uncheckedCastBecauseOfTypeErasure(Mockito.mock(Action.class));
+		Action<KnownElement<Element>> action = uncheckedCastBecauseOfTypeErasure(Mockito.mock(Action.class));
 		val container = anEmptyContainer();
 		container.create("e0");
 		container.create("e1", Element.class);
@@ -82,7 +82,7 @@ class NamedDomainObjectCollectionUtils_WhenElementKnownTest {
 
 	@Test
 	void canFilterKnownElementsByName() {
-		Action<NamedDomainObjectCollectionUtils.ElementInfo<Element>> action = uncheckedCastBecauseOfTypeErasure(Mockito.mock(Action.class));
+		Action<KnownElement<Element>> action = uncheckedCastBecauseOfTypeErasure(Mockito.mock(Action.class));
 		val container = anEmptyContainer();
 		container.create("e0");
 		container.create("e1", Element.class);
@@ -93,12 +93,12 @@ class NamedDomainObjectCollectionUtils_WhenElementKnownTest {
 
 	@Test
 	void canFilterKnownElementsByType() {
-		Action<NamedDomainObjectCollectionUtils.ElementInfo<Element>> action = uncheckedCastBecauseOfTypeErasure(Mockito.mock(Action.class));
+		Action<KnownElement<Element>> action = uncheckedCastBecauseOfTypeErasure(Mockito.mock(Action.class));
 		val container = anEmptyContainer();
 		container.create("e0");
 		container.create("e1", Element.class);
 		container.create("e2", ChildAElement.class);
-		whenElementKnown(container, onlyIf(compose(subtypeOf(ChildAElement.class), ElementInfo::getType), action));
+		whenElementKnown(container, onlyIf(compose(subtypeOf(ChildAElement.class), KnownElement::getType), action));
 		verify(action, times(1)).execute(any());
 	}
 


### PR DESCRIPTION
Add more API variants to `registerIfAbsent` helper. Formalize `whenElementKnown` helper API to allow query of the "known element" by creating a richer wrapper around the element info and container itself. Also, expose the `getType()` from the internal Gradle API.