### PR TITLE
Use OS name as-is when detecting OS family

### DIFF
--- a/subprojects/runtime-native/src/main/java/dev/nokee/runtime/nativebase/internal/DefaultOperatingSystemFamily.java
+++ b/subprojects/runtime-native/src/main/java/dev/nokee/runtime/nativebase/internal/DefaultOperatingSystemFamily.java
@@ -57,7 +57,7 @@ public class DefaultOperatingSystemFamily implements OperatingSystemFamily, Name
 		} else if (osName.contains("ios")) {
 			return IOS;
 		} else {
-			throw new UnsupportedOperationException("Unsupported operating system family of name '" + osName + "'");
+			return new DefaultOperatingSystemFamily(osName); // unknown OS family, use as-is
 		}
 	}
 


### PR DESCRIPTION
It simply move the issue further down the line. It seems like Gradle is
pretty opinionated on OS support based on their embedded native-platform
which have limited support. It should gracefully degrade into a mostly
workable state. However, based on exprimentation, starting process is
handled by the native-platform and don't have a acceptable fallback.