### PR TITLE
Expand guard to all binaries' isBuildable() methods

### DIFF
--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BundleBinaryInternal.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BundleBinaryInternal.java
@@ -88,7 +88,11 @@ public class BundleBinaryInternal extends BaseNativeBinary implements BundleBina
 
 	@Override
 	public boolean isBuildable() {
-		return super.isBuildable() && isBuildable(linkTask.get());
+		try {
+			return super.isBuildable() && isBuildable(linkTask.get());
+		} catch (Throwable ex) { // because toolchain selection calls xcrun for macOS which doesn't exists on non-mac system
+			return false;
+		}
 	}
 
 	private static boolean isBuildable(LinkBundle linkTask) {

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/ExecutableBinaryInternal.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/ExecutableBinaryInternal.java
@@ -109,7 +109,11 @@ public class ExecutableBinaryInternal extends BaseNativeBinary implements Execut
 
 	@Override
 	public boolean isBuildable() {
-		return super.isBuildable() && isBuildable(linkTask.get());
+		try {
+			return super.isBuildable() && isBuildable(linkTask.get());
+		} catch (Throwable ex) { // because toolchain selection calls xcrun for macOS which doesn't exists on non-mac system
+			return false;
+		}
 	}
 
 	private static boolean isBuildable(LinkExecutable linkTask) {

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/SharedLibraryBinaryInternal.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/SharedLibraryBinaryInternal.java
@@ -164,7 +164,11 @@ public class SharedLibraryBinaryInternal extends BaseNativeBinary implements Sha
 
 	@Override
 	public boolean isBuildable() {
-		return super.isBuildable() && isBuildable(linkTask.get());
+		try {
+			return super.isBuildable() && isBuildable(linkTask.get());
+		} catch (Throwable ex) { // because toolchain selection calls xcrun for macOS which doesn't exists on non-mac system
+			return false;
+		}
 	}
 
 	private static boolean isBuildable(LinkSharedLibrary linkTask) {


### PR DESCRIPTION
To prevent failures on non-Mac system because of xcrun change in Gradle
core.