### PR TITLE
Update toolbox to 1.5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ systemProp.org.gradle.internal.repository.initial.backoff=500
 
 lombokVersion=1.18.12
 minimumGradleVersion=6.2.1
-toolboxVersion=1.4.2
+toolboxVersion=1.5
 guavaVersion=28.2-jre
 commonsLangVersion=3.9
 commonsIoVersion=2.6

--- a/gradle/plugins/docs-gradle-plugin/settings.gradle
+++ b/gradle/plugins/docs-gradle-plugin/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'dev.gradleplugins.gradle-plugin-development' version '1.4.2'
+	id 'dev.gradleplugins.gradle-plugin-development' version '1.5'
 }
 
 rootProject.name = 'docs-gradle-plugin'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'dev.gradleplugins.gradle-plugin-development' version '1.4.2'
+	id 'dev.gradleplugins.gradle-plugin-development' version '1.5'
 }
 
 rootProject.name = 'gradle-native'

--- a/subprojects/docs/documentation-kit/gradle.properties
+++ b/subprojects/docs/documentation-kit/gradle.properties
@@ -1,6 +1,6 @@
 lombokVersion=1.18.12
 minimumGradleVersion=6.7.1
-toolboxVersion=1.4.2
+toolboxVersion=1.5
 guavaVersion=28.2-jre
 commonsLangVersion=3.9
 commonsIoVersion=2.6

--- a/subprojects/docs/documentation-kit/settings.gradle
+++ b/subprojects/docs/documentation-kit/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'dev.gradleplugins.gradle-plugin-development' version '1.4.2'
+	id 'dev.gradleplugins.gradle-plugin-development' version '1.5'
 }
 
 includeBuild 'gradle/plugins'

--- a/subprojects/docs/src/docs/manual/gradle-plugin-development-plugin.adoc
+++ b/subprojects/docs/src/docs/manual/gradle-plugin-development-plugin.adoc
@@ -18,7 +18,7 @@ It is also provide a migration path to <<java-gradle-plugin-plugin.adoc#,`dev.gr
 [source,groovy]
 ----
 plugins {
-   id 'dev.gradleplugins.gradle-plugin-development' version '1.4.2'
+   id 'dev.gradleplugins.gradle-plugin-development' version '1.5'
 }
 ----
 =====
@@ -28,7 +28,7 @@ plugins {
 [source,kotlin]
 ----
 plugins {
-   id("dev.gradleplugins.gradle-plugin-development") version("1.4.2")
+   id("dev.gradleplugins.gradle-plugin-development") version("1.5")
 }
 ----
 =====

--- a/subprojects/docs/src/docs/manual/gradle-plugin-functional-test-plugin.adoc
+++ b/subprojects/docs/src/docs/manual/gradle-plugin-functional-test-plugin.adoc
@@ -16,7 +16,7 @@ Use the Gradle Plugin Functional Test plugin to assist Gradle plugin functional 
 [source,groovy]
 ----
 plugins {
-   id 'dev.gradleplugins.gradle-plugin-functional-test' version '1.4.2'
+   id 'dev.gradleplugins.gradle-plugin-functional-test' version '1.5'
 }
 ----
 =====
@@ -26,7 +26,7 @@ plugins {
 [source,kotlin]
 ----
 plugins {
-   id("dev.gradleplugins.gradle-plugin-functional-test") version("1.4.2")
+   id("dev.gradleplugins.gradle-plugin-functional-test") version("1.5")
 }
 ----
 =====

--- a/subprojects/docs/src/docs/manual/gradle-plugin-unit-test-plugin.adoc
+++ b/subprojects/docs/src/docs/manual/gradle-plugin-unit-test-plugin.adoc
@@ -16,7 +16,7 @@ Use the Gradle Plugin Unit Test plugin to assist Gradle plugin unit testing.
 [source,groovy]
 ----
 plugins {
-   id 'dev.gradleplugins.gradle-plugin-unit-test' version '1.4.2'
+   id 'dev.gradleplugins.gradle-plugin-unit-test' version '1.5'
 }
 ----
 =====
@@ -26,7 +26,7 @@ plugins {
 [source,kotlin]
 ----
 plugins {
-   id("dev.gradleplugins.gradle-plugin-unit-test") version("1.4.2")
+   id("dev.gradleplugins.gradle-plugin-unit-test") version("1.5")
 }
 ----
 =====

--- a/subprojects/docs/src/docs/manual/groovy-gradle-plugin-plugin.adoc
+++ b/subprojects/docs/src/docs/manual/groovy-gradle-plugin-plugin.adoc
@@ -18,7 +18,7 @@ It is a drop-in replacement for the Gradle `java-gradle-plugin` and `groovy` cor
 [source,groovy]
 ----
 plugins {
-   id 'dev.gradleplugins.groovy-gradle-plugin' version '1.4.2'
+   id 'dev.gradleplugins.groovy-gradle-plugin' version '1.5'
 }
 ----
 =====
@@ -28,7 +28,7 @@ plugins {
 [source,kotlin]
 ----
 plugins {
-   id("dev.gradleplugins.groovy-gradle-plugin") version("1.4.2")
+   id("dev.gradleplugins.groovy-gradle-plugin") version("1.5")
 }
 ----
 =====

--- a/subprojects/docs/src/docs/manual/java-gradle-plugin-plugin.adoc
+++ b/subprojects/docs/src/docs/manual/java-gradle-plugin-plugin.adoc
@@ -18,7 +18,7 @@ It is a drop-in replacement for the Gradle `java-gradle-plugin` core plugin.
 [source,groovy]
 ----
 plugins {
-   id 'dev.gradleplugins.java-gradle-plugin' version '1.4.2'
+   id 'dev.gradleplugins.java-gradle-plugin' version '1.5'
 }
 ----
 =====
@@ -28,7 +28,7 @@ plugins {
 [source,kotlin]
 ----
 plugins {
-   id("dev.gradleplugins.java-gradle-plugin") version("1.4.2")
+   id("dev.gradleplugins.java-gradle-plugin") version("1.5")
 }
 ----
 =====

--- a/subprojects/docs/src/docs/samples/gradle-plugin-development-runtime-compatibilities/groovy-dsl/settings.gradle
+++ b/subprojects/docs/src/docs/samples/gradle-plugin-development-runtime-compatibilities/groovy-dsl/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-	id 'dev.gradleplugins.gradle-plugin-development' version '1.4.2'
+	id 'dev.gradleplugins.gradle-plugin-development' version '1.5'
 }
 
 rootProject.name = 'gradle-plugin-development-runtime-compatibilities'

--- a/subprojects/docs/src/docs/samples/gradle-plugin-development-runtime-compatibilities/kotlin-dsl/settings.gradle.kts
+++ b/subprojects/docs/src/docs/samples/gradle-plugin-development-runtime-compatibilities/kotlin-dsl/settings.gradle.kts
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-	id("dev.gradleplugins.gradle-plugin-development") version("1.4.2")
+	id("dev.gradleplugins.gradle-plugin-development") version("1.5")
 }
 
 rootProject.name = "gradle-plugin-development-runtime-compatibilities"

--- a/subprojects/docs/src/docs/samples/gradle-plugin-development-with-minimum-gradle-version/groovy-dsl/build.gradle
+++ b/subprojects/docs/src/docs/samples/gradle-plugin-development-with-minimum-gradle-version/groovy-dsl/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'dev.gradleplugins.java-gradle-plugin' version '1.4.2'
+	id 'dev.gradleplugins.java-gradle-plugin' version '1.5'
 	id 'groovy-base' // for Spock testing
 }
 

--- a/subprojects/docs/src/docs/samples/gradle-plugin-development-with-minimum-gradle-version/kotlin-dsl/build.gradle.kts
+++ b/subprojects/docs/src/docs/samples/gradle-plugin-development-with-minimum-gradle-version/kotlin-dsl/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-	id("dev.gradleplugins.java-gradle-plugin") version("1.4.2")
+	id("dev.gradleplugins.java-gradle-plugin") version("1.5")
 	id("groovy-base") // for Spock testing
 }
 

--- a/subprojects/docs/src/docs/samples/gradle-plugin-development-with-test-suites/groovy-dsl/build.gradle
+++ b/subprojects/docs/src/docs/samples/gradle-plugin-development-with-test-suites/groovy-dsl/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-	id 'dev.gradleplugins.java-gradle-plugin' version '1.4.2'
-	id 'dev.gradleplugins.gradle-plugin-unit-test' version '1.4.2'
-	id 'dev.gradleplugins.gradle-plugin-functional-test' version '1.4.2'
+	id 'dev.gradleplugins.java-gradle-plugin' version '1.5'
+	id 'dev.gradleplugins.gradle-plugin-unit-test' version '1.5'
+	id 'dev.gradleplugins.gradle-plugin-functional-test' version '1.5'
 	id 'groovy-base' // for Spock testing
 }
 

--- a/subprojects/docs/src/docs/samples/gradle-plugin-development-with-test-suites/kotlin-dsl/build.gradle.kts
+++ b/subprojects/docs/src/docs/samples/gradle-plugin-development-with-test-suites/kotlin-dsl/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-	id("dev.gradleplugins.java-gradle-plugin") version("1.4.2")
-	id("dev.gradleplugins.gradle-plugin-unit-test") version("1.4.2")
-	id("dev.gradleplugins.gradle-plugin-functional-test") version("1.4.2")
+	id("dev.gradleplugins.java-gradle-plugin") version("1.5")
+	id("dev.gradleplugins.gradle-plugin-unit-test") version("1.5")
+	id("dev.gradleplugins.gradle-plugin-functional-test") version("1.5")
 	id("groovy-base") // for Spock testing
 }
 

--- a/subprojects/docs/src/docs/samples/gradle-plugin-development-with-testing-strategies/groovy-dsl/build.gradle
+++ b/subprojects/docs/src/docs/samples/gradle-plugin-development-with-testing-strategies/groovy-dsl/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-	id 'dev.gradleplugins.java-gradle-plugin' version '1.4.2'
-	id 'dev.gradleplugins.gradle-plugin-functional-test' version '1.4.2'
+	id 'dev.gradleplugins.java-gradle-plugin' version '1.5'
+	id 'dev.gradleplugins.gradle-plugin-functional-test' version '1.5'
 	id 'groovy-base' // for Spock testing
 }
 

--- a/subprojects/docs/src/docs/samples/gradle-plugin-development-with-testing-strategies/kotlin-dsl/build.gradle.kts
+++ b/subprojects/docs/src/docs/samples/gradle-plugin-development-with-testing-strategies/kotlin-dsl/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-	id("dev.gradleplugins.java-gradle-plugin") version("1.4.2")
-	id("dev.gradleplugins.gradle-plugin-functional-test") version("1.4.2")
+	id("dev.gradleplugins.java-gradle-plugin") version("1.5")
+	id("dev.gradleplugins.gradle-plugin-functional-test") version("1.5")
 	id("groovy-base") // for Spock testing
 }
 

--- a/subprojects/templates/settings.gradle
+++ b/subprojects/templates/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'dev.gradleplugins.gradle-plugin-development' version '1.4.2'
+	id 'dev.gradleplugins.gradle-plugin-development' version '1.5'
 }
 
 gradle.rootProject {


### PR DESCRIPTION
This version includes changes for ad-hoc Gradle version for unit testing. This change is required to properly test the fix for https://github.com/nokeedev/gradle-native/issues/314.