### PR TITLE
Use non-internal variant view type in base native component

### DIFF
--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationComponent.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationComponent.java
@@ -34,6 +34,7 @@ import dev.nokee.platform.base.internal.tasks.TaskViewFactory;
 import dev.nokee.platform.base.internal.variants.KnownVariant;
 import dev.nokee.platform.base.internal.variants.VariantRepository;
 import dev.nokee.platform.base.internal.variants.VariantViewFactory;
+import dev.nokee.platform.base.internal.variants.VariantViewInternal;
 import dev.nokee.platform.ios.IosResourceSet;
 import dev.nokee.platform.ios.tasks.internal.*;
 import dev.nokee.platform.nativebase.ExecutableBinary;
@@ -128,6 +129,11 @@ public class DefaultIosApplicationComponent extends BaseNativeComponent<DefaultI
 	@Override
 	public BinaryView<Binary> getBinaries() {
 		return binaries;
+	}
+
+	@Override
+	public VariantViewInternal<DefaultIosApplicationVariant> getVariants() {
+		return (VariantViewInternal<DefaultIosApplicationVariant>) super.getVariants();
 	}
 
 	@Override

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeComponent.java
@@ -22,6 +22,7 @@ import dev.nokee.language.nativebase.tasks.NativeSourceCompile;
 import dev.nokee.model.internal.DomainObjectCreated;
 import dev.nokee.model.internal.DomainObjectDiscovered;
 import dev.nokee.model.internal.DomainObjectEventPublisher;
+import dev.nokee.platform.base.VariantView;
 import dev.nokee.platform.base.internal.*;
 import dev.nokee.platform.base.internal.tasks.TaskIdentifier;
 import dev.nokee.platform.base.internal.tasks.TaskName;
@@ -65,7 +66,7 @@ public abstract class BaseNativeComponent<T extends VariantInternal> extends Bas
 
 	public abstract NativeComponentDependencies getDependencies();
 
-	public VariantViewInternal<T> getVariants() {
+	public VariantView<T> getVariants() {
 		return getVariantCollection().getAsView(variantType);
 	}
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryComponent.java
@@ -30,6 +30,7 @@ import dev.nokee.platform.base.internal.tasks.TaskRegistry;
 import dev.nokee.platform.base.internal.tasks.TaskViewFactory;
 import dev.nokee.platform.base.internal.variants.VariantRepository;
 import dev.nokee.platform.base.internal.variants.VariantViewFactory;
+import dev.nokee.platform.base.internal.variants.VariantViewInternal;
 import dev.nokee.platform.nativebase.NativeLibraryComponentDependencies;
 import dev.nokee.platform.nativebase.internal.dependencies.DefaultNativeLibraryComponentDependencies;
 import dev.nokee.platform.nativebase.internal.dependencies.FrameworkAwareDependencyBucketFactory;
@@ -81,6 +82,11 @@ public class DefaultNativeLibraryComponent extends BaseNativeComponent<DefaultNa
 	@Override
 	public BinaryView<Binary> getBinaries() {
 		return binaries;
+	}
+
+	@Override
+	public VariantViewInternal<DefaultNativeLibraryVariant> getVariants() {
+		return (VariantViewInternal<DefaultNativeLibraryVariant>) super.getVariants();
 	}
 
 	@Override

--- a/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteComponent.java
+++ b/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteComponent.java
@@ -41,6 +41,7 @@ import dev.nokee.platform.base.internal.tasks.TaskRegistry;
 import dev.nokee.platform.base.internal.tasks.TaskViewFactory;
 import dev.nokee.platform.base.internal.variants.VariantRepository;
 import dev.nokee.platform.base.internal.variants.VariantViewFactory;
+import dev.nokee.platform.base.internal.variants.VariantViewInternal;
 import dev.nokee.platform.nativebase.ExecutableBinary;
 import dev.nokee.platform.nativebase.NativeBinary;
 import dev.nokee.platform.nativebase.internal.BaseNativeComponent;
@@ -158,6 +159,11 @@ public class DefaultNativeTestSuiteComponent extends BaseNativeComponent<Default
 	@Override
 	public BinaryView<Binary> getBinaries() {
 		return binaries;
+	}
+
+	@Override
+	public VariantViewInternal<DefaultNativeTestSuiteVariant> getVariants() {
+		return (VariantViewInternal<DefaultNativeTestSuiteVariant>) super.getVariants();
 	}
 
 	@Override

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/BaseXCTestTestSuiteComponent.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/BaseXCTestTestSuiteComponent.java
@@ -34,6 +34,7 @@ import dev.nokee.platform.base.internal.tasks.TaskViewFactory;
 import dev.nokee.platform.base.internal.variants.KnownVariant;
 import dev.nokee.platform.base.internal.variants.VariantRepository;
 import dev.nokee.platform.base.internal.variants.VariantViewFactory;
+import dev.nokee.platform.base.internal.variants.VariantViewInternal;
 import dev.nokee.platform.nativebase.BundleBinary;
 import dev.nokee.platform.nativebase.NativeComponentDependencies;
 import dev.nokee.platform.nativebase.internal.BaseNativeBinary;
@@ -122,6 +123,11 @@ public class BaseXCTestTestSuiteComponent extends BaseNativeComponent<DefaultXCT
 	@Override
 	public BinaryView<Binary> getBinaries() {
 		return binaries;
+	}
+
+	@Override
+	public VariantViewInternal<DefaultXCTestTestSuiteVariant> getVariants() {
+		return (VariantViewInternal<DefaultXCTestTestSuiteVariant>) super.getVariants();
 	}
 
 	@Override


### PR DESCRIPTION
As we are migrating over to the universal model, we are extracting some dependent changes from other parallel work. This PR is one of those work items. It's a temporary change to allow working of various things in parallel.