### PR TITLE
Introduce a very early model report task

### DIFF
--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/plugins/ModelBasePlugin.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/plugins/ModelBasePlugin.java
@@ -19,14 +19,19 @@ import dev.nokee.model.internal.DomainObjectEventPublisher;
 import dev.nokee.model.internal.DomainObjectEventPublisherImpl;
 import dev.nokee.model.internal.RealizableDomainObjectRealizer;
 import dev.nokee.model.internal.RealizableDomainObjectRealizerImpl;
-import dev.nokee.model.internal.core.ModelPropertyRegistrationFactory;
+import dev.nokee.model.internal.core.*;
 import dev.nokee.model.internal.registry.DefaultModelRegistry;
 import dev.nokee.model.internal.registry.ModelConfigurer;
 import dev.nokee.model.internal.registry.ModelLookup;
 import dev.nokee.model.internal.registry.ModelRegistry;
+import dev.nokee.model.internal.tasks.ModelReportTask;
+import dev.nokee.utils.TaskUtils;
 import lombok.val;
+import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.internal.logging.text.TreeFormatter;
 
 public class ModelBasePlugin implements Plugin<Project> {
 	@Override
@@ -42,5 +47,7 @@ public class ModelBasePlugin implements Plugin<Project> {
 		project.getExtensions().add(ModelLookup.class, "__NOKEE_modelLookup", modelRegistry);
 		project.getExtensions().add(ModelConfigurer.class, "__NOKEE_modelConfigurer", modelRegistry);
 		project.getExtensions().add(ModelPropertyRegistrationFactory.class, "__NOKEE_modelPropertyRegistrationFactory", new ModelPropertyRegistrationFactory(modelRegistry));
+
+		project.getTasks().register("nokeeModel", ModelReportTask.class, TaskUtils.configureDescription("Displays the configuration model of %s.", project));
 	}
 }

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/tasks/ModelReportTask.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/tasks/ModelReportTask.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.tasks;
+
+import dev.nokee.model.internal.core.*;
+import dev.nokee.model.internal.registry.ModelLookup;
+import lombok.val;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.internal.logging.text.TreeFormatter;
+
+public class ModelReportTask extends DefaultTask {
+	@TaskAction
+	private void doReport() {
+		val lookup = getProject().getExtensions().getByType(ModelLookup.class);
+		val rootNode = lookup.get(ModelPath.root());
+		TreeFormatter formatter = new TreeFormatter();
+		printNode(formatter, rootNode);
+		System.out.println(formatter.toString());
+	}
+
+	private void printNode(TreeFormatter formatter, ModelNode node) {
+		val path = ModelNodeUtils.getPath(node);
+		if (path.getName().isEmpty()) {
+			formatter.node("<root>");
+		} else {
+			formatter.node(path.getName());
+		}
+		val childNodes = node.getComponent(ModelComponentType.componentOf(DescendantNodes.class)).getDirectDescendants();
+		if (!childNodes.isEmpty()) {
+			formatter.startChildren();
+			for (ModelNode childNode : childNodes) {
+				printNode(formatter, childNode);
+			}
+			formatter.endChildren();
+		}
+	}
+}


### PR DESCRIPTION
Ultimately, the report task will show all entities, properties and
configuration actions. For now, we just print a layout of the entities
and properties as we don't have a way to differentiate them.