### PR TITLE
Introduce custom implementation type for each component

### DIFF
--- a/subprojects/platform-c/src/main/java/dev/nokee/platform/c/internal/plugins/CApplicationPlugin.java
+++ b/subprojects/platform-c/src/main/java/dev/nokee/platform/c/internal/plugins/CApplicationPlugin.java
@@ -76,7 +76,7 @@ public class CApplicationPlugin implements Plugin<Project> {
 	}
 
 	public static NodeRegistration cApplication(String name, Project project) {
-		return new NativeApplicationComponentModelRegistrationFactory(CApplication.class, project, (entity, path) -> {
+		return new NativeApplicationComponentModelRegistrationFactory(CApplication.class, DefaultCApplication.class, project, (entity, path) -> {
 			val registry = project.getExtensions().getByType(ModelRegistry.class);
 
 			// TODO: Should be created using CSourceSetSpec
@@ -97,5 +97,8 @@ public class CApplicationPlugin implements Plugin<Project> {
 
 			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(path.child("sources"), CApplicationSources.class));
 		}).create(name);
+	}
+
+	public static abstract class DefaultCApplication implements CApplication {
 	}
 }

--- a/subprojects/platform-c/src/main/java/dev/nokee/platform/c/internal/plugins/CLibraryPlugin.java
+++ b/subprojects/platform-c/src/main/java/dev/nokee/platform/c/internal/plugins/CLibraryPlugin.java
@@ -73,7 +73,7 @@ public class CLibraryPlugin implements Plugin<Project> {
 	}
 
 	public static NodeRegistration cLibrary(String name, Project project) {
-		return new NativeLibraryComponentModelRegistrationFactory(CLibrary.class, project, (entity, path) -> {
+		return new NativeLibraryComponentModelRegistrationFactory(CLibrary.class, DefaultCLibrary.class, project, (entity, path) -> {
 			val registry = project.getExtensions().getByType(ModelRegistry.class);
 
 			// TODO: Should be created using CSourceSetSpec
@@ -102,5 +102,8 @@ public class CLibraryPlugin implements Plugin<Project> {
 
 			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(path.child("sources"), CLibrarySources.class));
 		}).create(name);
+	}
+
+	public static abstract class DefaultCLibrary implements CLibrary {
 	}
 }

--- a/subprojects/platform-cpp/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppApplicationPlugin.java
+++ b/subprojects/platform-cpp/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppApplicationPlugin.java
@@ -75,7 +75,7 @@ public class CppApplicationPlugin implements Plugin<Project> {
 	}
 
 	public static NodeRegistration cppApplication(String name, Project project) {
-		return new NativeApplicationComponentModelRegistrationFactory(CppApplication.class, project, (entity, path) -> {
+		return new NativeApplicationComponentModelRegistrationFactory(CppApplication.class, DefaultCppApplication.class, project, (entity, path) -> {
 			val registry = project.getExtensions().getByType(ModelRegistry.class);
 
 			// TODO: Should be created using CppSourceSetSpec
@@ -96,5 +96,8 @@ public class CppApplicationPlugin implements Plugin<Project> {
 
 			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(path.child("sources"), CppApplicationSources.class));
 		}).create(name);
+	}
+
+	public static abstract class DefaultCppApplication implements CppApplication {
 	}
 }

--- a/subprojects/platform-cpp/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppLibraryPlugin.java
+++ b/subprojects/platform-cpp/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppLibraryPlugin.java
@@ -73,7 +73,7 @@ public class CppLibraryPlugin implements Plugin<Project> {
 	}
 
 	public static NodeRegistration cppLibrary(String name, Project project) {
-		return new NativeLibraryComponentModelRegistrationFactory(CppLibrary.class, project, (entity, path) -> {
+		return new NativeLibraryComponentModelRegistrationFactory(CppLibrary.class, DefaultCppLibrary.class, project, (entity, path) -> {
 			val registry = project.getExtensions().getByType(ModelRegistry.class);
 
 			// TODO: Should be created using CppSourceSetSpec
@@ -102,5 +102,8 @@ public class CppLibraryPlugin implements Plugin<Project> {
 
 			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(path.child("sources"), CppLibrarySources.class));
 		}).create(name);
+	}
+
+	public static abstract class DefaultCppLibrary implements CppLibrary {
 	}
 }

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/IosApplicationComponentModelRegistrationFactory.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/IosApplicationComponentModelRegistrationFactory.java
@@ -72,18 +72,20 @@ import static dev.nokee.platform.base.internal.LanguageSourceSetConventionSuppli
 import static org.gradle.language.base.plugins.LifecycleBasePlugin.ASSEMBLE_TASK_NAME;
 
 public final class IosApplicationComponentModelRegistrationFactory {
-	private final Class<? extends Component> componentType;
+	private final Class<Component> componentType;
+	private final Class<? extends Component> implementationComponentType;
 	private final BiConsumer<? super ModelNode, ? super ModelPath> sourceRegistration;
 	private final Project project;
 
-	public IosApplicationComponentModelRegistrationFactory(Class<? extends Component> componentType, Project project, BiConsumer<? super ModelNode, ? super ModelPath> sourceRegistration) {
-		this.componentType = componentType;
+	public <T extends Component> IosApplicationComponentModelRegistrationFactory(Class<? super T> componentType, Class<T> implementationComponentType, Project project, BiConsumer<? super ModelNode, ? super ModelPath> sourceRegistration) {
+		this.componentType = (Class<Component>) componentType;
+		this.implementationComponentType = implementationComponentType;
 		this.sourceRegistration = sourceRegistration;
 		this.project = project;
 	}
 
 	public NodeRegistration create(String name) {
-		return NodeRegistration.of(name, of(componentType))
+		return NodeRegistration.unmanaged(name, of(componentType), () -> project.getObjects().newInstance(implementationComponentType))
 			.action(allDirectDescendants(mutate(of(LanguageSourceSet.class)))
 				.apply(executeUsingProjection(of(LanguageSourceSet.class), withConventionOf(maven(ComponentName.of(name)))::accept)))
 			.withComponent(IsComponent.tag())

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/ObjectiveCIosApplicationPlugin.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/ObjectiveCIosApplicationPlugin.java
@@ -105,7 +105,7 @@ public class ObjectiveCIosApplicationPlugin implements Plugin<Project> {
 	}
 
 	public static NodeRegistration objectiveCIosApplication(String name, Project project) {
-		return new IosApplicationComponentModelRegistrationFactory(ObjectiveCIosApplication.class, project, (entity, path) -> {
+		return new IosApplicationComponentModelRegistrationFactory(ObjectiveCIosApplication.class, DefaultObjectiveCIosApplication.class, project, (entity, path) -> {
 			val registry = project.getExtensions().getByType(ModelRegistry.class);
 
 			// TODO: Should be created using CSourceSetSpec
@@ -138,5 +138,8 @@ public class ObjectiveCIosApplicationPlugin implements Plugin<Project> {
 			.action(allDirectDescendants(mutate(of(ObjectiveCSourceSet.class)))
 				.apply(executeUsingProjection(of(ObjectiveCSourceSet.class), withConventionOf(maven(ComponentName.of(name)), defaultObjectiveCGradle(ComponentName.of(name)))::accept)))
 			;
+	}
+
+	public static abstract class DefaultObjectiveCIosApplication implements ObjectiveCIosApplication {
 	}
 }

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/SwiftIosApplicationPlugin.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/SwiftIosApplicationPlugin.java
@@ -72,7 +72,7 @@ public class SwiftIosApplicationPlugin implements Plugin<Project> {
 	}
 
 	public static NodeRegistration swiftIosApplication(String name, Project project) {
-		return new IosApplicationComponentModelRegistrationFactory(SwiftIosApplication.class, project, (entity, path) -> {
+		return new IosApplicationComponentModelRegistrationFactory(SwiftIosApplication.class, DefaultSwiftIosApplication.class, project, (entity, path) -> {
 			val registry = project.getExtensions().getByType(ModelRegistry.class);
 
 			// TODO: Should be created using SwiftSourceSetSpec
@@ -93,5 +93,8 @@ public class SwiftIosApplicationPlugin implements Plugin<Project> {
 
 			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(path.child("sources"), SwiftIosApplicationSources.class));
 		}).create(name);
+	}
+
+	public static abstract class DefaultSwiftIosApplication implements SwiftIosApplication {
 	}
 }

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/plugins/JniLibraryPlugin.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/plugins/JniLibraryPlugin.java
@@ -515,7 +515,7 @@ public class JniLibraryPlugin implements Plugin<Project> {
 	public static NodeRegistration javaNativeInterfaceLibrary(String name, Project project) {
 		val identifier = ComponentIdentifier.of(ComponentName.of(name), JniLibraryComponentInternal.class, ProjectIdentifier.of(project));
 		assert identifier.isMainComponent();
-		return NodeRegistration.of(name, of(JavaNativeInterfaceLibrary.class))
+		return NodeRegistration.unmanaged(name, of(JavaNativeInterfaceLibrary.class), () -> project.getObjects().newInstance(DefaultJavaNativeInterfaceLibrary.class))
 			.action(allDirectDescendants(mutate(of(LanguageSourceSet.class))).apply(executeUsingProjection(of(LanguageSourceSet.class), withConventionOf(maven(ComponentName.of(name)))::accept)))
 			.withComponent(IsComponent.tag())
 			.withComponent(createdUsing(of(JavaNativeInterfaceComponentVariants.class), () -> {
@@ -598,6 +598,9 @@ public class JniLibraryPlugin implements Plugin<Project> {
 			.action(allDirectDescendants(mutate(of(ObjectiveCppSourceSet.class)))
 				.apply(executeUsingProjection(of(ObjectiveCppSourceSet.class), withConventionOf(maven(ComponentName.of(name)), defaultObjectiveCppGradle(ComponentName.of(name)))::accept)))
 			;
+	}
+
+	public static abstract class DefaultJavaNativeInterfaceLibrary implements JavaNativeInterfaceLibrary {
 	}
 
 	private static boolean isGradleVersionGreaterOrEqualsTo6Dot3() {

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/NativeApplicationComponentModelRegistrationFactory.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/NativeApplicationComponentModelRegistrationFactory.java
@@ -54,18 +54,20 @@ import static dev.nokee.platform.nativebase.internal.plugins.NativeApplicationPl
 import static dev.nokee.platform.nativebase.internal.plugins.NativeComponentBasePlugin.nativeApplicationProjection;
 
 public final class NativeApplicationComponentModelRegistrationFactory {
-	private final Class<? extends Component> componentType;
+	private final Class<Component> componentType;
+	private final Class<? extends Component> implementationComponentType;
 	private final BiConsumer<? super ModelNode, ? super ModelPath> sourceRegistration;
 	private final Project project;
 
-	public NativeApplicationComponentModelRegistrationFactory(Class<? extends Component> componentType, Project project, BiConsumer<? super ModelNode, ? super ModelPath> sourceRegistration) {
-		this.componentType = componentType;
+	public <T extends Component> NativeApplicationComponentModelRegistrationFactory(Class<? super T> componentType, Class<T> implementationComponentType, Project project, BiConsumer<? super ModelNode, ? super ModelPath> sourceRegistration) {
+		this.componentType = (Class<Component>) componentType;
+		this.implementationComponentType = implementationComponentType;
 		this.sourceRegistration = sourceRegistration;
 		this.project = project;
 	}
 
 	public NodeRegistration create(String name) {
-		return NodeRegistration.of(name, of(componentType))
+		return NodeRegistration.unmanaged(name, of(componentType), () -> project.getObjects().newInstance(implementationComponentType))
 			// TODO: Should configure FileCollection on CApplication
 			//   and link FileCollection to source sets
 			.action(allDirectDescendants(mutate(of(LanguageSourceSet.class)))

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/NativeLibraryComponentModelRegistrationFactory.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/NativeLibraryComponentModelRegistrationFactory.java
@@ -66,18 +66,20 @@ import static dev.nokee.platform.nativebase.internal.plugins.NativeLibraryPlugin
 import static dev.nokee.utils.TransformerUtils.transformEach;
 
 public final class NativeLibraryComponentModelRegistrationFactory {
-	private final Class<? extends Component> componentType;
+	private final Class<Component> componentType;
+	private final Class<? extends Component> implementationComponentType;
 	private final BiConsumer<? super ModelNode, ? super ModelPath> sourceRegistration;
 	private final Project project;
 
-	public NativeLibraryComponentModelRegistrationFactory(Class<? extends Component> componentType, Project project, BiConsumer<? super ModelNode, ? super ModelPath> sourceRegistration) {
-		this.componentType = componentType;
+	public <T extends Component> NativeLibraryComponentModelRegistrationFactory(Class<? super T> componentType, Class<T> implementationComponentType, Project project, BiConsumer<? super ModelNode, ? super ModelPath> sourceRegistration) {
+		this.componentType = (Class<Component>) componentType;
+		this.implementationComponentType = implementationComponentType;
 		this.sourceRegistration = sourceRegistration;
 		this.project = project;
 	}
 
 	public NodeRegistration create(String name) {
-		return NodeRegistration.of(name, of(componentType))
+		return NodeRegistration.unmanaged(name, of(componentType), () -> project.getObjects().newInstance(implementationComponentType))
 			// TODO: Should configure FileCollection on CApplication
 			//   and link FileCollection to source sets
 			.action(allDirectDescendants(mutate(of(LanguageSourceSet.class)))

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeApplicationPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeApplicationPlugin.java
@@ -104,7 +104,7 @@ public class NativeApplicationPlugin implements Plugin<Project> {
 	}
 
 	public static NodeRegistration nativeApplication(String name, Project project) {
-		return new NativeApplicationComponentModelRegistrationFactory(NativeApplicationExtension.class, project, (entity, path) -> {
+		return new NativeApplicationComponentModelRegistrationFactory(NativeApplicationExtension.class, DefaultNativeApplicationExtension.class, project, (entity, path) -> {
 			val registry = project.getExtensions().getByType(ModelRegistry.class);
 
 			// TODO: Should be created using CHeaderSetSpec
@@ -236,6 +236,9 @@ public class NativeApplicationPlugin implements Plugin<Project> {
 				}));
 			})))
 			;
+	}
+
+	public static abstract class DefaultNativeApplicationExtension implements NativeApplicationExtension {
 	}
 
 	private static void whenElementKnown(Object target, ModelAction action) {

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeLibraryPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeLibraryPlugin.java
@@ -107,7 +107,7 @@ public class NativeLibraryPlugin implements Plugin<Project> {
 	}
 
 	public static NodeRegistration nativeLibrary(String name, Project project) {
-		return new NativeLibraryComponentModelRegistrationFactory(NativeLibraryExtension.class, project, (entity, path) -> {
+		return new NativeLibraryComponentModelRegistrationFactory(NativeLibraryExtension.class, DefaultNativeLibraryExtension.class, project, (entity, path) -> {
 			val registry = project.getExtensions().getByType(ModelRegistry.class);
 
 			// TODO: Should be created using CHeaderSetSpec
@@ -128,6 +128,9 @@ public class NativeLibraryPlugin implements Plugin<Project> {
 
 			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(path.child("sources"), NativeLibrarySources.class));
 		}).create(name);
+	}
+
+	public static abstract class DefaultNativeLibraryExtension implements NativeLibraryExtension {
 	}
 
 	public static NodeRegistration nativeLibraryVariant(VariantIdentifier<DefaultNativeLibraryVariant> identifier, DefaultNativeLibraryComponent component, Project project) {

--- a/subprojects/platform-objective-c/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCApplicationPlugin.java
+++ b/subprojects/platform-objective-c/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCApplicationPlugin.java
@@ -80,7 +80,7 @@ public class ObjectiveCApplicationPlugin implements Plugin<Project> {
 	}
 
 	public static NodeRegistration objectiveCApplication(String name, Project project) {
-		return new NativeApplicationComponentModelRegistrationFactory(ObjectiveCApplication.class, project, (entity, path) -> {
+		return new NativeApplicationComponentModelRegistrationFactory(ObjectiveCApplication.class, DefaultObjectiveCApplication.class, project, (entity, path) -> {
 			val registry = project.getExtensions().getByType(ModelRegistry.class);
 
 			// TODO: Should be created using ObjectiveCSourceSetSpec
@@ -102,5 +102,8 @@ public class ObjectiveCApplicationPlugin implements Plugin<Project> {
 			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(path.child("sources"), ObjectiveCApplicationSources.class));
 		}).create(name).action(allDirectDescendants(mutate(of(ObjectiveCSourceSet.class)))
 			.apply(executeUsingProjection(of(ObjectiveCSourceSet.class), withConventionOf(maven(ComponentName.of(name)), defaultObjectiveCGradle(ComponentName.of(name)))::accept)));
+	}
+
+	public static abstract class DefaultObjectiveCApplication implements ObjectiveCApplication {
 	}
 }

--- a/subprojects/platform-objective-c/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCLibraryPlugin.java
+++ b/subprojects/platform-objective-c/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCLibraryPlugin.java
@@ -78,7 +78,7 @@ public class ObjectiveCLibraryPlugin implements Plugin<Project> {
 	}
 
 	public static NodeRegistration objectiveCLibrary(String name, Project project) {
-		return new NativeLibraryComponentModelRegistrationFactory(ObjectiveCLibrary.class, project, (entity, path) -> {
+		return new NativeLibraryComponentModelRegistrationFactory(ObjectiveCLibrary.class, DefaultObjectiveCLibrary.class, project, (entity, path) -> {
 			val registry = project.getExtensions().getByType(ModelRegistry.class);
 
 			// TODO: Should be created using ObjectiveCSourceSetSpec
@@ -108,5 +108,8 @@ public class ObjectiveCLibraryPlugin implements Plugin<Project> {
 			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(path.child("sources"), ObjectiveCLibrarySources.class));
 		}).create(name).action(allDirectDescendants(mutate(of(ObjectiveCSourceSet.class)))
 			.apply(executeUsingProjection(of(ObjectiveCSourceSet.class), withConventionOf(maven(ComponentName.of(name)), defaultObjectiveCGradle(ComponentName.of(name)))::accept)));
+	}
+
+	public static abstract class DefaultObjectiveCLibrary implements ObjectiveCLibrary {
 	}
 }

--- a/subprojects/platform-objective-cpp/src/main/java/dev/nokee/platform/objectivecpp/internal/plugins/ObjectiveCppApplicationPlugin.java
+++ b/subprojects/platform-objective-cpp/src/main/java/dev/nokee/platform/objectivecpp/internal/plugins/ObjectiveCppApplicationPlugin.java
@@ -80,7 +80,7 @@ public class ObjectiveCppApplicationPlugin implements Plugin<Project> {
 	}
 
 	public static NodeRegistration objectiveCppApplication(String name, Project project) {
-		return new NativeApplicationComponentModelRegistrationFactory(ObjectiveCppApplication.class, project, (entity, path) -> {
+		return new NativeApplicationComponentModelRegistrationFactory(ObjectiveCppApplication.class, DefaultObjectiveCppApplication.class, project, (entity, path) -> {
 			val registry = project.getExtensions().getByType(ModelRegistry.class);
 
 			// TODO: Should be created using ObjectiveCppSourceSetSpec
@@ -102,5 +102,8 @@ public class ObjectiveCppApplicationPlugin implements Plugin<Project> {
 			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(path.child("sources"), ObjectiveCppApplicationSources.class));
 		}).create(name).action(allDirectDescendants(mutate(of(ObjectiveCppSourceSet.class)))
 			.apply(executeUsingProjection(of(ObjectiveCppSourceSet.class), withConventionOf(maven(ComponentName.of(name)), defaultObjectiveCppGradle(ComponentName.of(name)))::accept)));
+	}
+
+	public static abstract class DefaultObjectiveCppApplication implements ObjectiveCppApplication {
 	}
 }

--- a/subprojects/platform-objective-cpp/src/main/java/dev/nokee/platform/objectivecpp/internal/plugins/ObjectiveCppLibraryPlugin.java
+++ b/subprojects/platform-objective-cpp/src/main/java/dev/nokee/platform/objectivecpp/internal/plugins/ObjectiveCppLibraryPlugin.java
@@ -78,7 +78,7 @@ public class ObjectiveCppLibraryPlugin implements Plugin<Project> {
 	}
 
 	public static NodeRegistration objectiveCppLibrary(String name, Project project) {
-		return new NativeLibraryComponentModelRegistrationFactory(ObjectiveCppLibrary.class, project, (entity, path) -> {
+		return new NativeLibraryComponentModelRegistrationFactory(ObjectiveCppLibrary.class, DefaultObjectiveCppLibrary.class, project, (entity, path) -> {
 			val registry = project.getExtensions().getByType(ModelRegistry.class);
 
 			// TODO: Should be created using ObjectiveCppSourceSetSpec
@@ -108,5 +108,8 @@ public class ObjectiveCppLibraryPlugin implements Plugin<Project> {
 			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(path.child("sources"), ObjectiveCppLibrarySources.class));
 		}).create(name).action(allDirectDescendants(mutate(of(ObjectiveCppSourceSet.class)))
 			.apply(executeUsingProjection(of(ObjectiveCppSourceSet.class), withConventionOf(maven(ComponentName.of(name)), defaultObjectiveCppGradle(ComponentName.of(name)))::accept)));
+	}
+
+	public static abstract class DefaultObjectiveCppLibrary implements ObjectiveCppLibrary {
 	}
 }

--- a/subprojects/platform-swift/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftApplicationPlugin.java
+++ b/subprojects/platform-swift/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftApplicationPlugin.java
@@ -75,7 +75,7 @@ public class SwiftApplicationPlugin implements Plugin<Project> {
 	}
 
 	public static NodeRegistration swiftApplication(String name, Project project) {
-		return new NativeApplicationComponentModelRegistrationFactory(SwiftApplication.class, project, (entity, path) -> {
+		return new NativeApplicationComponentModelRegistrationFactory(SwiftApplication.class, DefaultSwiftApplication.class, project, (entity, path) -> {
 			val registry = project.getExtensions().getByType(ModelRegistry.class);
 
 			// TODO: Should be created using SwiftSourceSetSpec
@@ -88,5 +88,8 @@ public class SwiftApplicationPlugin implements Plugin<Project> {
 
 			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(path.child("sources"), SwiftApplicationSources.class));
 		}).create(name);
+	}
+
+	public static abstract class DefaultSwiftApplication implements SwiftApplication {
 	}
 }

--- a/subprojects/platform-swift/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftLibraryPlugin.java
+++ b/subprojects/platform-swift/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftLibraryPlugin.java
@@ -73,7 +73,7 @@ public class SwiftLibraryPlugin implements Plugin<Project> {
 	}
 
 	public static NodeRegistration swiftLibrary(String name, Project project) {
-		return new NativeLibraryComponentModelRegistrationFactory(SwiftLibrary.class, project, (entity, path) -> {
+		return new NativeLibraryComponentModelRegistrationFactory(SwiftLibrary.class, DefaultSwiftLibrary.class, project, (entity, path) -> {
 			val registry = project.getExtensions().getByType(ModelRegistry.class);
 
 			// TODO: Should be created using SwiftSourceSetSpec
@@ -86,5 +86,8 @@ public class SwiftLibraryPlugin implements Plugin<Project> {
 
 			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(path.child("sources"), SwiftLibrarySources.class));
 		}).create(name);
+	}
+
+	public static abstract class DefaultSwiftLibrary implements SwiftLibrary {
 	}
 }


### PR DESCRIPTION
Our previous approach was to save some typing and mixin the model with
the domain object implementation. It does not separate the concern
properly. Instead, we will now aim at generating the implementation to
save typing instead.