### PR TITLE
Introduce registry adapter for containers

### DIFF
--- a/subprojects/core-model/src/main/java/dev/nokee/model/NamedDomainObjectContainerRegistryAdapter.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/NamedDomainObjectContainerRegistryAdapter.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model;
+
+import dev.nokee.utils.NamedDomainObjectCollectionUtils;
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.NamedDomainObjectProvider;
+
+import java.util.Objects;
+
+import static dev.nokee.model.SupportedTypes.instanceOf;
+import static dev.nokee.utils.NamedDomainObjectCollectionUtils.getElementType;
+
+final class NamedDomainObjectContainerRegistryAdapter<T> implements NamedDomainObjectRegistry<T> {
+	public static <T> NamedDomainObjectContainerRegistryAdapter<T> newRegistry(NamedDomainObjectContainer<T> container) {
+		return new NamedDomainObjectContainerRegistryAdapter<>(container);
+	}
+
+	private final RegistrableType registrableType;
+	private final NamedDomainObjectContainer<T> container;
+
+	private NamedDomainObjectContainerRegistryAdapter(NamedDomainObjectContainer<T> container) {
+		this.container = container;
+		this.registrableType = new DefaultRegistrableType(getElementType(container));
+	}
+
+	@Override
+	public NamedDomainObjectProvider<T> register(String name) {
+		return container.register(name);
+	}
+
+	@Override
+	public NamedDomainObjectProvider<T> registerIfAbsent(String name) {
+		return NamedDomainObjectCollectionUtils.registerIfAbsent(container, name);
+	}
+
+	@Override
+	public RegistrableType getRegistrableType() {
+		return registrableType;
+	}
+
+	@Override
+	public String toString() {
+		return container + " registry";
+	}
+
+	private static final class DefaultRegistrableType implements RegistrableType {
+		private final SupportedType registrableType;
+
+		private DefaultRegistrableType(Class<?> containerType) {
+			this.registrableType = instanceOf(containerType);
+		}
+
+		@Override
+		public boolean canRegisterType(Class<?> type) {
+			Objects.requireNonNull(type);
+			return registrableType.supports(type);
+		}
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/NamedDomainObjectRegistry.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/NamedDomainObjectRegistry.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model;
+
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.NamedDomainObjectProvider;
+import org.gradle.api.provider.Provider;
+
+public interface NamedDomainObjectRegistry<T> {
+	/**
+	 * Creates a registry for the specified container.
+	 *
+	 * @param container  a named domain object container, must not be null
+	 * @param <T>  the type of objects to register
+	 * @return a registry adapter for the specified container, never null
+	 */
+	static <T> NamedDomainObjectRegistry<T> of(NamedDomainObjectContainer<T> container) {
+		return NamedDomainObjectContainerRegistryAdapter.newRegistry(container);
+	}
+
+	/**
+	 * Defines a new object, which will be created when it is required.
+	 * An object is 'required' when the object is located using query methods or when {@link Provider#get()} is called on the return value of this method.
+	 *
+	 * @param name  the name of the object, must not be null
+	 * @return a {@link Provider} that whose value will be the object, when queried, never null
+	 * @throws InvalidUserDataException If a object with the given name already exists in this project.
+	 */
+	NamedDomainObjectProvider<T> register(String name) throws InvalidUserDataException;
+
+	/**
+	 * Defines a new object, which will be created when it is required, only if an object with the same name does not already exist.
+	 * An object is 'required' when the object is located using query methods or when {@link Provider#get()} is called on the return value of this method.
+	 * If the object already exist, the same provider will be returned.
+	 *
+	 * @param name  the name of the object, must not be null
+	 * @return a {@link Provider} that whose value will be the object, when queried, never null
+	 */
+	NamedDomainObjectProvider<T> registerIfAbsent(String name);
+
+	/**
+	 * Returns the registrable type for this registry.
+	 *
+	 * @return registrable types of this registry, never null
+	 */
+	RegistrableType getRegistrableType();
+
+	/**
+	 * Represent the registrable type for the registry.
+	 */
+	interface RegistrableType {
+		/**
+		 * Returns {@literal true} if the specified type is registrable.
+		 *
+		 * @param type  the type to check against registry, must not be null
+		 * @return {@code true} if the specified type is registrable or {@code false} otherwise
+		 */
+		boolean canRegisterType(Class<?> type);
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/PolymorphicDomainObjectContainerRegistryAdapter.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/PolymorphicDomainObjectContainerRegistryAdapter.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model;
+
+import dev.nokee.utils.NamedDomainObjectCollectionUtils;
+import org.gradle.api.NamedDomainObjectProvider;
+import org.gradle.api.PolymorphicDomainObjectContainer;
+import org.gradle.api.Task;
+import org.gradle.api.internal.PolymorphicDomainObjectContainerInternal;
+import org.gradle.api.tasks.TaskContainer;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Stream;
+
+final class PolymorphicDomainObjectContainerRegistryAdapter<T> implements PolymorphicDomainObjectRegistry<T> {
+	public static <T> PolymorphicDomainObjectContainerRegistryAdapter<T> newRegistry(PolymorphicDomainObjectContainer<T> container) {
+		if (container instanceof TaskContainer) {
+			return new PolymorphicDomainObjectContainerRegistryAdapter<>(container, new TaskContainerRegistrableTypes());
+		} else {
+			return new PolymorphicDomainObjectContainerRegistryAdapter<>(container, new DefaultRegistrableTypes((PolymorphicDomainObjectContainerInternal<?>) container));
+		}
+	}
+
+	private final PolymorphicDomainObjectContainer<T> container;
+	private final RegistrableTypes registrableTypes;
+
+	private PolymorphicDomainObjectContainerRegistryAdapter(PolymorphicDomainObjectContainer<T> container, RegistrableTypes registrableTypes) {
+		this.container = container;
+		this.registrableTypes = registrableTypes;
+	}
+
+	@Override
+	public <S extends T> NamedDomainObjectProvider<S> register(String name, Class<S> type) {
+		Objects.requireNonNull(name);
+		Objects.requireNonNull(type);
+		return container.register(name, type);
+	}
+
+	@Override
+	public <S extends T> NamedDomainObjectProvider<S> registerIfAbsent(String name, Class<S> type) {
+		Objects.requireNonNull(name);
+		Objects.requireNonNull(type);
+		return NamedDomainObjectCollectionUtils.registerIfAbsent(container, name, type);
+	}
+
+	@Override
+	public RegistrableTypes getRegistrableTypes() {
+		return registrableTypes;
+	}
+
+	@Override
+	public String toString() {
+		return container + " registry";
+	}
+
+	private static final class DefaultRegistrableTypes implements RegistrableTypes {
+		private final PolymorphicDomainObjectContainerInternal<?> container;
+
+		private DefaultRegistrableTypes(PolymorphicDomainObjectContainerInternal<?> container) {
+			this.container = container;
+		}
+
+		@Override
+		public boolean canRegisterType(Class<?> type) {
+			Objects.requireNonNull(type);
+			return getSupportedTypes().anyMatch(it -> it.supports(type));
+		}
+
+		private Stream<SupportedType> getSupportedTypes() {
+			return getCreatableType().stream().map(SupportedTypes::instanceOf);
+		}
+
+		private Set<? extends Class<?>> getCreatableType() {
+			return container.getCreateableTypes();
+		}
+	}
+
+	private static final class TaskContainerRegistrableTypes implements RegistrableTypes {
+		private final SupportedType registrableTypes = SupportedTypes.anySubtypeOf(Task.class);
+
+		@Override
+		public boolean canRegisterType(Class<?> type) {
+			Objects.requireNonNull(type);
+			return registrableTypes.supports(type);
+		}
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/PolymorphicDomainObjectRegistry.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/PolymorphicDomainObjectRegistry.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model;
+
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.NamedDomainObjectProvider;
+import org.gradle.api.PolymorphicDomainObjectContainer;
+import org.gradle.api.provider.Provider;
+
+public interface PolymorphicDomainObjectRegistry<T> {
+	/**
+	 * Creates a registry for the specified container.
+	 *
+	 * @param container  a named domain object container, must not be null
+	 * @param <T>  the type of objects to register
+	 * @return a registry adapter for the specified container, never null
+	 */
+	static <T> PolymorphicDomainObjectRegistry<T> of(PolymorphicDomainObjectContainer<T> container) {
+		return PolymorphicDomainObjectContainerRegistryAdapter.newRegistry(container);
+	}
+
+	/**
+	 * Defines a new object, which will be created when it is required.
+	 * An object is 'required' when the object is located using query methods or when {@link Provider#get()} is called on the return value of this method.
+	 *
+	 * @param name  the name of the object, must not be null
+	 * @param type  the object type, must not be null
+	 * @return a {@link Provider} that whose value will be the object, when queried, never null
+	 * @throws InvalidUserDataException If a object with the given name already exists in this project.
+	 */
+	<S extends T> NamedDomainObjectProvider<S> register(String name, Class<S> type) throws InvalidUserDataException;
+
+	/**
+	 * Defines a new object, which will be created when it is required, only if an object with the same name does not already exist.
+	 * An object is 'required' when the object is located using query methods or when {@link Provider#get()} is called on the return value of this method.
+	 * If the object already exist, the same provider will be returned.
+	 *
+	 * @param name  the name of the object, must not be null
+	 * @param type  the object type, must not be null
+	 * @return a {@link Provider} that whose value will be the object, when queried, never null
+	 */
+	<S extends T> NamedDomainObjectProvider<S> registerIfAbsent(String name, Class<S> type);
+
+	/**
+	 * Returns the registrable types known to this registry.
+	 *
+	 * @return registrable types of this registry, never null
+	 */
+	RegistrableTypes getRegistrableTypes();
+
+	/**
+	 * Represent all registrable types for the registry.
+	 */
+	interface RegistrableTypes {
+		/**
+		 * Returns {@literal true} if the specified type is registrable.
+		 *
+		 * @param type  the type to check against registry, must not be null
+		 * @return {@code true} if the specified type is registrable or {@code false} otherwise
+		 */
+		boolean canRegisterType(Class<?> type);
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/SupportedType.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/SupportedType.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model;
+
+/**
+ * Describe a supported registrable type for the registry.
+ */
+interface SupportedType {
+	/**
+	 * Returns {@code true} if the specified type is supported.
+	 *
+	 * @param type  the type to check support, must not be null
+	 * @return {@code true} if the specified type is supported or {@code false} otherwise
+	 */
+	boolean supports(Class<?> type);
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/SupportedTypes.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/SupportedTypes.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model;
+
+import lombok.EqualsAndHashCode;
+
+final class SupportedTypes {
+	private SupportedTypes() {}
+
+	public static SupportedType instanceOf(Class<?> type) {
+		return new InstanceOfSupportedType(type);
+	}
+
+	@EqualsAndHashCode
+	private static final class InstanceOfSupportedType implements SupportedType {
+		private final Class<?> type;
+
+		private InstanceOfSupportedType(Class<?> type) {
+			this.type = type;
+		}
+
+		@Override
+		public boolean supports(Class<?> type) {
+			return this.type.equals(type);
+		}
+
+		@Override
+		public String toString() {
+			return type.getSimpleName();
+		}
+	}
+
+	public static SupportedType anySubtypeOf(Class<?> type) {
+		return new SubtypeOfSupportedType(type);
+	}
+
+	@EqualsAndHashCode
+	private static final class SubtypeOfSupportedType implements SupportedType {
+		private final Class<?> type;
+
+		private SubtypeOfSupportedType(Class<?> type) {
+			this.type = type;
+		}
+
+		@Override
+		public boolean supports(Class<?> type) {
+			return this.type.isAssignableFrom(type);
+		}
+
+		@Override
+		public String toString() {
+			return "subtypes of '" + type.getSimpleName() + "'";
+		}
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/AdhocNamedDomainObjectRegistryTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/AdhocNamedDomainObjectRegistryTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model;
+
+import lombok.EqualsAndHashCode;
+import lombok.val;
+import org.gradle.api.Named;
+import org.gradle.api.NamedDomainObjectProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasToString;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AdhocNamedDomainObjectRegistryTest implements NamedDomainObjectRegistryTester<AdhocNamedDomainObjectRegistryTest.MyType> {
+	private NamedDomainObjectRegistry<MyType> subject;
+	private NamedDomainObjectProvider<MyType> e0;
+	private NamedDomainObjectProvider<MyType> e1;
+	private NamedDomainObjectProvider<MyType> e2;
+
+	@BeforeEach
+	void setup() {
+		val container = objectFactory().domainObjectContainer(MyType.class, MyType::new);
+		System.out.println(container);
+		subject = NamedDomainObjectRegistry.of(container);
+		e0 = container.register("a");
+		e1 = container.register("b");
+		e2 = container.register("c");
+	}
+
+	@Override
+	public NamedDomainObjectRegistry<MyType> subject() {
+		return subject;
+	}
+
+	@Override
+	public NamedDomainObjectProvider<MyType> e0() {
+		return e0;
+	}
+
+	@Override
+	public NamedDomainObjectProvider<MyType> e1() {
+		return e1;
+	}
+
+	@Override
+	public NamedDomainObjectProvider<MyType> e2() {
+		return e2;
+	}
+
+	@Test
+	void checkToString() {
+		assertThat(subject, hasToString("MyType container registry"));
+	}
+
+	@Nested
+	class RegistrableTypesTest implements RegistrableTypeTester {
+		@Override
+		public NamedDomainObjectRegistry.RegistrableType subject() {
+			return subject.getRegistrableType();
+		}
+
+		@Test
+		void canRegisterContainerElementType() {
+			assertTrue(subject().canRegisterType(MyType.class));
+		}
+	}
+
+	@EqualsAndHashCode
+	public static final class MyType implements Named {
+		private final String name;
+
+		public MyType(String name) {
+			this.name = name;
+		}
+
+		@Override
+		public String getName() {
+			return name;
+		}
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/AdhocPolymorphicDomainObjetRegistryTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/AdhocPolymorphicDomainObjetRegistryTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model;
+
+import lombok.EqualsAndHashCode;
+import lombok.val;
+import org.gradle.api.Named;
+import org.gradle.api.NamedDomainObjectProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasToString;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AdhocPolymorphicDomainObjetRegistryTest implements PolymorphicDomainObjectRegistryTester<AdhocPolymorphicDomainObjetRegistryTest.MyType> {
+	private PolymorphicDomainObjectRegistry<MyType> subject;
+	private NamedDomainObjectProvider<MyType.A> e0;
+	private NamedDomainObjectProvider<MyType.B> e1;
+	private NamedDomainObjectProvider<MyType.C> e2;
+	private NamedDomainObjectProvider<MyType.D> e3;
+
+	@BeforeEach
+	void setup() {
+		val container = objectFactory().polymorphicDomainObjectContainer(MyType.class);
+		container.registerFactory(MyType.A.class, MyType.A::new);
+		container.registerFactory(MyType.B.class, MyType.B::new);
+		container.registerFactory(MyType.C.class, MyType.C::new);
+		container.registerFactory(MyType.D.class, MyType.D::new);
+
+		subject =  PolymorphicDomainObjectRegistry.of(container);
+		e0 = container.register("a", MyType.A.class);
+		e1 = container.register("b", MyType.B.class);
+		e2 = container.register("c", MyType.C.class);
+		e3 = container.register("d", MyType.D.class);
+	}
+
+	@Override
+	public PolymorphicDomainObjectRegistry<MyType> subject() {
+		return subject;
+	}
+
+	@Override
+	public NamedDomainObjectProvider<? extends MyType> e0() {
+		return e0;
+	}
+
+	@Override
+	public NamedDomainObjectProvider<? extends MyType> e1() {
+		return e1;
+	}
+
+	@Override
+	public NamedDomainObjectProvider<? extends MyType> e2() {
+		return e2;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <S extends MyType> NamedDomainObjectProvider<? extends S> e3() {
+		return (NamedDomainObjectProvider<? extends S>) e3;
+	}
+
+	@Test
+	void checkToString() {
+		assertThat(subject, hasToString("MyType container registry"));
+	}
+
+	@Nested
+	class RegistrableTypesTest implements RegistrableTypesTester {
+		@Override
+		public PolymorphicDomainObjectRegistry.RegistrableTypes subject() {
+			return subject.getRegistrableTypes();
+		}
+
+		@Test
+		void canRegisterAllTypeWithRegisteredFactory() {
+			assertTrue(subject().canRegisterType(MyType.A.class));
+			assertTrue(subject().canRegisterType(MyType.B.class));
+			assertTrue(subject().canRegisterType(MyType.C.class));
+			assertTrue(subject().canRegisterType(MyType.D.class));
+		}
+
+		@Test
+		void cannotRegisterTypesWithoutRegisteredFactory() {
+			assertFalse(subject().canRegisterType(MyType.class));
+		}
+	}
+
+	@EqualsAndHashCode
+	public static class MyType implements Named {
+		private final String name;
+
+		public MyType(String name) {
+			this.name = name;
+		}
+
+		@Override
+		public String getName() {
+			return name;
+		}
+
+		@EqualsAndHashCode(callSuper = true)
+		public static final class A extends MyType {
+			public A(String name) {
+				super(name);
+			}
+		}
+
+		@EqualsAndHashCode(callSuper = true)
+		public static final class B extends MyType {
+			public B(String name) {
+				super(name);
+			}
+		}
+
+		@EqualsAndHashCode(callSuper = true)
+		public static final class C extends MyType {
+			public C(String name) {
+				super(name);
+			}
+		}
+
+		@EqualsAndHashCode(callSuper = true)
+		public static final class D extends MyType {
+			public D(String name) {
+				super(name);
+			}
+		}
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/ConfigurationContainerRegistryTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/ConfigurationContainerRegistryTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model;
+
+import lombok.val;
+import org.gradle.api.NamedDomainObjectProvider;
+import org.gradle.api.artifacts.Configuration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.internal.testing.util.ProjectTestUtils.rootProject;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasToString;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ConfigurationContainerRegistryTest implements NamedDomainObjectRegistryTester<Configuration> {
+	private NamedDomainObjectRegistry<Configuration> subject;
+	private NamedDomainObjectProvider<Configuration> e0;
+	private NamedDomainObjectProvider<Configuration> e1;
+	private NamedDomainObjectProvider<Configuration> e2;
+
+	@BeforeEach
+	void setup() {
+		val container = rootProject().getConfigurations();
+		System.out.println(container);
+		subject = NamedDomainObjectRegistry.of(container);
+		e0 = container.register("a");
+		e1 = container.register("b");
+		e2 = container.register("c");
+	}
+
+	@Override
+	public NamedDomainObjectRegistry<Configuration> subject() {
+		return subject;
+	}
+
+	@Override
+	public NamedDomainObjectProvider<Configuration> e0() {
+		return e0;
+	}
+
+	@Override
+	public NamedDomainObjectProvider<Configuration> e1() {
+		return e1;
+	}
+
+	@Override
+	public NamedDomainObjectProvider<Configuration> e2() {
+		return e2;
+	}
+
+	@Test
+	void checkToString() {
+		assertThat(subject, hasToString("configuration container registry"));
+	}
+
+	@Nested
+	class RegistrableTypesTest implements RegistrableTypeTester {
+		@Override
+		public NamedDomainObjectRegistry.RegistrableType subject() {
+			return subject.getRegistrableType();
+		}
+
+		@Test
+		void canRegisterContainerElementType() {
+			assertTrue(subject().canRegisterType(Configuration.class));
+		}
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/NamedDomainObjectRegistryTester.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/NamedDomainObjectRegistryTester.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model;
+
+import com.google.common.collect.testing.WrongType;
+import com.google.common.testing.NullPointerTester;
+import dev.nokee.utils.ProviderUtils;
+import lombok.val;
+import org.gradle.api.NamedDomainObjectProvider;
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.internal.testing.GradleProviderMatchers.providerOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public interface NamedDomainObjectRegistryTester<T> {
+	NamedDomainObjectRegistry<T> subject();
+
+	NamedDomainObjectProvider<T> e0();
+
+	NamedDomainObjectProvider<T> e1();
+
+	NamedDomainObjectProvider<T> e2();
+
+	default Class<T> getType() {
+		return ProviderUtils.getType(e0())
+			.orElseThrow(() -> new RuntimeException("Please implements PolymorphicDomainObjectContainerRegistryTester#getType()."));
+	}
+
+	@Test
+	@SuppressWarnings("UnstableApiUsage")
+	default void checkNulls() {
+		new NullPointerTester().testAllPublicInstanceMethods(subject());
+	}
+
+	@Test
+	default void canRegisterWhenElementAbsent() {
+		val result = subject().register("nevu");
+		assertNotNull(result);
+		assertEquals("nevu", result.getName());
+		assertThat(result, providerOf(isA(getType())));
+	}
+
+	@Test
+	default void canRegisterIfAbsentWhenElementIsAbsent() {
+		val result = subject().registerIfAbsent("cera");
+		assertNotNull(result);
+		assertEquals("cera", result.getName());
+		assertThat(result, providerOf(isA(getType())));
+	}
+
+	@Test
+	default void throwsExceptionOnRegisterWhenElementPresent() {
+		assertThrows(RuntimeException.class, () -> subject().register(e0().getName()));
+	}
+
+	@Test
+	default void doesNotThrowExceptionOnRegisterIfAbsentWhenElementIsPresent() {
+		val result = assertDoesNotThrow(() -> subject().registerIfAbsent(e1().getName()));
+		assertNotNull(result);
+		assertEquals(e1().getName(), result.getName());
+		assertThat(result, providerOf(e1().get()));
+	}
+
+	@Test
+	default void hasRegistrableType() {
+		assertNotNull(subject().getRegistrableType());
+	}
+
+	interface RegistrableTypeTester {
+		NamedDomainObjectRegistry.RegistrableType subject();
+
+		@Test
+		default void throwsNullPointerExceptionIfRegisterTypeIsNull() {
+			assertThrows(NullPointerException.class, () -> subject().canRegisterType(null));
+		}
+
+		@Test
+		default void returnsFalseForNonRegistrableType() {
+			assertFalse(subject().canRegisterType(WrongType.class));
+		}
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/PolymorphicDomainObjectRegistryTester.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/PolymorphicDomainObjectRegistryTester.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model;
+
+import com.google.common.collect.testing.WrongType;
+import com.google.common.testing.NullPointerTester;
+import dev.nokee.utils.ProviderUtils;
+import lombok.val;
+import org.gradle.api.NamedDomainObjectProvider;
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.internal.testing.GradleProviderMatchers.providerOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isA;
+import static org.junit.jupiter.api.Assertions.*;
+
+public interface PolymorphicDomainObjectRegistryTester<T> {
+	PolymorphicDomainObjectRegistry<T> subject();
+
+	NamedDomainObjectProvider<? extends T> e0();
+
+	NamedDomainObjectProvider<? extends T> e1();
+
+	NamedDomainObjectProvider<? extends T> e2();
+
+	<S extends T> NamedDomainObjectProvider<? extends S> e3();
+
+	default Class<? extends T> getType() {
+		return ProviderUtils.getType(e0())
+			.orElseThrow(() -> new RuntimeException("Please implements PolymorphicDomainObjectContainerRegistryTester#getType()."));
+	}
+
+	@SuppressWarnings("unchecked")
+	default <S extends T> Class<? extends S> getOtherType() {
+		return (Class<? extends S>) ProviderUtils.getType(e3())
+			.orElseThrow(() -> new RuntimeException("Please implements PolymorphicDomainObjectContainerRegistryTester#getOtherType()."));
+	}
+
+	@Test
+	@SuppressWarnings("UnstableApiUsage")
+	default void checkNulls() {
+		new NullPointerTester().testAllPublicInstanceMethods(subject());
+	}
+
+	@Test
+	default void canRegisterWhenElementAbsent() {
+		val result = subject().register("faxo", getType());
+		assertNotNull(result);
+		assertEquals("faxo", result.getName());
+		assertThat(result, providerOf(isA(getType())));
+	}
+
+	@Test
+	default void canRegisterIfAbsentWhenElementIsAbsent() {
+		val result = subject().registerIfAbsent("qico", getOtherType());
+		assertNotNull(result);
+		assertEquals("qico", result.getName());
+		assertThat(result, providerOf(isA(getOtherType())));
+	}
+
+	@Test
+	default void throwsExceptionOnRegisterWhenElementPresent() {
+		assertThrows(RuntimeException.class, () -> subject().register(e0().getName(), getType()));
+	}
+
+	@Test
+	default void doesNotThrowExceptionOnRegisterIfAbsentWhenElementIsPresent() {
+		val result = assertDoesNotThrow(() -> subject().registerIfAbsent(e3().getName(), getOtherType()));
+		assertNotNull(result);
+		assertEquals(e3().getName(), result.getName());
+		assertThat(result, providerOf(e3().get()));
+	}
+
+	@Test
+	default void throwsExceptionWhenRegisteringTypeDoesNotMatchExistingElement() {
+		assertThrows(RuntimeException.class, () -> subject().registerIfAbsent(e3().getName(), getType()));
+	}
+
+	@Test
+	default void hasRegistrableTypes() {
+		assertNotNull(subject().getRegistrableTypes());
+	}
+
+	interface RegistrableTypesTester {
+		PolymorphicDomainObjectRegistry.RegistrableTypes subject();
+
+		@Test
+		default void throwsNullPointerExceptionIfRegisterTypeIsNull() {
+			assertThrows(NullPointerException.class, () -> subject().canRegisterType(null));
+		}
+
+		@Test
+		default void returnsFalseForNonRegistrableTypes() {
+			assertFalse(subject().canRegisterType(WrongType.class));
+		}
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/TaskContainerRegistryTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/TaskContainerRegistryTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model;
+
+import lombok.EqualsAndHashCode;
+import lombok.val;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.NamedDomainObjectProvider;
+import org.gradle.api.Task;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.internal.testing.util.ProjectTestUtils.rootProject;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasToString;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TaskContainerRegistryTest implements PolymorphicDomainObjectRegistryTester<Task> {
+	private PolymorphicDomainObjectRegistry<Task> subject;
+	private NamedDomainObjectProvider<MyTask.A> e0;
+	private NamedDomainObjectProvider<MyTask.B> e1;
+	private NamedDomainObjectProvider<MyTask.C> e2;
+	private NamedDomainObjectProvider<MyTask.D> e3;
+
+	@BeforeEach
+	void setup() {
+		val container = rootProject().getTasks();
+		System.out.println(container);
+
+		subject =  PolymorphicDomainObjectRegistry.of(container);
+		e0 = container.register("a", MyTask.A.class);
+		e1 = container.register("b", MyTask.B.class);
+		e2 = container.register("c", MyTask.C.class);
+		e3 = container.register("d", MyTask.D.class);
+	}
+
+	@Override
+	public PolymorphicDomainObjectRegistry<Task> subject() {
+		return subject;
+	}
+
+	@Override
+	public NamedDomainObjectProvider<? extends Task> e0() {
+		return e0;
+	}
+
+	@Override
+	public NamedDomainObjectProvider<? extends Task> e1() {
+		return e1;
+	}
+
+	@Override
+	public NamedDomainObjectProvider<? extends Task> e2() {
+		return e2;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <S extends Task> NamedDomainObjectProvider<? extends S> e3() {
+		return (NamedDomainObjectProvider<? extends S>) e3;
+	}
+
+	@Test
+	void checkToString() {
+		assertThat(subject, hasToString("task set registry"));
+	}
+
+	@Nested
+	class RegistrableTypesTest implements RegistrableTypesTester {
+		@Override
+		public PolymorphicDomainObjectRegistry.RegistrableTypes subject() {
+			return subject.getRegistrableTypes();
+		}
+
+		@Test
+		void canRegisterAnyTaskType() {
+			assertTrue(subject().canRegisterType(MyTask.class));
+			assertTrue(subject().canRegisterType(MyTask.A.class));
+			assertTrue(subject().canRegisterType(MyTask.B.class));
+			assertTrue(subject().canRegisterType(MyTask.C.class));
+			assertTrue(subject().canRegisterType(MyTask.D.class));
+			assertTrue(subject().canRegisterType(MyOtherTask.class));
+		}
+	}
+
+	@EqualsAndHashCode(callSuper = true)
+	public static class MyTask extends DefaultTask {
+		@EqualsAndHashCode(callSuper = true)
+		public static /*final*/ class A extends MyTask {}
+
+		@EqualsAndHashCode(callSuper = true)
+		public static /*final*/ class B extends MyTask {}
+
+		@EqualsAndHashCode(callSuper = true)
+		public static /*final*/ class C extends MyTask {}
+
+		@EqualsAndHashCode(callSuper = true)
+		public static /*final*/ class D extends MyTask {}
+	}
+
+	public interface MyOtherTask extends Task {}
+}


### PR DESCRIPTION
The adapaters creates a standard API for containers and
other domain object repositories. The API can then be used for
registering needs and possibly decoration needs as well.