### PR TITLE
Use property identifier instead of ModelPath

### DIFF
--- a/subprojects/core-model/core-model.gradle
+++ b/subprojects/core-model/core-model.gradle
@@ -8,6 +8,7 @@ plugins {
 dependencies {
 	implementation project(':coreUtils')
 	implementation "com.google.guava:guava:${guavaVersion}"
+	implementation "org.apache.commons:commons-lang3:${commonsLangVersion}"
 
 	testImplementation gradleApi(minimumGradleVersion)
 	testImplementation "dev.gradleplugins:gradle-fixtures-well-behaving-plugins:latest.release"

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/DomainObjectIdentifierUtils.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/DomainObjectIdentifierUtils.java
@@ -16,7 +16,10 @@
 package dev.nokee.model.internal;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Streams;
 import dev.nokee.model.DomainObjectIdentifier;
+import dev.nokee.model.HasName;
+import dev.nokee.model.internal.core.ModelPath;
 import lombok.EqualsAndHashCode;
 import lombok.val;
 
@@ -24,6 +27,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public final class DomainObjectIdentifierUtils {
 	private DomainObjectIdentifierUtils() {}
@@ -185,5 +190,17 @@ public final class DomainObjectIdentifierUtils {
 			return (TypeAwareDomainObjectIdentifier<S>) identifier;
 		}
 		throw new ClassCastException(String.format("Failed to cast identifier %s of type %s to identifier of type %s.", identifier.toString(), identifier.getType().getName(), outputIdentifierType.getName()));
+	}
+
+	public static ModelPath toPath(DomainObjectIdentifier identifier) {
+		return ModelPath.path(Streams.stream(identifier).flatMap(it -> {
+			if (it instanceof ProjectIdentifier) {
+				return Stream.empty();
+			} else if (it instanceof HasName) {
+				return Stream.of(((HasName) it).getName().toString());
+			} else {
+				throw new UnsupportedOperationException();
+			}
+		}).collect(Collectors.toList()));
 	}
 }

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/ModelPropertyIdentifier.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/ModelPropertyIdentifier.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal;
+
+import com.google.common.collect.ImmutableList;
+import dev.nokee.model.DomainObjectIdentifier;
+import lombok.EqualsAndHashCode;
+
+import java.util.Iterator;
+
+@EqualsAndHashCode
+public final class ModelPropertyIdentifier implements DomainObjectIdentifier {
+	public static ModelPropertyIdentifier of(DomainObjectIdentifier ownerIdentifier, String propertyName) {
+		return new ModelPropertyIdentifier(ownerIdentifier, ModelPropertyIdentity.of(propertyName));
+	}
+
+	private final DomainObjectIdentifier ownerIdentifier;
+	private final ModelPropertyIdentity identity;
+
+	public ModelPropertyIdentifier(DomainObjectIdentifier ownerIdentifier, ModelPropertyIdentity identity) {
+		this.ownerIdentifier = ownerIdentifier;
+		this.identity = identity;
+	}
+
+	public DomainObjectIdentifier getOwnerIdentifier() {
+		return ownerIdentifier;
+	}
+
+	@Override
+	public Iterator<Object> iterator() {
+		return ImmutableList.builder().addAll(ownerIdentifier).add(identity).build().iterator();
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/ModelPropertyIdentity.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/ModelPropertyIdentity.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal;
+
+import dev.nokee.model.HasName;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode
+public final class ModelPropertyIdentity implements HasName {
+	private final ModelPropertyName name;
+
+	private ModelPropertyIdentity(ModelPropertyName name) {
+		this.name = name;
+	}
+
+	public static ModelPropertyIdentity of(String name) {
+		return new ModelPropertyIdentity(ModelPropertyName.of(name));
+	}
+
+	@Override
+	public ModelPropertyName getName() {
+		return name;
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/ModelPropertyName.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/ModelPropertyName.java
@@ -28,6 +28,7 @@ public final class ModelPropertyName {
 
 	private ModelPropertyName(String name) {
 		Objects.requireNonNull(name);
+		// Checks are disabled until single variant names are not empty strings...
 //		checkArgument(!name.isEmpty());
 //		checkArgument(CharUtils.isAsciiAlphaLower(name.charAt(0)));
 //		checkArgument(StringUtils.containsOnly(StringUtils.substring(name, 1), VALID_PART_CHARACTERS));

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/ModelPropertyName.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/ModelPropertyName.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal;
+
+import org.apache.commons.lang3.CharUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public final class ModelPropertyName {
+	private static final String VALID_PART_CHARACTERS = "abcdefghijklmnopqrstuvwxyz" + "ABCDEFGHIJKLMNOPQRSTUVWXYZ" + "0123456789" + "-_";
+	private final String name;
+
+	private ModelPropertyName(String name) {
+		Objects.requireNonNull(name);
+//		checkArgument(!name.isEmpty());
+//		checkArgument(CharUtils.isAsciiAlphaLower(name.charAt(0)));
+//		checkArgument(StringUtils.containsOnly(StringUtils.substring(name, 1), VALID_PART_CHARACTERS));
+		this.name = name;
+	}
+
+	public static ModelPropertyName of(String name) {
+		return new ModelPropertyName(name);
+	}
+
+	public String get() {
+		return name;
+	}
+
+	@Override
+	public String toString() {
+		return name;
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelPropertyRegistrationFactory.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelPropertyRegistrationFactory.java
@@ -28,6 +28,8 @@ import lombok.val;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static dev.nokee.model.internal.DomainObjectIdentifierUtils.toPath;
+
 public final class ModelPropertyRegistrationFactory {
 	private final ModelLookup lookup;
 
@@ -77,17 +79,5 @@ public final class ModelPropertyRegistrationFactory {
 				}
 			}))
 			.build();
-	}
-
-	private static ModelPath toPath(ModelPropertyIdentifier identifier) {
-		return ModelPath.path(Streams.stream(identifier).flatMap(it -> {
-			if (it instanceof ProjectIdentifier) {
-				return Stream.empty();
-			} else if (it instanceof HasName) {
-				return Stream.of(((HasName) it).getName().toString());
-			} else {
-				throw new UnsupportedOperationException();
-			}
-		}).collect(Collectors.toList()));
 	}
 }

--- a/subprojects/language-base/src/main/java/dev/nokee/language/base/internal/LanguageSourceSetRegistrationBuilder.java
+++ b/subprojects/language-base/src/main/java/dev/nokee/language/base/internal/LanguageSourceSetRegistrationBuilder.java
@@ -15,18 +15,13 @@
  */
 package dev.nokee.language.base.internal;
 
-import com.google.common.collect.Streams;
 import dev.nokee.internal.Factory;
 import dev.nokee.language.base.ConfigurableSourceSet;
-import dev.nokee.model.HasName;
-import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.model.internal.core.*;
 import dev.nokee.model.internal.registry.ModelRegistry;
 import dev.nokee.model.internal.state.ModelState;
 
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
+import static dev.nokee.model.internal.DomainObjectIdentifierUtils.toPath;
 import static dev.nokee.model.internal.core.ModelProjections.createdUsing;
 import static dev.nokee.model.internal.core.ModelProjections.managed;
 import static dev.nokee.model.internal.type.ModelType.of;
@@ -54,17 +49,5 @@ public final class LanguageSourceSetRegistrationBuilder {
 
 	public ModelRegistration build() {
 		return builder.build();
-	}
-
-	private static ModelPath toPath(LanguageSourceSetIdentifier identifier) {
-		return ModelPath.path(Streams.stream(identifier).flatMap(it -> {
-			if (it instanceof ProjectIdentifier) {
-				return Stream.empty();
-			} else if (it instanceof HasName) {
-				return Stream.of(((HasName) it).getName().toString());
-			} else {
-				throw new UnsupportedOperationException();
-			}
-		}).collect(Collectors.toList()));
 	}
 }

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ComponentBinariesPropertyRegistrationFactory.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ComponentBinariesPropertyRegistrationFactory.java
@@ -17,6 +17,9 @@ package dev.nokee.platform.base.internal;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Streams;
+import dev.nokee.model.HasName;
+import dev.nokee.model.internal.ModelPropertyIdentifier;
+import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.model.internal.core.*;
 import dev.nokee.model.internal.registry.ModelConfigurer;
 import dev.nokee.model.internal.registry.ModelLookup;
@@ -30,6 +33,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.provider.ProviderFactory;
 
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static dev.nokee.model.internal.core.ModelComponentType.projectionOf;
 import static dev.nokee.model.internal.core.ModelProjections.createdUsing;
@@ -50,30 +54,43 @@ public final class ComponentBinariesPropertyRegistrationFactory {
 		this.modelLookup = modelLookup;
 	}
 
-	// TODO: We should accept the property identifier and use that to figure out descendant, path, and finalizing.
-	public ModelRegistration create(ModelPath path) {
+	public ModelRegistration create(ModelPropertyIdentifier identifier) {
+		val path = toPath(identifier);
 		assert path.getParent().isPresent();
 		val ownerPath = path.getParent().get();
 		return ModelRegistration.builder()
 			.withComponent(path)
+			.withComponent(identifier)
 			.withComponent(IsModelProperty.tag())
 			.withComponent(createdUsing(of(BinaryView.class), () -> new BinaryViewAdapter<>(new ViewAdapter<>(Binary.class, new ModelNodeBackedViewStrategy(providers, () -> {
 				ModelStates.realize(modelLookup.get(ownerPath));
 				ModelStates.finalize(modelLookup.get(ownerPath));
 			})))))
-			.action(ModelActionWithInputs.of(ModelComponentReference.of(ModelPath.class), ModelComponentReference.of(ModelState.IsAtLeastRegistered.class), (ee, pp, ignored) -> {
-				if (path.equals(pp)) {
+			.action(ModelActionWithInputs.of(ModelComponentReference.of(ModelPropertyIdentifier.class), ModelComponentReference.of(ModelState.IsAtLeastRegistered.class), (ee, id, ignored) -> {
+				if (id.equals(identifier)) {
 					modelConfigurer.configure(ModelActionWithInputs.of(ModelComponentReference.of(ModelPath.class), ModelComponentReference.of(ModelState.IsAtLeastCreated.class), ModelComponentReference.of(IsBinary.class), ModelComponentReference.ofAny(projectionOf(Binary.class)), (e, p, ignored1, ignored2, projection) -> {
 						if (ownerPath.isDescendant(p)) {
 							val elementName = StringUtils.uncapitalize(Streams.stream(Iterables.skip(p, Iterables.size(ownerPath)))
 								.filter(it -> !it.isEmpty())
 								.map(StringUtils::capitalize)
 								.collect(Collectors.joining()));
-							registry.register(propertyFactory.create(path.child(elementName), e));
+							registry.register(propertyFactory.create(ModelPropertyIdentifier.of(identifier, elementName), e));
 						}
 					}));
 				}
 			}))
 			.build();
+	}
+
+	private static ModelPath toPath(ModelPropertyIdentifier identifier) {
+		return ModelPath.path(Streams.stream(identifier).flatMap(it -> {
+			if (it instanceof ProjectIdentifier) {
+				return Stream.empty();
+			} else if (it instanceof HasName) {
+				return Stream.of(((HasName) it).getName().toString());
+			} else {
+				throw new UnsupportedOperationException();
+			}
+		}).collect(Collectors.toList()));
 	}
 }

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ComponentBinariesPropertyRegistrationFactory.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ComponentBinariesPropertyRegistrationFactory.java
@@ -17,9 +17,7 @@ package dev.nokee.platform.base.internal;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Streams;
-import dev.nokee.model.HasName;
 import dev.nokee.model.internal.ModelPropertyIdentifier;
-import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.model.internal.core.*;
 import dev.nokee.model.internal.registry.ModelConfigurer;
 import dev.nokee.model.internal.registry.ModelLookup;
@@ -33,8 +31,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.provider.ProviderFactory;
 
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
+import static dev.nokee.model.internal.DomainObjectIdentifierUtils.toPath;
 import static dev.nokee.model.internal.core.ModelComponentType.projectionOf;
 import static dev.nokee.model.internal.core.ModelProjections.createdUsing;
 import static dev.nokee.model.internal.type.ModelType.of;
@@ -80,17 +78,5 @@ public final class ComponentBinariesPropertyRegistrationFactory {
 				}
 			}))
 			.build();
-	}
-
-	private static ModelPath toPath(ModelPropertyIdentifier identifier) {
-		return ModelPath.path(Streams.stream(identifier).flatMap(it -> {
-			if (it instanceof ProjectIdentifier) {
-				return Stream.empty();
-			} else if (it instanceof HasName) {
-				return Stream.of(((HasName) it).getName().toString());
-			} else {
-				throw new UnsupportedOperationException();
-			}
-		}).collect(Collectors.toList()));
 	}
 }

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ComponentDependenciesPropertyRegistrationFactory.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ComponentDependenciesPropertyRegistrationFactory.java
@@ -17,9 +17,7 @@ package dev.nokee.platform.base.internal;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Streams;
-import dev.nokee.model.HasName;
 import dev.nokee.model.internal.ModelPropertyIdentifier;
-import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.model.internal.core.*;
 import dev.nokee.model.internal.registry.ModelConfigurer;
 import dev.nokee.model.internal.registry.ModelLookup;
@@ -32,11 +30,10 @@ import org.gradle.api.artifacts.Configuration;
 
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
+import static dev.nokee.model.internal.DomainObjectIdentifierUtils.toPath;
 import static dev.nokee.model.internal.core.ModelComponentType.projectionOf;
 import static dev.nokee.model.internal.core.ModelProjections.createdUsing;
-import static dev.nokee.model.internal.core.ModelProjections.ofInstance;
 import static dev.nokee.model.internal.type.ModelType.of;
 
 public final class ComponentDependenciesPropertyRegistrationFactory {
@@ -77,17 +74,5 @@ public final class ComponentDependenciesPropertyRegistrationFactory {
 				}
 			}))
 			.build();
-	}
-
-	private static ModelPath toPath(ModelPropertyIdentifier identifier) {
-		return ModelPath.path(Streams.stream(identifier).flatMap(it -> {
-			if (it instanceof ProjectIdentifier) {
-				return Stream.empty();
-			} else if (it instanceof HasName) {
-				return Stream.of(((HasName) it).getName().toString());
-			} else {
-				throw new UnsupportedOperationException();
-			}
-		}).collect(Collectors.toList()));
 	}
 }

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ComponentSourcesPropertyRegistrationFactory.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ComponentSourcesPropertyRegistrationFactory.java
@@ -20,11 +20,9 @@ import com.google.common.collect.Streams;
 import dev.nokee.language.base.FunctionalSourceSet;
 import dev.nokee.language.base.LanguageSourceSet;
 import dev.nokee.language.base.internal.IsLanguageSourceSet;
-import dev.nokee.model.HasName;
 import dev.nokee.model.internal.BaseDomainObjectViewProjection;
 import dev.nokee.model.internal.BaseNamedDomainObjectViewProjection;
 import dev.nokee.model.internal.ModelPropertyIdentifier;
-import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.model.internal.core.*;
 import dev.nokee.model.internal.registry.ModelConfigurer;
 import dev.nokee.model.internal.registry.ModelRegistry;
@@ -33,8 +31,8 @@ import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
+import static dev.nokee.model.internal.DomainObjectIdentifierUtils.toPath;
 import static dev.nokee.model.internal.core.ModelComponentType.projectionOf;
 import static dev.nokee.model.internal.core.ModelProjections.managed;
 import static dev.nokee.model.internal.type.ModelType.of;
@@ -75,17 +73,5 @@ public final class ComponentSourcesPropertyRegistrationFactory {
 				}
 			}))
 			.build();
-	}
-
-	private static ModelPath toPath(ModelPropertyIdentifier identifier) {
-		return ModelPath.path(Streams.stream(identifier).flatMap(it -> {
-			if (it instanceof ProjectIdentifier) {
-				return Stream.empty();
-			} else if (it instanceof HasName) {
-				return Stream.of(((HasName) it).getName().toString());
-			} else {
-				throw new UnsupportedOperationException();
-			}
-		}).collect(Collectors.toList()));
 	}
 }

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ComponentTasksPropertyRegistrationFactory.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ComponentTasksPropertyRegistrationFactory.java
@@ -17,9 +17,7 @@ package dev.nokee.platform.base.internal;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Streams;
-import dev.nokee.model.HasName;
 import dev.nokee.model.internal.ModelPropertyIdentifier;
-import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.model.internal.core.*;
 import dev.nokee.model.internal.registry.ModelConfigurer;
 import dev.nokee.model.internal.registry.ModelLookup;
@@ -33,8 +31,8 @@ import org.gradle.api.Task;
 import org.gradle.api.provider.ProviderFactory;
 
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
+import static dev.nokee.model.internal.DomainObjectIdentifierUtils.toPath;
 import static dev.nokee.model.internal.core.ModelComponentType.projectionOf;
 import static dev.nokee.model.internal.core.ModelProjections.createdUsing;
 import static dev.nokee.model.internal.type.ModelType.of;
@@ -80,17 +78,5 @@ public final class ComponentTasksPropertyRegistrationFactory {
 				}
 			}))
 			.build();
-	}
-
-	private static ModelPath toPath(ModelPropertyIdentifier identifier) {
-		return ModelPath.path(Streams.stream(identifier).flatMap(it -> {
-			if (it instanceof ProjectIdentifier) {
-				return Stream.empty();
-			} else if (it instanceof HasName) {
-				return Stream.of(((HasName) it).getName().toString());
-			} else {
-				throw new UnsupportedOperationException();
-			}
-		}).collect(Collectors.toList()));
 	}
 }

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ComponentTasksPropertyRegistrationFactory.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ComponentTasksPropertyRegistrationFactory.java
@@ -17,14 +17,15 @@ package dev.nokee.platform.base.internal;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Streams;
+import dev.nokee.model.HasName;
+import dev.nokee.model.internal.ModelPropertyIdentifier;
+import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.model.internal.core.*;
 import dev.nokee.model.internal.registry.ModelConfigurer;
 import dev.nokee.model.internal.registry.ModelLookup;
 import dev.nokee.model.internal.registry.ModelRegistry;
 import dev.nokee.model.internal.state.ModelState;
 import dev.nokee.model.internal.state.ModelStates;
-import dev.nokee.platform.base.Binary;
-import dev.nokee.platform.base.BinaryView;
 import dev.nokee.platform.base.TaskView;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
@@ -32,6 +33,7 @@ import org.gradle.api.Task;
 import org.gradle.api.provider.ProviderFactory;
 
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static dev.nokee.model.internal.core.ModelComponentType.projectionOf;
 import static dev.nokee.model.internal.core.ModelProjections.createdUsing;
@@ -52,30 +54,43 @@ public final class ComponentTasksPropertyRegistrationFactory {
 		this.modelLookup = modelLookup;
 	}
 
-	// TODO: We should accept the property identifier and use that to figure out descendant, path, and finalizing.
-	public ModelRegistration create(ModelPath path) {
+	public ModelRegistration create(ModelPropertyIdentifier identifier) {
+		val path = toPath(identifier);
 		assert path.getParent().isPresent();
 		val ownerPath = path.getParent().get();
 		return ModelRegistration.builder()
 			.withComponent(path)
+			.withComponent(identifier)
 			.withComponent(IsModelProperty.tag())
 			.withComponent(createdUsing(of(TaskView.class), () -> new TaskViewAdapter<>(new ViewAdapter<>(Task.class, new ModelNodeBackedViewStrategy(providers, () -> {
 				ModelStates.realize(modelLookup.get(ownerPath));
 				ModelStates.finalize(modelLookup.get(ownerPath));
 			})))))
-			.action(ModelActionWithInputs.of(ModelComponentReference.of(ModelPath.class), ModelComponentReference.of(ModelState.IsAtLeastRegistered.class), (ee, pp, ignored) -> {
-				if (path.equals(pp)) {
+			.action(ModelActionWithInputs.of(ModelComponentReference.of(ModelPropertyIdentifier.class), ModelComponentReference.of(ModelState.IsAtLeastRegistered.class), (ee, id, ignored) -> {
+				if (id.equals(identifier)) {
 					modelConfigurer.configure(ModelActionWithInputs.of(ModelComponentReference.of(ModelPath.class), ModelComponentReference.of(ModelState.IsAtLeastCreated.class), ModelComponentReference.of(IsTask.class), ModelComponentReference.ofAny(projectionOf(Task.class)), (e, p, ignored1, ignored2, projection) -> {
 						if (ownerPath.isDescendant(p)) {
 							val elementName = StringUtils.uncapitalize(Streams.stream(Iterables.skip(p, Iterables.size(ownerPath)))
 								.filter(it -> !it.isEmpty())
 								.map(StringUtils::capitalize)
 								.collect(Collectors.joining()));
-							registry.register(propertyFactory.create(path.child(elementName), e));
+							registry.register(propertyFactory.create(ModelPropertyIdentifier.of(identifier, elementName), e));
 						}
 					}));
 				}
 			}))
 			.build();
+	}
+
+	private static ModelPath toPath(ModelPropertyIdentifier identifier) {
+		return ModelPath.path(Streams.stream(identifier).flatMap(it -> {
+			if (it instanceof ProjectIdentifier) {
+				return Stream.empty();
+			} else if (it instanceof HasName) {
+				return Stream.of(((HasName) it).getName().toString());
+			} else {
+				throw new UnsupportedOperationException();
+			}
+		}).collect(Collectors.toList()));
 	}
 }

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ComponentVariantsPropertyRegistrationFactory.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ComponentVariantsPropertyRegistrationFactory.java
@@ -15,10 +15,7 @@
  */
 package dev.nokee.platform.base.internal;
 
-import com.google.common.collect.Streams;
-import dev.nokee.model.HasName;
 import dev.nokee.model.internal.ModelPropertyIdentifier;
-import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.model.internal.core.*;
 import dev.nokee.model.internal.registry.ModelLookup;
 import dev.nokee.model.internal.registry.ModelRegistry;
@@ -29,9 +26,7 @@ import dev.nokee.platform.base.VariantView;
 import lombok.val;
 import org.gradle.api.provider.ProviderFactory;
 
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
+import static dev.nokee.model.internal.DomainObjectIdentifierUtils.toPath;
 import static dev.nokee.model.internal.core.ModelProjections.createdUsing;
 import static dev.nokee.model.internal.type.ModelType.of;
 
@@ -62,17 +57,5 @@ public final class ComponentVariantsPropertyRegistrationFactory {
 				}
 			}))
 			.build();
-	}
-
-	private static ModelPath toPath(ModelPropertyIdentifier identifier) {
-		return ModelPath.path(Streams.stream(identifier).flatMap(it -> {
-			if (it instanceof ProjectIdentifier) {
-				return Stream.empty();
-			} else if (it instanceof HasName) {
-				return Stream.of(((HasName) it).getName().toString());
-			} else {
-				throw new UnsupportedOperationException();
-			}
-		}).collect(Collectors.toList()));
 	}
 }

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantIdentifier.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantIdentifier.java
@@ -16,6 +16,7 @@
 package dev.nokee.platform.base.internal;
 
 import com.google.common.collect.Iterators;
+import dev.nokee.model.HasName;
 import dev.nokee.model.internal.DomainObjectIdentifierInternal;
 import dev.nokee.model.internal.NamedDomainObjectIdentifier;
 import dev.nokee.model.internal.TypeAwareDomainObjectIdentifier;
@@ -39,7 +40,7 @@ import java.util.stream.Collectors;
 import static java.util.Objects.requireNonNull;
 
 @EqualsAndHashCode
-public final class VariantIdentifier<T extends Variant> implements DomainObjectIdentifierInternal, NamedDomainObjectIdentifier, TypeAwareDomainObjectIdentifier<T> {
+public final class VariantIdentifier<T extends Variant> implements DomainObjectIdentifierInternal, NamedDomainObjectIdentifier, TypeAwareDomainObjectIdentifier<T>, HasName {
 	@Getter private final String unambiguousName;
 	@Getter private final Class<T> type;
 	@Getter private final ComponentIdentifier componentIdentifier;

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/ConsumableDependencyBucketRegistrationFactory.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/ConsumableDependencyBucketRegistrationFactory.java
@@ -39,6 +39,7 @@ import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Provider;
 
+import static dev.nokee.model.internal.DomainObjectIdentifierUtils.toPath;
 import static dev.nokee.model.internal.core.ModelProjections.createdUsing;
 import static dev.nokee.model.internal.core.ModelProjections.ofInstance;
 import static dev.nokee.model.internal.type.ModelType.of;
@@ -71,7 +72,7 @@ public final class ConsumableDependencyBucketRegistrationFactory {
 			}
 		});
 		configurationProvider.configure(attachOutgoingArtifactToConfiguration(outgoing));
-		val entityPath = DependencyBuckets.toPath(identifier);
+		val entityPath = toPath(identifier);
 		return ModelRegistration.builder()
 			.withComponent(entityPath)
 			.withComponent(identifier)

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/DeclarableDependencyBucketRegistrationFactory.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/DeclarableDependencyBucketRegistrationFactory.java
@@ -33,6 +33,7 @@ import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.plugins.ExtensionAware;
 
+import static dev.nokee.model.internal.DomainObjectIdentifierUtils.toPath;
 import static dev.nokee.model.internal.core.ModelProjections.createdUsing;
 import static dev.nokee.model.internal.core.ModelProjections.createdUsingNoInject;
 import static dev.nokee.model.internal.type.ModelType.of;
@@ -61,7 +62,7 @@ public final class DeclarableDependencyBucketRegistrationFactory {
 				throw new IllegalStateException("Bucket registration mismatch!");
 			}
 		});
-		val entityPath = DependencyBuckets.toPath(identifier);
+		val entityPath = toPath(identifier);
 		return ModelRegistration.builder()
 			.withComponent(entityPath)
 			.withComponent(identifier)

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/DependencyBucketName.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/DependencyBucketName.java
@@ -16,7 +16,6 @@
 package dev.nokee.platform.base.internal.dependencies;
 
 import lombok.EqualsAndHashCode;
-import lombok.ToString;
 
 import static com.google.common.base.Preconditions.checkArgument;
 

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/DependencyBuckets.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/DependencyBuckets.java
@@ -53,20 +53,6 @@ public final class DependencyBuckets {
 		return builder.toString();
 	}
 
-	public static ModelPath toPath(DependencyBucketIdentifier identifier) {
-		return ModelPath.path(Streams.stream(identifier).flatMap(it -> {
-			if (it instanceof ProjectIdentifier) {
-				return Stream.empty();
-			} else if (it instanceof HasName) {
-				return Stream.of(((HasName) it).getName().toString());
-			} else if (it instanceof VariantIdentifier) {
-				return Stream.of(((VariantIdentifier<?>) it).getUnambiguousName());
-			} else {
-				throw new UnsupportedOperationException();
-			}
-		}).collect(Collectors.toList()));
-	}
-
 	public static String configurationName(DependencyBucketIdentifier identifier) {
 		return StringUtils.uncapitalize(Streams.stream(identifier)
 			.flatMap(it -> {

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/ResolvableDependencyBucketRegistrationFactory.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/ResolvableDependencyBucketRegistrationFactory.java
@@ -35,6 +35,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.plugins.ExtensionAware;
 
+import static dev.nokee.model.internal.DomainObjectIdentifierUtils.toPath;
 import static dev.nokee.model.internal.core.ModelProjections.createdUsing;
 import static dev.nokee.model.internal.core.ModelProjections.ofInstance;
 import static dev.nokee.model.internal.type.ModelType.of;
@@ -64,7 +65,7 @@ public final class ResolvableDependencyBucketRegistrationFactory {
 				throw new IllegalStateException("Bucket registration mismatch!");
 			}
 		});
-		val entityPath = DependencyBuckets.toPath(identifier);
+		val entityPath = toPath(identifier);
 		return ModelRegistration.builder()
 			.withComponent(entityPath)
 			.withComponent(identifier)

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/plugins/ComponentModelBasePlugin.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/plugins/ComponentModelBasePlugin.java
@@ -18,6 +18,8 @@ package dev.nokee.platform.base.internal.plugins;
 import dev.nokee.internal.Factory;
 import dev.nokee.language.base.LanguageSourceSet;
 import dev.nokee.language.base.internal.plugins.LanguageBasePlugin;
+import dev.nokee.model.internal.ModelPropertyIdentifier;
+import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.model.internal.core.*;
 import dev.nokee.model.internal.plugins.ModelBasePlugin;
 import dev.nokee.model.internal.registry.ModelConfigurer;
@@ -63,7 +65,7 @@ public class ComponentModelBasePlugin implements Plugin<Project> {
 		val propertyFactory = project.getExtensions().getByType(ModelPropertyRegistrationFactory.class);
 		project.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelComponentReference.of(ModelPath.class), ModelComponentReference.of(ModelState.IsAtLeastCreated.class), ModelComponentReference.of(IsComponent.class), ModelComponentReference.ofAny(ModelComponentType.projectionOf(Component.class)), (e, p, ignored1, ignored2, projection) -> {
 			if (ModelPath.root().isDirectDescendant(p)) {
-				modeRegistry.register(propertyFactory.create(ModelPath.path("components").child(p.getName()), e));
+				modeRegistry.register(propertyFactory.create(ModelPropertyIdentifier.of(ModelPropertyIdentifier.of(ProjectIdentifier.of(project),"components"), p.getName()), e));
 			}
 		}));
 

--- a/subprojects/platform-c/src/main/java/dev/nokee/platform/c/internal/plugins/CApplicationPlugin.java
+++ b/subprojects/platform-c/src/main/java/dev/nokee/platform/c/internal/plugins/CApplicationPlugin.java
@@ -25,6 +25,7 @@ import dev.nokee.language.c.internal.plugins.CLanguageBasePlugin;
 import dev.nokee.language.c.internal.plugins.CSourceSetRegistrationFactory;
 import dev.nokee.language.nativebase.NativeHeaderSet;
 import dev.nokee.language.nativebase.internal.toolchains.NokeeStandardToolChainsPlugin;
+import dev.nokee.model.internal.ModelPropertyIdentifier;
 import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.model.internal.core.ModelRegistration;
 import dev.nokee.model.internal.registry.ModelRegistry;
@@ -83,14 +84,15 @@ public class CApplicationPlugin implements Plugin<Project> {
 	}
 
 	public static ModelRegistration cApplication(String name, Project project) {
+		val identifier = ComponentIdentifier.builder().name(ComponentName.of(name)).displayName("C application").withProjectIdentifier(ProjectIdentifier.of(project)).build();
 		return new NativeApplicationComponentModelRegistrationFactory(CApplication.class, DefaultCApplication.class, project, (entity, path) -> {
 			val registry = project.getExtensions().getByType(ModelRegistry.class);
 
 			registry.register(project.getExtensions().getByType(CSourceSetRegistrationFactory.class).create(LanguageSourceSetIdentifier.of(entity.getComponent(ComponentIdentifier.class), "c")));
 			registry.register(project.getExtensions().getByType(CHeaderSetRegistrationFactory.class).create(LanguageSourceSetIdentifier.of(entity.getComponent(ComponentIdentifier.class), "headers")));
 
-			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(path.child("sources"), CApplicationSources.class));
-		}).create(ComponentIdentifier.builder().name(ComponentName.of(name)).displayName("C application").withProjectIdentifier(ProjectIdentifier.of(project)).build());
+			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "sources"), CApplicationSources.class));
+		}).create(identifier);
 	}
 
 	public static abstract class DefaultCApplication implements CApplication

--- a/subprojects/platform-c/src/main/java/dev/nokee/platform/c/internal/plugins/CLibraryPlugin.java
+++ b/subprojects/platform-c/src/main/java/dev/nokee/platform/c/internal/plugins/CLibraryPlugin.java
@@ -25,6 +25,7 @@ import dev.nokee.language.c.internal.plugins.CLanguageBasePlugin;
 import dev.nokee.language.c.internal.plugins.CSourceSetRegistrationFactory;
 import dev.nokee.language.nativebase.NativeHeaderSet;
 import dev.nokee.language.nativebase.internal.toolchains.NokeeStandardToolChainsPlugin;
+import dev.nokee.model.internal.ModelPropertyIdentifier;
 import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.model.internal.core.ModelRegistration;
 import dev.nokee.model.internal.registry.ModelRegistry;
@@ -85,6 +86,7 @@ public class CLibraryPlugin implements Plugin<Project> {
 	}
 
 	public static ModelRegistration cLibrary(String name, Project project) {
+		val identifier = ComponentIdentifier.builder().name(ComponentName.of(name)).displayName("C library").withProjectIdentifier(ProjectIdentifier.of(project)).build();
 		return new NativeLibraryComponentModelRegistrationFactory(CLibrary.class, DefaultCLibrary.class, project, (entity, path) -> {
 			val registry = project.getExtensions().getByType(ModelRegistry.class);
 
@@ -92,8 +94,8 @@ public class CLibraryPlugin implements Plugin<Project> {
 			registry.register(project.getExtensions().getByType(CHeaderSetRegistrationFactory.class).create(LanguageSourceSetIdentifier.of(entity.getComponent(ComponentIdentifier.class), "public")));
 			registry.register(project.getExtensions().getByType(CHeaderSetRegistrationFactory.class).create(LanguageSourceSetIdentifier.of(entity.getComponent(ComponentIdentifier.class), "headers")));
 
-			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(path.child("sources"), CLibrarySources.class));
-		}).create(ComponentIdentifier.builder().name(ComponentName.of(name)).displayName("C library").withProjectIdentifier(ProjectIdentifier.of(project)).build());
+			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "sources"), CLibrarySources.class));
+		}).create(identifier);
 	}
 
 	public static abstract class DefaultCLibrary implements CLibrary

--- a/subprojects/platform-cpp/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppApplicationPlugin.java
+++ b/subprojects/platform-cpp/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppApplicationPlugin.java
@@ -25,6 +25,7 @@ import dev.nokee.language.cpp.internal.plugins.CppLanguageBasePlugin;
 import dev.nokee.language.cpp.internal.plugins.CppSourceSetRegistrationFactory;
 import dev.nokee.language.nativebase.NativeHeaderSet;
 import dev.nokee.language.nativebase.internal.toolchains.NokeeStandardToolChainsPlugin;
+import dev.nokee.model.internal.ModelPropertyIdentifier;
 import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.model.internal.core.ModelRegistration;
 import dev.nokee.model.internal.registry.ModelRegistry;
@@ -83,14 +84,15 @@ public class CppApplicationPlugin implements Plugin<Project> {
 	}
 
 	public static ModelRegistration cppApplication(String name, Project project) {
+		val identifier = ComponentIdentifier.builder().name(ComponentName.of(name)).displayName("C++ application").withProjectIdentifier(ProjectIdentifier.of(project)).build();
 		return new NativeApplicationComponentModelRegistrationFactory(CppApplication.class, DefaultCppApplication.class, project, (entity, path) -> {
 			val registry = project.getExtensions().getByType(ModelRegistry.class);
 
 			registry.register(project.getExtensions().getByType(CppSourceSetRegistrationFactory.class).create(LanguageSourceSetIdentifier.of(entity.getComponent(ComponentIdentifier.class), "cpp")));
 			registry.register(project.getExtensions().getByType(CppHeaderSetRegistrationFactory.class).create(LanguageSourceSetIdentifier.of(entity.getComponent(ComponentIdentifier.class), "headers")));
 
-			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(path.child("sources"), CppApplicationSources.class));
-		}).create(ComponentIdentifier.builder().name(ComponentName.of(name)).displayName("C++ application").withProjectIdentifier(ProjectIdentifier.of(project)).build());
+			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "sources"), CppApplicationSources.class));
+		}).create(identifier);
 	}
 
 	public static abstract class DefaultCppApplication implements CppApplication

--- a/subprojects/platform-cpp/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppLibraryPlugin.java
+++ b/subprojects/platform-cpp/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppLibraryPlugin.java
@@ -25,6 +25,7 @@ import dev.nokee.language.cpp.internal.plugins.CppLanguageBasePlugin;
 import dev.nokee.language.cpp.internal.plugins.CppSourceSetRegistrationFactory;
 import dev.nokee.language.nativebase.NativeHeaderSet;
 import dev.nokee.language.nativebase.internal.toolchains.NokeeStandardToolChainsPlugin;
+import dev.nokee.model.internal.ModelPropertyIdentifier;
 import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.model.internal.core.ModelRegistration;
 import dev.nokee.model.internal.registry.ModelRegistry;
@@ -85,6 +86,7 @@ public class CppLibraryPlugin implements Plugin<Project> {
 	}
 
 	public static ModelRegistration cppLibrary(String name, Project project) {
+		val identifier = ComponentIdentifier.builder().name(ComponentName.of(name)).displayName("C++ library").withProjectIdentifier(ProjectIdentifier.of(project)).build();
 		return new NativeLibraryComponentModelRegistrationFactory(CppLibrary.class, DefaultCppLibrary.class, project, (entity, path) -> {
 			val registry = project.getExtensions().getByType(ModelRegistry.class);
 
@@ -92,8 +94,8 @@ public class CppLibraryPlugin implements Plugin<Project> {
 			registry.register(project.getExtensions().getByType(CppHeaderSetRegistrationFactory.class).create(LanguageSourceSetIdentifier.of(entity.getComponent(ComponentIdentifier.class), "public")));
 			registry.register(project.getExtensions().getByType(CppHeaderSetRegistrationFactory.class).create(LanguageSourceSetIdentifier.of(entity.getComponent(ComponentIdentifier.class), "headers")));
 
-			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(path.child("sources"), CppLibrarySources.class));
-		}).create(ComponentIdentifier.builder().name(ComponentName.of(name)).displayName("C++ library").withProjectIdentifier(ProjectIdentifier.of(project)).build());
+			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "sources"), CppLibrarySources.class));
+		}).create(identifier);
 	}
 
 	public static abstract class DefaultCppLibrary implements CppLibrary

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/IosApplicationComponentModelRegistrationFactory.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/IosApplicationComponentModelRegistrationFactory.java
@@ -24,6 +24,7 @@ import dev.nokee.model.DomainObjectProvider;
 import dev.nokee.model.NamedDomainObjectRegistry;
 import dev.nokee.model.PolymorphicDomainObjectRegistry;
 import dev.nokee.model.internal.DomainObjectEventPublisher;
+import dev.nokee.model.internal.ModelPropertyIdentifier;
 import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.model.internal.core.*;
 import dev.nokee.model.internal.registry.ModelLookup;
@@ -118,7 +119,7 @@ public final class IosApplicationComponentModelRegistrationFactory {
 						sourceRegistration.accept(entity, path);
 
 						val bucketFactory = new DeclarableDependencyBucketRegistrationFactory(NamedDomainObjectRegistry.of(project.getConfigurations()), new FrameworkAwareDependencyBucketFactory(project.getObjects(), new DefaultDependencyBucketFactory(NamedDomainObjectRegistry.of(project.getConfigurations()), DependencyFactory.forProject(project))));
-						registry.register(project.getExtensions().getByType(ComponentDependenciesPropertyRegistrationFactory.class).create(path.child("dependencies"), NativeComponentDependencies.class, ModelBackedNativeComponentDependencies::new));
+						registry.register(project.getExtensions().getByType(ComponentDependenciesPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "dependencies"), NativeComponentDependencies.class, ModelBackedNativeComponentDependencies::new));
 
 						registry.register(bucketFactory.create(DependencyBucketIdentifier.of(declarable("implementation"), identifier)));
 						registry.register(bucketFactory.create(DependencyBucketIdentifier.of(declarable("compileOnly"), identifier)));
@@ -149,11 +150,11 @@ public final class IosApplicationComponentModelRegistrationFactory {
 							.build());
 						registry.register(dimensions.buildVariants(path.child("buildVariants"), buildVariants.get()));
 
-						registry.register(project.getExtensions().getByType(ComponentBinariesPropertyRegistrationFactory.class).create(path.child("binaries")));
+						registry.register(project.getExtensions().getByType(ComponentBinariesPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "binaries")));
 
-						registry.register(project.getExtensions().getByType(ComponentVariantsPropertyRegistrationFactory.class).create(path.child("variants"), DefaultIosApplicationVariant.class));
+						registry.register(project.getExtensions().getByType(ComponentVariantsPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "variants"), DefaultIosApplicationVariant.class));
 
-						registry.register(project.getExtensions().getByType(ComponentTasksPropertyRegistrationFactory.class).create(path.child("tasks")));
+						registry.register(project.getExtensions().getByType(ComponentTasksPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "tasks")));
 					}
 				}
 			}))
@@ -210,7 +211,7 @@ public final class IosApplicationComponentModelRegistrationFactory {
 			.action(self(discover()).apply(ModelActionWithInputs.of(ModelComponentReference.of(ModelPath.class), (entity, path) -> {
 				val registry = project.getExtensions().getByType(ModelRegistry.class);
 
-				val dependencies = registry.register(project.getExtensions().getByType(ComponentDependenciesPropertyRegistrationFactory.class).create(path.child("dependencies"), NativeComponentDependencies.class, ModelBackedNativeComponentDependencies::new));
+				val dependencies = registry.register(project.getExtensions().getByType(ComponentDependenciesPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "dependencies"), NativeComponentDependencies.class, ModelBackedNativeComponentDependencies::new));
 
 				val bucketFactory = new DeclarableDependencyBucketRegistrationFactory(NamedDomainObjectRegistry.of(project.getConfigurations()), new DefaultDependencyBucketFactory(NamedDomainObjectRegistry.of(project.getConfigurations()), DependencyFactory.forProject(project)));
 				val implementation = registry.register(bucketFactory.create(DependencyBucketIdentifier.of(declarable("implementation"), identifier)));
@@ -253,9 +254,9 @@ public final class IosApplicationComponentModelRegistrationFactory {
 				val incoming = entity.getComponent(NativeIncomingDependencies.class);
 				entity.addComponent(new VariantComponentDependencies<NativeComponentDependencies>(dependencies.as(NativeComponentDependencies.class)::get, incoming, outgoing));
 
-				registry.register(project.getExtensions().getByType(ComponentBinariesPropertyRegistrationFactory.class).create(path.child("binaries")));
+				registry.register(project.getExtensions().getByType(ComponentBinariesPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "binaries")));
 
-				registry.register(project.getExtensions().getByType(ComponentTasksPropertyRegistrationFactory.class).create(path.child("tasks")));
+				registry.register(project.getExtensions().getByType(ComponentTasksPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "tasks")));
 
 				val executableIdentifier = BinaryIdentifier.of(BinaryName.of("executable"), ExecutableBinaryInternal.class, identifier);
 				val executable = registry.register(ModelRegistration.builder()

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/ObjectiveCIosApplicationPlugin.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/ObjectiveCIosApplicationPlugin.java
@@ -28,6 +28,7 @@ import dev.nokee.language.objectivec.ObjectiveCSourceSet;
 import dev.nokee.language.objectivec.internal.plugins.ObjectiveCLanguageBasePlugin;
 import dev.nokee.language.objectivec.internal.plugins.ObjectiveCSourceSetRegistrationFactory;
 import dev.nokee.language.swift.internal.plugins.SwiftSourceSetRegistrationFactory;
+import dev.nokee.model.internal.ModelPropertyIdentifier;
 import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.model.internal.core.*;
 import dev.nokee.model.internal.registry.ModelConfigurer;
@@ -119,6 +120,7 @@ public class ObjectiveCIosApplicationPlugin implements Plugin<Project> {
 	}
 
 	public static ModelRegistration objectiveCIosApplication(String name, Project project) {
+		val identifier = ComponentIdentifier.builder().name(ComponentName.of(name)).displayName("Objective-C iOS application").withProjectIdentifier(ProjectIdentifier.of(project)).build();
 		return new IosApplicationComponentModelRegistrationFactory(ObjectiveCIosApplication.class, DefaultObjectiveCIosApplication.class, project, (entity, path) -> {
 			val registry = project.getExtensions().getByType(ModelRegistry.class);
 
@@ -126,14 +128,14 @@ public class ObjectiveCIosApplicationPlugin implements Plugin<Project> {
 			registry.register(project.getExtensions().getByType(CHeaderSetRegistrationFactory.class).create(LanguageSourceSetIdentifier.of(entity.getComponent(ComponentIdentifier.class), "headers")));
 			registry.register(project.getExtensions().getByType(IosResourceSetRegistrationFactory.class).create(LanguageSourceSetIdentifier.of(entity.getComponent(ComponentIdentifier.class), "resources")));
 
-			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(path.child("sources"), ObjectiveCIosApplicationSources.class));
+			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "sources"), ObjectiveCIosApplicationSources.class));
 
 			project.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelComponentReference.of(ModelPath.class), ModelComponentReference.of(ModelState.IsAtLeastRealized.class), ModelComponentReference.ofAny(ModelComponentType.projectionOf(ObjectiveCSourceSet.class)), (e, p, ignored, projection) -> {
 				if (path.isDescendant(p)) {
 					withConventionOf(maven(ComponentName.of(name)), defaultObjectiveCGradle(ComponentName.of(name))).accept(ModelNodeUtils.get(e, LanguageSourceSet.class));
 				}
 			}));
-		}).create(ComponentIdentifier.builder().name(ComponentName.of(name)).displayName("Objective-C iOS application").withProjectIdentifier(ProjectIdentifier.of(project)).build());
+		}).create(identifier);
 	}
 
 	public static abstract class DefaultObjectiveCIosApplication implements ObjectiveCIosApplication

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/SwiftIosApplicationPlugin.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/SwiftIosApplicationPlugin.java
@@ -19,6 +19,7 @@ import dev.nokee.language.base.internal.LanguageSourceSetIdentifier;
 import dev.nokee.language.swift.SwiftSourceSet;
 import dev.nokee.language.swift.internal.plugins.SwiftLanguageBasePlugin;
 import dev.nokee.language.swift.internal.plugins.SwiftSourceSetRegistrationFactory;
+import dev.nokee.model.internal.ModelPropertyIdentifier;
 import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.model.internal.core.ModelRegistration;
 import dev.nokee.model.internal.registry.ModelRegistry;
@@ -74,14 +75,15 @@ public class SwiftIosApplicationPlugin implements Plugin<Project> {
 	}
 
 	public static ModelRegistration swiftIosApplication(String name, Project project) {
+		val identifier = ComponentIdentifier.builder().name(ComponentName.of(name)).displayName("Swift iOS application").withProjectIdentifier(ProjectIdentifier.of(project)).build();
 		return new IosApplicationComponentModelRegistrationFactory(SwiftIosApplication.class, DefaultSwiftIosApplication.class, project, (entity, path) -> {
 			val registry = project.getExtensions().getByType(ModelRegistry.class);
 
 			registry.register(project.getExtensions().getByType(SwiftSourceSetRegistrationFactory.class).create(LanguageSourceSetIdentifier.of(entity.getComponent(ComponentIdentifier.class), "swift")));
 			registry.register(project.getExtensions().getByType(IosResourceSetRegistrationFactory.class).create(LanguageSourceSetIdentifier.of(entity.getComponent(ComponentIdentifier.class), "resources")));
 
-			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(path.child("sources"), SwiftIosApplicationSources.class));
-		}).create(ComponentIdentifier.builder().name(ComponentName.of(name)).displayName("Swift iOS application").withProjectIdentifier(ProjectIdentifier.of(project)).build());
+			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "sources"), SwiftIosApplicationSources.class));
+		}).create(identifier);
 	}
 
 	public static abstract class DefaultSwiftIosApplication implements SwiftIosApplication

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/plugins/JniLibraryPlugin.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/plugins/JniLibraryPlugin.java
@@ -42,6 +42,7 @@ import dev.nokee.model.KnownDomainObject;
 import dev.nokee.model.NamedDomainObjectRegistry;
 import dev.nokee.model.internal.DomainObjectDiscovered;
 import dev.nokee.model.internal.DomainObjectEventPublisher;
+import dev.nokee.model.internal.ModelPropertyIdentifier;
 import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.model.internal.core.*;
 import dev.nokee.model.internal.registry.ModelLookup;
@@ -549,7 +550,7 @@ public class JniLibraryPlugin implements Plugin<Project> {
 						// TODO: ONLY if applying include language plugin
 						registry.register(project.getExtensions().getByType(CHeaderSetRegistrationFactory.class).create(LanguageSourceSetIdentifier.of(entity.getComponent(ComponentIdentifier.class), "headers")));
 
-						registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(path.child("sources"), JavaNativeInterfaceLibrarySources.class));
+						registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "sources"), JavaNativeInterfaceLibrarySources.class));
 
 						val dependencyContainer = project.getObjects().newInstance(DefaultComponentDependencies.class, identifier, new FrameworkAwareDependencyBucketFactory(project.getObjects(), new DependencyBucketFactoryImpl(NamedDomainObjectRegistry.of(project.getConfigurations()), DependencyFactory.forProject(project))));
 						val dependencies = project.getObjects().newInstance(DefaultJavaNativeInterfaceLibraryComponentDependencies.class, dependencyContainer);
@@ -559,7 +560,7 @@ public class JniLibraryPlugin implements Plugin<Project> {
 							.withComponent(ModelProjections.ofInstance(dependencies))
 							.build());
 
-						registry.register(project.getExtensions().getByType(ComponentVariantsPropertyRegistrationFactory.class).create(path.child("variants"), JniLibrary.class));
+						registry.register(project.getExtensions().getByType(ComponentVariantsPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "variants"), JniLibrary.class));
 
 						registry.register(ModelRegistration.builder()
 							.withComponent(path.child("binaries"))

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/NativeApplicationComponentModelRegistrationFactory.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/NativeApplicationComponentModelRegistrationFactory.java
@@ -21,6 +21,7 @@ import dev.nokee.model.DependencyFactory;
 import dev.nokee.model.DomainObjectProvider;
 import dev.nokee.model.NamedDomainObjectRegistry;
 import dev.nokee.model.PolymorphicDomainObjectRegistry;
+import dev.nokee.model.internal.ModelPropertyIdentifier;
 import dev.nokee.model.internal.core.*;
 import dev.nokee.model.internal.registry.ModelRegistry;
 import dev.nokee.model.internal.state.ModelState;
@@ -29,7 +30,9 @@ import dev.nokee.model.internal.type.TypeOf;
 import dev.nokee.platform.base.BuildVariant;
 import dev.nokee.platform.base.Component;
 import dev.nokee.platform.base.internal.*;
-import dev.nokee.platform.base.internal.dependencies.*;
+import dev.nokee.platform.base.internal.dependencies.DeclarableDependencyBucketRegistrationFactory;
+import dev.nokee.platform.base.internal.dependencies.DefaultDependencyBucketFactory;
+import dev.nokee.platform.base.internal.dependencies.DependencyBucketIdentifier;
 import dev.nokee.platform.nativebase.NativeApplication;
 import dev.nokee.platform.nativebase.NativeApplicationComponentDependencies;
 import dev.nokee.platform.nativebase.internal.dependencies.FrameworkAwareDependencyBucketFactory;
@@ -98,7 +101,7 @@ public final class NativeApplicationComponentModelRegistrationFactory {
 						sourceRegistration.accept(entity, path);
 
 						val bucketFactory = new DeclarableDependencyBucketRegistrationFactory(NamedDomainObjectRegistry.of(project.getConfigurations()), new FrameworkAwareDependencyBucketFactory(project.getObjects(), new DefaultDependencyBucketFactory(NamedDomainObjectRegistry.of(project.getConfigurations()), DependencyFactory.forProject(project))));
-						registry.register(project.getExtensions().getByType(ComponentDependenciesPropertyRegistrationFactory.class).create(path.child("dependencies"), NativeApplicationComponentDependencies.class, ModelBackedNativeApplicationComponentDependencies::new));
+						registry.register(project.getExtensions().getByType(ComponentDependenciesPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "dependencies"), NativeApplicationComponentDependencies.class, ModelBackedNativeApplicationComponentDependencies::new));
 
 						registry.register(bucketFactory.create(DependencyBucketIdentifier.of(declarable("implementation"), identifier)));
 						registry.register(bucketFactory.create(DependencyBucketIdentifier.of(declarable("compileOnly"), identifier)));
@@ -129,11 +132,11 @@ public final class NativeApplicationComponentModelRegistrationFactory {
 							.build());
 						registry.register(dimensions.buildVariants(path.child("buildVariants"), buildVariants.get()));
 
-						registry.register(project.getExtensions().getByType(ComponentVariantsPropertyRegistrationFactory.class).create(path.child("variants"), NativeApplication.class));
+						registry.register(project.getExtensions().getByType(ComponentVariantsPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "variants"), NativeApplication.class));
 
-						registry.register(project.getExtensions().getByType(ComponentBinariesPropertyRegistrationFactory.class).create(path.child("binaries")));
+						registry.register(project.getExtensions().getByType(ComponentBinariesPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "binaries")));
 
-						registry.register(project.getExtensions().getByType(ComponentTasksPropertyRegistrationFactory.class).create(path.child("tasks")));
+						registry.register(project.getExtensions().getByType(ComponentTasksPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "tasks")));
 					}
 				}
 			}))

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/NativeLibraryComponentModelRegistrationFactory.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/NativeLibraryComponentModelRegistrationFactory.java
@@ -25,6 +25,7 @@ import dev.nokee.model.DependencyFactory;
 import dev.nokee.model.DomainObjectProvider;
 import dev.nokee.model.NamedDomainObjectRegistry;
 import dev.nokee.model.PolymorphicDomainObjectRegistry;
+import dev.nokee.model.internal.ModelPropertyIdentifier;
 import dev.nokee.model.internal.core.*;
 import dev.nokee.model.internal.registry.ModelLookup;
 import dev.nokee.model.internal.registry.ModelRegistry;
@@ -34,7 +35,9 @@ import dev.nokee.model.internal.type.TypeOf;
 import dev.nokee.platform.base.BuildVariant;
 import dev.nokee.platform.base.Component;
 import dev.nokee.platform.base.internal.*;
-import dev.nokee.platform.base.internal.dependencies.*;
+import dev.nokee.platform.base.internal.dependencies.DeclarableDependencyBucketRegistrationFactory;
+import dev.nokee.platform.base.internal.dependencies.DefaultDependencyBucketFactory;
+import dev.nokee.platform.base.internal.dependencies.DependencyBucketIdentifier;
 import dev.nokee.platform.nativebase.NativeBinary;
 import dev.nokee.platform.nativebase.NativeLibrary;
 import dev.nokee.platform.nativebase.NativeLibraryComponentDependencies;
@@ -111,7 +114,7 @@ public final class NativeLibraryComponentModelRegistrationFactory {
 						sourceRegistration.accept(entity, path);
 
 						val bucketFactory = new DeclarableDependencyBucketRegistrationFactory(NamedDomainObjectRegistry.of(project.getConfigurations()), new FrameworkAwareDependencyBucketFactory(project.getObjects(), new DefaultDependencyBucketFactory(NamedDomainObjectRegistry.of(project.getConfigurations()), DependencyFactory.forProject(project))));
-						registry.register(project.getExtensions().getByType(ComponentDependenciesPropertyRegistrationFactory.class).create(path.child("dependencies"), NativeLibraryComponentDependencies.class, ModelBackedNativeLibraryComponentDependencies::new));
+						registry.register(project.getExtensions().getByType(ComponentDependenciesPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "dependencies"), NativeLibraryComponentDependencies.class, ModelBackedNativeLibraryComponentDependencies::new));
 
 						registry.register(bucketFactory.create(DependencyBucketIdentifier.of(declarable("api"), identifier)));
 						registry.register(bucketFactory.create(DependencyBucketIdentifier.of(declarable("implementation"), identifier)));
@@ -143,11 +146,11 @@ public final class NativeLibraryComponentModelRegistrationFactory {
 							.build());
 						registry.register(dimensions.buildVariants(path.child("buildVariants"), buildVariants.get()));
 
-						registry.register(project.getExtensions().getByType(ComponentVariantsPropertyRegistrationFactory.class).create(path.child("variants"), NativeLibrary.class));
+						registry.register(project.getExtensions().getByType(ComponentVariantsPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "variants"), NativeLibrary.class));
 
-						registry.register(project.getExtensions().getByType(ComponentBinariesPropertyRegistrationFactory.class).create(path.child("binaries")));
+						registry.register(project.getExtensions().getByType(ComponentBinariesPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "binaries")));
 
-						registry.register(project.getExtensions().getByType(ComponentTasksPropertyRegistrationFactory.class).create(path.child("tasks")));
+						registry.register(project.getExtensions().getByType(ComponentTasksPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "tasks")));
 					}
 				}
 			}))

--- a/subprojects/platform-objective-c/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCApplicationPlugin.java
+++ b/subprojects/platform-objective-c/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCApplicationPlugin.java
@@ -26,6 +26,7 @@ import dev.nokee.language.nativebase.internal.toolchains.NokeeStandardToolChains
 import dev.nokee.language.objectivec.ObjectiveCSourceSet;
 import dev.nokee.language.objectivec.internal.plugins.ObjectiveCLanguageBasePlugin;
 import dev.nokee.language.objectivec.internal.plugins.ObjectiveCSourceSetRegistrationFactory;
+import dev.nokee.model.internal.ModelPropertyIdentifier;
 import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.model.internal.core.*;
 import dev.nokee.model.internal.registry.ModelConfigurer;
@@ -87,20 +88,21 @@ public class ObjectiveCApplicationPlugin implements Plugin<Project> {
 	}
 
 	public static ModelRegistration objectiveCApplication(String name, Project project) {
+		val identifier = ComponentIdentifier.builder().name(ComponentName.of(name)).displayName("Objective-C application").withProjectIdentifier(ProjectIdentifier.of(project)).build();
 		return new NativeApplicationComponentModelRegistrationFactory(ObjectiveCApplication.class, DefaultObjectiveCApplication.class, project, (entity, path) -> {
 			val registry = project.getExtensions().getByType(ModelRegistry.class);
 
 			registry.register(project.getExtensions().getByType(ObjectiveCSourceSetRegistrationFactory.class).create(LanguageSourceSetIdentifier.of(entity.getComponent(ComponentIdentifier.class), "objectiveC")));
 			registry.register(project.getExtensions().getByType(CHeaderSetRegistrationFactory.class).create(LanguageSourceSetIdentifier.of(entity.getComponent(ComponentIdentifier.class), "headers")));
 
-			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(path.child("sources"), ObjectiveCApplicationSources.class));
+			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "sources"), ObjectiveCApplicationSources.class));
 
 			project.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelComponentReference.of(ModelPath.class), ModelComponentReference.of(ModelState.IsAtLeastRealized.class), ModelComponentReference.ofAny(ModelComponentType.projectionOf(ObjectiveCSourceSet.class)), (e, p, ignored, projection) -> {
 				if (path.isDescendant(p)) {
 					withConventionOf(maven(ComponentName.of(name)), defaultObjectiveCGradle(ComponentName.of(name))).accept(ModelNodeUtils.get(e, LanguageSourceSet.class));
 				}
 			}));
-		}).create(ComponentIdentifier.builder().name(ComponentName.of(name)).displayName("Objective-C application").withProjectIdentifier(ProjectIdentifier.of(project)).build());
+		}).create(identifier);
 	}
 
 	public static abstract class DefaultObjectiveCApplication implements ObjectiveCApplication

--- a/subprojects/platform-objective-c/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCLibraryPlugin.java
+++ b/subprojects/platform-objective-c/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCLibraryPlugin.java
@@ -26,6 +26,7 @@ import dev.nokee.language.nativebase.internal.toolchains.NokeeStandardToolChains
 import dev.nokee.language.objectivec.ObjectiveCSourceSet;
 import dev.nokee.language.objectivec.internal.plugins.ObjectiveCLanguageBasePlugin;
 import dev.nokee.language.objectivec.internal.plugins.ObjectiveCSourceSetRegistrationFactory;
+import dev.nokee.model.internal.ModelPropertyIdentifier;
 import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.model.internal.core.*;
 import dev.nokee.model.internal.registry.ModelConfigurer;
@@ -89,6 +90,7 @@ public class ObjectiveCLibraryPlugin implements Plugin<Project> {
 	}
 
 	public static ModelRegistration objectiveCLibrary(String name, Project project) {
+		val identifier = ComponentIdentifier.builder().name(ComponentName.of(name)).displayName("Objective-C library").withProjectIdentifier(ProjectIdentifier.of(project)).build();
 		return new NativeLibraryComponentModelRegistrationFactory(ObjectiveCLibrary.class, DefaultObjectiveCLibrary.class, project, (entity, path) -> {
 			val registry = project.getExtensions().getByType(ModelRegistry.class);
 
@@ -97,14 +99,14 @@ public class ObjectiveCLibraryPlugin implements Plugin<Project> {
 			registry.register(project.getExtensions().getByType(CHeaderSetRegistrationFactory.class).create(LanguageSourceSetIdentifier.of(entity.getComponent(ComponentIdentifier.class), "public")));
 			registry.register(project.getExtensions().getByType(CHeaderSetRegistrationFactory.class).create(LanguageSourceSetIdentifier.of(entity.getComponent(ComponentIdentifier.class), "headers")));
 
-			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(path.child("sources"), ObjectiveCLibrarySources.class));
+			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "sources"), ObjectiveCLibrarySources.class));
 
 			project.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelComponentReference.of(ModelPath.class), ModelComponentReference.of(ModelState.IsAtLeastRealized.class), ModelComponentReference.ofAny(ModelComponentType.projectionOf(ObjectiveCSourceSet.class)), (e, p, ignored, projection) -> {
 				if (path.isDescendant(p)) {
 					withConventionOf(maven(ComponentName.of(name)), defaultObjectiveCGradle(ComponentName.of(name))).accept(ModelNodeUtils.get(e, LanguageSourceSet.class));
 				}
 			}));
-		}).create(ComponentIdentifier.builder().name(ComponentName.of(name)).displayName("Objective-C library").withProjectIdentifier(ProjectIdentifier.of(project)).build());
+		}).create(identifier);
 	}
 
 	public static abstract class DefaultObjectiveCLibrary implements ObjectiveCLibrary

--- a/subprojects/platform-objective-cpp/src/main/java/dev/nokee/platform/objectivecpp/internal/plugins/ObjectiveCppApplicationPlugin.java
+++ b/subprojects/platform-objective-cpp/src/main/java/dev/nokee/platform/objectivecpp/internal/plugins/ObjectiveCppApplicationPlugin.java
@@ -26,6 +26,7 @@ import dev.nokee.language.nativebase.internal.toolchains.NokeeStandardToolChains
 import dev.nokee.language.objectivecpp.ObjectiveCppSourceSet;
 import dev.nokee.language.objectivecpp.internal.plugins.ObjectiveCppLanguageBasePlugin;
 import dev.nokee.language.objectivecpp.internal.plugins.ObjectiveCppSourceSetRegistrationFactory;
+import dev.nokee.model.internal.ModelPropertyIdentifier;
 import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.model.internal.core.*;
 import dev.nokee.model.internal.registry.ModelConfigurer;
@@ -88,6 +89,7 @@ public class ObjectiveCppApplicationPlugin implements Plugin<Project> {
 	}
 
 	public static ModelRegistration objectiveCppApplication(String name, Project project) {
+		val identifier = ComponentIdentifier.builder().name(ComponentName.of(name)).displayName("Objective-C++ application").withProjectIdentifier(ProjectIdentifier.of(project)).build();
 		return new NativeApplicationComponentModelRegistrationFactory(ObjectiveCppApplication.class, DefaultObjectiveCppApplication.class, project, (entity, path) -> {
 			val registry = project.getExtensions().getByType(ModelRegistry.class);
 
@@ -95,14 +97,14 @@ public class ObjectiveCppApplicationPlugin implements Plugin<Project> {
 
 			registry.register(project.getExtensions().getByType(CppHeaderSetRegistrationFactory.class).create(LanguageSourceSetIdentifier.of(entity.getComponent(ComponentIdentifier.class), "headers")));
 
-			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(path.child("sources"), ObjectiveCppApplicationSources.class));
+			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "sources"), ObjectiveCppApplicationSources.class));
 
 			project.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelComponentReference.of(ModelPath.class), ModelComponentReference.of(ModelState.IsAtLeastRealized.class), ModelComponentReference.ofAny(ModelComponentType.projectionOf(ObjectiveCppSourceSet.class)), (e, p, ignored, projection) -> {
 				if (path.isDescendant(p)) {
 					withConventionOf(maven(ComponentName.of(name)), defaultObjectiveCppGradle(ComponentName.of(name))).accept(ModelNodeUtils.get(e, LanguageSourceSet.class));
 				}
 			}));
-		}).create(ComponentIdentifier.builder().name(ComponentName.of(name)).displayName("Objective-C++ application").withProjectIdentifier(ProjectIdentifier.of(project)).build());
+		}).create(identifier);
 	}
 
 	public static abstract class DefaultObjectiveCppApplication implements ObjectiveCppApplication

--- a/subprojects/platform-objective-cpp/src/main/java/dev/nokee/platform/objectivecpp/internal/plugins/ObjectiveCppLibraryPlugin.java
+++ b/subprojects/platform-objective-cpp/src/main/java/dev/nokee/platform/objectivecpp/internal/plugins/ObjectiveCppLibraryPlugin.java
@@ -26,6 +26,7 @@ import dev.nokee.language.nativebase.internal.toolchains.NokeeStandardToolChains
 import dev.nokee.language.objectivecpp.ObjectiveCppSourceSet;
 import dev.nokee.language.objectivecpp.internal.plugins.ObjectiveCppLanguageBasePlugin;
 import dev.nokee.language.objectivecpp.internal.plugins.ObjectiveCppSourceSetRegistrationFactory;
+import dev.nokee.model.internal.ModelPropertyIdentifier;
 import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.model.internal.core.*;
 import dev.nokee.model.internal.registry.ModelConfigurer;
@@ -90,6 +91,7 @@ public class ObjectiveCppLibraryPlugin implements Plugin<Project> {
 	}
 
 	public static ModelRegistration objectiveCppLibrary(String name, Project project) {
+		val identifier = ComponentIdentifier.builder().name(ComponentName.of(name)).displayName("Objective-C++ library").withProjectIdentifier(ProjectIdentifier.of(project)).build();
 		return new NativeLibraryComponentModelRegistrationFactory(ObjectiveCppLibrary.class, DefaultObjectiveCppLibrary.class, project, (entity, path) -> {
 			val registry = project.getExtensions().getByType(ModelRegistry.class);
 
@@ -98,14 +100,14 @@ public class ObjectiveCppLibraryPlugin implements Plugin<Project> {
 			registry.register(project.getExtensions().getByType(CppHeaderSetRegistrationFactory.class).create(LanguageSourceSetIdentifier.of(entity.getComponent(ComponentIdentifier.class), "public")));
 			registry.register(project.getExtensions().getByType(CppHeaderSetRegistrationFactory.class).create(LanguageSourceSetIdentifier.of(entity.getComponent(ComponentIdentifier.class), "headers")));
 
-			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(path.child("sources"), ObjectiveCppLibrarySources.class));
+			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "sources"), ObjectiveCppLibrarySources.class));
 
 			project.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelComponentReference.of(ModelPath.class), ModelComponentReference.of(ModelState.IsAtLeastRealized.class), ModelComponentReference.ofAny(ModelComponentType.projectionOf(ObjectiveCppSourceSet.class)), (e, p, ignored, projection) -> {
 				if (path.isDescendant(p)) {
 					withConventionOf(maven(ComponentName.of(name)), defaultObjectiveCppGradle(ComponentName.of(name))).accept(ModelNodeUtils.get(e, LanguageSourceSet.class));
 				}
 			}));
-		}).create(ComponentIdentifier.builder().name(ComponentName.of(name)).displayName("Objective-C++ library").withProjectIdentifier(ProjectIdentifier.of(project)).build());
+		}).create(identifier);
 	}
 
 	public static abstract class DefaultObjectiveCppLibrary implements ObjectiveCppLibrary

--- a/subprojects/platform-swift/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftApplicationPlugin.java
+++ b/subprojects/platform-swift/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftApplicationPlugin.java
@@ -19,6 +19,7 @@ import dev.nokee.language.base.internal.LanguageSourceSetIdentifier;
 import dev.nokee.language.swift.SwiftSourceSet;
 import dev.nokee.language.swift.internal.plugins.SwiftLanguageBasePlugin;
 import dev.nokee.language.swift.internal.plugins.SwiftSourceSetRegistrationFactory;
+import dev.nokee.model.internal.ModelPropertyIdentifier;
 import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.model.internal.core.ModelRegistration;
 import dev.nokee.model.internal.registry.ModelRegistry;
@@ -76,13 +77,14 @@ public class SwiftApplicationPlugin implements Plugin<Project> {
 	}
 
 	public static ModelRegistration swiftApplication(String name, Project project) {
+		val identifier = ComponentIdentifier.builder().name(ComponentName.of(name)).displayName("Swift application").withProjectIdentifier(ProjectIdentifier.of(project)).build();
 		return new NativeApplicationComponentModelRegistrationFactory(SwiftApplication.class, DefaultSwiftApplication.class, project, (entity, path) -> {
 			val registry = project.getExtensions().getByType(ModelRegistry.class);
 
 			registry.register(project.getExtensions().getByType(SwiftSourceSetRegistrationFactory.class).create(LanguageSourceSetIdentifier.of(entity.getComponent(ComponentIdentifier.class), "swift")));
 
-			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(path.child("sources"), SwiftApplicationSources.class));
-		}).create(ComponentIdentifier.builder().name(ComponentName.of(name)).displayName("Swift application").withProjectIdentifier(ProjectIdentifier.of(project)).build());
+			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "sources"), SwiftApplicationSources.class));
+		}).create(identifier);
 	}
 
 	public static abstract class DefaultSwiftApplication implements SwiftApplication

--- a/subprojects/platform-swift/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftLibraryPlugin.java
+++ b/subprojects/platform-swift/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftLibraryPlugin.java
@@ -19,6 +19,7 @@ import dev.nokee.language.base.internal.LanguageSourceSetIdentifier;
 import dev.nokee.language.swift.SwiftSourceSet;
 import dev.nokee.language.swift.internal.plugins.SwiftLanguageBasePlugin;
 import dev.nokee.language.swift.internal.plugins.SwiftSourceSetRegistrationFactory;
+import dev.nokee.model.internal.ModelPropertyIdentifier;
 import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.model.internal.core.ModelRegistration;
 import dev.nokee.model.internal.registry.ModelRegistry;
@@ -77,13 +78,14 @@ public class SwiftLibraryPlugin implements Plugin<Project> {
 	}
 
 	public static ModelRegistration swiftLibrary(String name, Project project) {
+		val identifier = ComponentIdentifier.builder().name(ComponentName.of(name)).displayName("Swift library").withProjectIdentifier(ProjectIdentifier.of(project)).build();
 		return new NativeLibraryComponentModelRegistrationFactory(SwiftLibrary.class, DefaultSwiftLibrary.class, project, (entity, path) -> {
 			val registry = project.getExtensions().getByType(ModelRegistry.class);
 
 			registry.register(project.getExtensions().getByType(SwiftSourceSetRegistrationFactory.class).create(LanguageSourceSetIdentifier.of(entity.getComponent(ComponentIdentifier.class), "swift")));
 
-			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(path.child("sources"), SwiftLibrarySources.class));
-		}).create(ComponentIdentifier.builder().name(ComponentName.of(name)).displayName("Swift library").withProjectIdentifier(ProjectIdentifier.of(project)).build());
+			registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "sources"), SwiftLibrarySources.class));
+		}).create(identifier);
 	}
 
 	public static abstract class DefaultSwiftLibrary implements SwiftLibrary

--- a/subprojects/testing-base/src/main/java/dev/nokee/testing/base/internal/plugins/TestingBasePlugin.java
+++ b/subprojects/testing-base/src/main/java/dev/nokee/testing/base/internal/plugins/TestingBasePlugin.java
@@ -15,6 +15,8 @@
  */
 package dev.nokee.testing.base.internal.plugins;
 
+import dev.nokee.model.internal.ModelPropertyIdentifier;
+import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.model.internal.core.*;
 import dev.nokee.model.internal.registry.ModelConfigurer;
 import dev.nokee.model.internal.registry.ModelLookup;
@@ -47,7 +49,7 @@ public class TestingBasePlugin implements Plugin<Project> {
 		val propertyFactory = project.getExtensions().getByType(ModelPropertyRegistrationFactory.class);
 		project.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelComponentReference.of(ModelPath.class), ModelComponentReference.of(ModelState.IsAtLeastCreated.class), ModelComponentReference.of(IsTestComponent.class), ModelComponentReference.ofAny(ModelComponentType.projectionOf(TestSuiteComponent.class)), (e, p, ignored1, ignored2, projection) -> {
 			if (ModelPath.root().isDirectDescendant(p)) {
-				modeRegistry.register(propertyFactory.create(ModelPath.path("testSuites").child(p.getName()), e));
+				modeRegistry.register(propertyFactory.create(ModelPropertyIdentifier.of(ModelPropertyIdentifier.of(ProjectIdentifier.of(project), "testSuites"), p.getName()), e));
 			}
 		}));
 

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/plugins/ObjectiveCXCTestTestSuitePlugin.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/plugins/ObjectiveCXCTestTestSuitePlugin.java
@@ -22,6 +22,8 @@ import dev.nokee.language.base.internal.BaseLanguageSourceSetProjection;
 import dev.nokee.language.base.internal.IsLanguageSourceSet;
 import dev.nokee.language.base.internal.LanguageSourceSetIdentifier;
 import dev.nokee.language.c.CHeaderSet;
+import dev.nokee.language.c.internal.plugins.CHeaderSetRegistrationFactory;
+import dev.nokee.language.c.internal.plugins.CSourceSetRegistrationFactory;
 import dev.nokee.language.objectivec.ObjectiveCSourceSet;
 import dev.nokee.language.objectivec.internal.plugins.ObjectiveCSourceSetRegistrationFactory;
 import dev.nokee.language.swift.SwiftSourceSet;
@@ -161,14 +163,7 @@ public class ObjectiveCXCTestTestSuitePlugin implements Plugin<Project> {
 						val propertyFactory = project.getExtensions().getByType(ModelPropertyRegistrationFactory.class);
 
 						registry.register(project.getExtensions().getByType(ObjectiveCSourceSetRegistrationFactory.class).create(LanguageSourceSetIdentifier.of(entity.getComponent(ComponentIdentifier.class), "objectiveC")));
-
-						// TODO: Should be created using CHeaderSetSpec
-						val headers = registry.register(ModelRegistration.builder()
-							.withComponent(path.child("headers"))
-							.withComponent(IsLanguageSourceSet.tag())
-							.withComponent(managed(of(CHeaderSet.class)))
-							.withComponent(managed(of(BaseLanguageSourceSetProjection.class)))
-							.build());
+						registry.register(project.getExtensions().getByType(CHeaderSetRegistrationFactory.class).create(LanguageSourceSetIdentifier.of(entity.getComponent(ComponentIdentifier.class), "headers")));
 
 						registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(path.child("sources"), NativeApplicationSources.class));
 
@@ -303,14 +298,7 @@ public class ObjectiveCXCTestTestSuitePlugin implements Plugin<Project> {
 						val registry = project.getExtensions().getByType(ModelRegistry.class);
 
 						registry.register(project.getExtensions().getByType(ObjectiveCSourceSetRegistrationFactory.class).create(LanguageSourceSetIdentifier.of(entity.getComponent(ComponentIdentifier.class), "objectiveC")));
-
-						// TODO: Should be created using CHeaderSetSpec
-						registry.register(ModelRegistration.builder()
-							.withComponent(path.child("headers"))
-							.withComponent(IsLanguageSourceSet.tag())
-							.withComponent(managed(of(CHeaderSet.class)))
-							.withComponent(managed(of(BaseLanguageSourceSetProjection.class)))
-							.build());
+						registry.register(project.getExtensions().getByType(CHeaderSetRegistrationFactory.class).create(LanguageSourceSetIdentifier.of(entity.getComponent(ComponentIdentifier.class), "headers")));
 
 						registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(path.child("sources"), NativeApplicationSources.class));
 

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/plugins/ObjectiveCXCTestTestSuitePlugin.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/plugins/ObjectiveCXCTestTestSuitePlugin.java
@@ -29,6 +29,7 @@ import dev.nokee.language.objectivec.internal.plugins.ObjectiveCSourceSetRegistr
 import dev.nokee.language.swift.SwiftSourceSet;
 import dev.nokee.model.*;
 import dev.nokee.model.internal.DomainObjectEventPublisher;
+import dev.nokee.model.internal.ModelPropertyIdentifier;
 import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.model.internal.core.*;
 import dev.nokee.model.internal.registry.ModelLookup;
@@ -165,16 +166,16 @@ public class ObjectiveCXCTestTestSuitePlugin implements Plugin<Project> {
 						registry.register(project.getExtensions().getByType(ObjectiveCSourceSetRegistrationFactory.class).create(LanguageSourceSetIdentifier.of(entity.getComponent(ComponentIdentifier.class), "objectiveC")));
 						registry.register(project.getExtensions().getByType(CHeaderSetRegistrationFactory.class).create(LanguageSourceSetIdentifier.of(entity.getComponent(ComponentIdentifier.class), "headers")));
 
-						registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(path.child("sources"), NativeApplicationSources.class));
+						registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "sources"), NativeApplicationSources.class));
 
-						registry.register(project.getExtensions().getByType(ComponentBinariesPropertyRegistrationFactory.class).create(path.child("binaries")));
+						registry.register(project.getExtensions().getByType(ComponentBinariesPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "binaries")));
 
-						registry.register(project.getExtensions().getByType(ComponentVariantsPropertyRegistrationFactory.class).create(path.child("variants"), DefaultXCTestTestSuiteVariant.class));
+						registry.register(project.getExtensions().getByType(ComponentVariantsPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "variants"), DefaultXCTestTestSuiteVariant.class));
 
-						registry.register(project.getExtensions().getByType(ComponentTasksPropertyRegistrationFactory.class).create(path.child("tasks")));
+						registry.register(project.getExtensions().getByType(ComponentTasksPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "tasks")));
 
 						val bucketFactory = new DeclarableDependencyBucketRegistrationFactory(NamedDomainObjectRegistry.of(project.getConfigurations()), new FrameworkAwareDependencyBucketFactory(project.getObjects(), new DefaultDependencyBucketFactory(NamedDomainObjectRegistry.of(project.getConfigurations()), DependencyFactory.forProject(project))));
-						registry.register(project.getExtensions().getByType(ComponentDependenciesPropertyRegistrationFactory.class).create(path.child("dependencies"), NativeComponentDependencies.class, ModelBackedNativeComponentDependencies::new));
+						registry.register(project.getExtensions().getByType(ComponentDependenciesPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "dependencies"), NativeComponentDependencies.class, ModelBackedNativeComponentDependencies::new));
 
 						registry.register(bucketFactory.create(DependencyBucketIdentifier.of(declarable("implementation"), identifier)));
 						registry.register(bucketFactory.create(DependencyBucketIdentifier.of(declarable("compileOnly"), identifier)));
@@ -300,16 +301,16 @@ public class ObjectiveCXCTestTestSuitePlugin implements Plugin<Project> {
 						registry.register(project.getExtensions().getByType(ObjectiveCSourceSetRegistrationFactory.class).create(LanguageSourceSetIdentifier.of(entity.getComponent(ComponentIdentifier.class), "objectiveC")));
 						registry.register(project.getExtensions().getByType(CHeaderSetRegistrationFactory.class).create(LanguageSourceSetIdentifier.of(entity.getComponent(ComponentIdentifier.class), "headers")));
 
-						registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(path.child("sources"), NativeApplicationSources.class));
+						registry.register(project.getExtensions().getByType(ComponentSourcesPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "sources"), NativeApplicationSources.class));
 
-						registry.register(project.getExtensions().getByType(ComponentBinariesPropertyRegistrationFactory.class).create(path.child("binaries")));
+						registry.register(project.getExtensions().getByType(ComponentBinariesPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "binaries")));
 
-						registry.register(project.getExtensions().getByType(ComponentVariantsPropertyRegistrationFactory.class).create(path.child("variants"), DefaultXCTestTestSuiteVariant.class));
+						registry.register(project.getExtensions().getByType(ComponentVariantsPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "variants"), DefaultXCTestTestSuiteVariant.class));
 
-						registry.register(project.getExtensions().getByType(ComponentTasksPropertyRegistrationFactory.class).create(path.child("tasks")));
+						registry.register(project.getExtensions().getByType(ComponentTasksPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "tasks")));
 
 						val bucketFactory = new DeclarableDependencyBucketRegistrationFactory(NamedDomainObjectRegistry.of(project.getConfigurations()), new FrameworkAwareDependencyBucketFactory(project.getObjects(), new DefaultDependencyBucketFactory(NamedDomainObjectRegistry.of(project.getConfigurations()), DependencyFactory.forProject(project))));
-						registry.register(project.getExtensions().getByType(ComponentDependenciesPropertyRegistrationFactory.class).create(path.child("dependencies"), NativeComponentDependencies.class, ModelBackedNativeComponentDependencies::new));
+						registry.register(project.getExtensions().getByType(ComponentDependenciesPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "dependencies"), NativeComponentDependencies.class, ModelBackedNativeComponentDependencies::new));
 
 						registry.register(bucketFactory.create(DependencyBucketIdentifier.of(declarable("implementation"), identifier)));
 						registry.register(bucketFactory.create(DependencyBucketIdentifier.of(declarable("compileOnly"), identifier)));
@@ -407,13 +408,13 @@ public class ObjectiveCXCTestTestSuitePlugin implements Plugin<Project> {
 		};
 	}
 
-	private static NodeRegistration xcTestTestSuiteVariant(VariantIdentifier<DefaultXCTestTestSuiteVariant> variantIdentifier, BaseXCTestTestSuiteComponent component, Project project) {
+	private static NodeRegistration xcTestTestSuiteVariant(VariantIdentifier<DefaultXCTestTestSuiteVariant> identifier, BaseXCTestTestSuiteComponent component, Project project) {
 		val taskRegistry = project.getExtensions().getByType(TaskRegistry.class);
-		val assembleTask = taskRegistry.registerIfAbsent(TaskIdentifier.of(TaskName.of(ASSEMBLE_TASK_NAME), variantIdentifier));
-		return NodeRegistration.unmanaged(variantIdentifier.getUnambiguousName(), of(DefaultXCTestTestSuiteVariant.class), () -> {
-			return project.getObjects().newInstance(DefaultXCTestTestSuiteVariant.class, variantIdentifier, project.getObjects(), project.getProviders(), assembleTask, project.getExtensions().getByType(BinaryViewFactory.class));
+		val assembleTask = taskRegistry.registerIfAbsent(TaskIdentifier.of(TaskName.of(ASSEMBLE_TASK_NAME), identifier));
+		return NodeRegistration.unmanaged(identifier.getUnambiguousName(), of(DefaultXCTestTestSuiteVariant.class), () -> {
+			return project.getObjects().newInstance(DefaultXCTestTestSuiteVariant.class, identifier, project.getObjects(), project.getProviders(), assembleTask, project.getExtensions().getByType(BinaryViewFactory.class));
 		})
-			.withComponent(variantIdentifier)
+			.withComponent(identifier)
 			.withComponent(IsVariant.tag())
 			.action(self().apply(once(ModelActionWithInputs.of(ModelComponentReference.of(ModelPath.class), (entity, path) -> {
 				entity.addComponent(new ModelBackedNativeIncomingDependencies(path, project.getObjects(), project.getProviders(), project.getExtensions().getByType(ModelLookup.class)));
@@ -421,13 +422,12 @@ public class ObjectiveCXCTestTestSuitePlugin implements Plugin<Project> {
 			.action(self(discover()).apply(ModelActionWithInputs.of(ModelComponentReference.of(ModelPath.class), (entity, path) -> {
 				val registry = project.getExtensions().getByType(ModelRegistry.class);
 
-				registry.register(project.getExtensions().getByType(ComponentBinariesPropertyRegistrationFactory.class).create(path.child("binaries")));
+				registry.register(project.getExtensions().getByType(ComponentBinariesPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "binaries")));
 
-				registry.register(project.getExtensions().getByType(ComponentTasksPropertyRegistrationFactory.class).create(path.child("tasks")));
+				registry.register(project.getExtensions().getByType(ComponentTasksPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "tasks")));
 
-				val dependencies = registry.register(project.getExtensions().getByType(ComponentDependenciesPropertyRegistrationFactory.class).create(path.child("dependencies"), NativeComponentDependencies.class, ModelBackedNativeComponentDependencies::new));
+				val dependencies = registry.register(project.getExtensions().getByType(ComponentDependenciesPropertyRegistrationFactory.class).create(ModelPropertyIdentifier.of(identifier, "dependencies"), NativeComponentDependencies.class, ModelBackedNativeComponentDependencies::new));
 
-				val identifier = variantIdentifier;
 				val bucketFactory = new DeclarableDependencyBucketRegistrationFactory(NamedDomainObjectRegistry.of(project.getConfigurations()), new DefaultDependencyBucketFactory(NamedDomainObjectRegistry.of(project.getConfigurations()), DependencyFactory.forProject(project)));
 				val implementation = registry.register(bucketFactory.create(DependencyBucketIdentifier.of(declarable("implementation"), identifier)));
 				val compileOnly = registry.register(bucketFactory.create(DependencyBucketIdentifier.of(declarable("compileOnly"), identifier)));


### PR DESCRIPTION
We want to eliminate the model path as a means to reference entities as they don't represent reality. For example, the model path `components.main.variants.windows.sources.c` would reference the C source set of the Windows variant of the main component for the project. The identifier would be `<project>.main.windows.c`. As elements and properties are two different things their reference is done differently and the universal model should account for that.