### PR TITLE
Use source set factory in unit tests

### DIFF
--- a/subprojects/language-base/language-base.gradle
+++ b/subprojects/language-base/language-base.gradle
@@ -21,6 +21,10 @@ dependencies {
 
 gradlePlugin {
 	plugins {
+		languageBase {
+			id = "dev.nokee.language-base"
+			implementationClass = "dev.nokee.language.base.internal.plugins.LanguageBasePlugin"
+		}
 	}
 }
 

--- a/subprojects/language-base/src/functionalTest/groovy/dev/nokee/language/base/LanguageBasePluginWellBehavedPluginTest.java
+++ b/subprojects/language-base/src/functionalTest/groovy/dev/nokee/language/base/LanguageBasePluginWellBehavedPluginTest.java
@@ -27,6 +27,7 @@ class LanguageBasePluginWellBehavedPluginTest {
 	@TestFactory
 	Stream<DynamicTest> checkWellBehavedPlugin() {
 		return new WellBehavedPluginTester()
+			.qualifiedPluginId("dev.nokee.language-base")
 			.pluginClass(LanguageBasePlugin.class)
 			.stream().map(TestCaseUtils::toJUnit5DynamicTest);
 	}

--- a/subprojects/language-c/language-c.gradle
+++ b/subprojects/language-c/language-c.gradle
@@ -18,6 +18,10 @@ dependencies {
 
 gradlePlugin {
 	plugins {
+		cLanguageBase {
+			id = 'dev.nokee.c-language-base'
+			implementationClass = 'dev.nokee.language.c.internal.plugins.CLanguageBasePlugin'
+		}
 		cLanguage {
 			id = 'dev.nokee.c-language'
 			implementationClass = 'dev.nokee.language.c.internal.plugins.CLanguagePlugin'

--- a/subprojects/language-c/src/functionalTest/groovy/dev/nokee/language/c/CLanguageBasePluginWellBehavedPluginTest.java
+++ b/subprojects/language-c/src/functionalTest/groovy/dev/nokee/language/c/CLanguageBasePluginWellBehavedPluginTest.java
@@ -27,6 +27,7 @@ class CLanguageBasePluginWellBehavedPluginTest {
 	@TestFactory
 	Stream<DynamicTest> checkWellBehavedPlugin() {
 		return new WellBehavedPluginTester()
+			.qualifiedPluginId("dev.nokee.c-language-base")
 			.pluginClass(CLanguageBasePlugin.class)
 			.stream().map(TestCaseUtils::toJUnit5DynamicTest);
 	}

--- a/subprojects/language-c/src/test/groovy/dev/nokee/language/c/CSourceSetTest.java
+++ b/subprojects/language-c/src/test/groovy/dev/nokee/language/c/CSourceSetTest.java
@@ -17,32 +17,31 @@ package dev.nokee.language.c;
 
 import dev.nokee.internal.testing.util.ProjectTestUtils;
 import dev.nokee.language.base.internal.LanguageSourceSetIdentifier;
-import dev.nokee.language.base.internal.LanguageSourceSetRegistrationFactory;
-import dev.nokee.language.base.internal.SourceSetFactory;
 import dev.nokee.language.base.testers.LanguageSourceSetTester;
 import dev.nokee.language.c.internal.plugins.CSourceSetRegistrationFactory;
-import dev.nokee.model.internal.registry.DefaultModelRegistry;
+import dev.nokee.model.internal.registry.ModelRegistry;
 import lombok.val;
 
 import java.io.File;
 
-import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
 import static dev.nokee.model.internal.ProjectIdentifier.ofRootProject;
 
 class CSourceSetTest extends LanguageSourceSetTester<CSourceSet> {
 	@Override
 	public CSourceSet createSubject() {
-		val objects = objectFactory();
-		val registry = new DefaultModelRegistry(objects::newInstance);
-		val factory = new CSourceSetRegistrationFactory(new LanguageSourceSetRegistrationFactory(objects, registry, new SourceSetFactory(objects)));
+		val project = ProjectTestUtils.rootProject();
+		project.getPluginManager().apply("dev.nokee.c-language-base");
+		val registry = project.getExtensions().getByType(ModelRegistry.class);
+		val factory = project.getExtensions().getByType(CSourceSetRegistrationFactory.class);
 		return registry.register(factory.create(LanguageSourceSetIdentifier.of(ofRootProject(), "test"))).as(CSourceSet.class).get();
 	}
 
 	@Override
 	public CSourceSet createSubject(File temporaryDirectory) {
-		val objects = ProjectTestUtils.createRootProject(temporaryDirectory).getObjects();
-		val registry = new DefaultModelRegistry(objects::newInstance);
-		val factory = new CSourceSetRegistrationFactory(new LanguageSourceSetRegistrationFactory(objects, registry, new SourceSetFactory(objects)));
+		val project = ProjectTestUtils.createRootProject(temporaryDirectory);
+		project.getPluginManager().apply("dev.nokee.c-language-base");
+		val registry = project.getExtensions().getByType(ModelRegistry.class);
+		val factory = project.getExtensions().getByType(CSourceSetRegistrationFactory.class);
 		return registry.register(factory.create(LanguageSourceSetIdentifier.of(ofRootProject(), "test"))).as(CSourceSet.class).get();
 	}
 }

--- a/subprojects/language-cpp/language-cpp.gradle
+++ b/subprojects/language-cpp/language-cpp.gradle
@@ -18,6 +18,10 @@ dependencies {
 
 gradlePlugin {
 	plugins {
+		cppLanguageBase {
+			id = 'dev.nokee.cpp-language-base'
+			implementationClass = 'dev.nokee.language.cpp.internal.plugins.CppLanguageBasePlugin'
+		}
 		cppLanguage {
 			id = 'dev.nokee.cpp-language'
 			implementationClass = 'dev.nokee.language.cpp.internal.plugins.CppLanguagePlugin'

--- a/subprojects/language-cpp/src/functionalTest/groovy/dev/nokee/language/cpp/CppLanguageBasePluginWellBehavedPluginTest.java
+++ b/subprojects/language-cpp/src/functionalTest/groovy/dev/nokee/language/cpp/CppLanguageBasePluginWellBehavedPluginTest.java
@@ -27,6 +27,7 @@ class CppLanguageBasePluginWellBehavedPluginTest {
 	@TestFactory
 	Stream<DynamicTest> checkWellBehavedPlugin() {
 		return new WellBehavedPluginTester()
+			.qualifiedPluginId("dev.nokee.cpp-language-base")
 			.pluginClass(CppLanguageBasePlugin.class)
 			.stream().map(TestCaseUtils::toJUnit5DynamicTest);
 	}

--- a/subprojects/language-cpp/src/test/groovy/dev/nokee/language/cpp/CppSourceSetTest.java
+++ b/subprojects/language-cpp/src/test/groovy/dev/nokee/language/cpp/CppSourceSetTest.java
@@ -17,33 +17,31 @@ package dev.nokee.language.cpp;
 
 import dev.nokee.internal.testing.util.ProjectTestUtils;
 import dev.nokee.language.base.internal.LanguageSourceSetIdentifier;
-import dev.nokee.language.base.internal.LanguageSourceSetRegistrationFactory;
-import dev.nokee.language.base.internal.SourceSetFactory;
 import dev.nokee.language.base.testers.LanguageSourceSetTester;
 import dev.nokee.language.cpp.internal.plugins.CppSourceSetRegistrationFactory;
-import dev.nokee.model.internal.registry.DefaultModelRegistry;
+import dev.nokee.model.internal.registry.ModelRegistry;
 import lombok.val;
 
 import java.io.File;
 
-import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
-import static dev.nokee.model.fixtures.ModelRegistryTestUtils.registry;
 import static dev.nokee.model.internal.ProjectIdentifier.ofRootProject;
 
 class CppSourceSetTest extends LanguageSourceSetTester<CppSourceSet> {
 	@Override
 	public CppSourceSet createSubject() {
-		val objects = objectFactory();
-		val registry = new DefaultModelRegistry(objects::newInstance);
-		val factory = new CppSourceSetRegistrationFactory(new LanguageSourceSetRegistrationFactory(objects, registry, new SourceSetFactory(objects)));
+		val project = ProjectTestUtils.rootProject();
+		project.getPluginManager().apply("dev.nokee.cpp-language-base");
+		val registry = project.getExtensions().getByType(ModelRegistry.class);
+		val factory = project.getExtensions().getByType(CppSourceSetRegistrationFactory.class);
 		return registry.register(factory.create(LanguageSourceSetIdentifier.of(ofRootProject(), "test"))).as(CppSourceSet.class).get();
 	}
 
 	@Override
 	public CppSourceSet createSubject(File temporaryDirectory) {
-		val objects = ProjectTestUtils.createRootProject(temporaryDirectory).getObjects();
-		val registry = new DefaultModelRegistry(objects::newInstance);
-		val factory = new CppSourceSetRegistrationFactory(new LanguageSourceSetRegistrationFactory(objects, registry, new SourceSetFactory(objects)));
+		val project = ProjectTestUtils.createRootProject(temporaryDirectory);
+		project.getPluginManager().apply("dev.nokee.cpp-language-base");
+		val registry = project.getExtensions().getByType(ModelRegistry.class);
+		val factory = project.getExtensions().getByType(CppSourceSetRegistrationFactory.class);
 		return registry.register(factory.create(LanguageSourceSetIdentifier.of(ofRootProject(), "test"))).as(CppSourceSet.class).get();
 	}
 }

--- a/subprojects/language-objective-c/language-objective-c.gradle
+++ b/subprojects/language-objective-c/language-objective-c.gradle
@@ -18,6 +18,10 @@ dependencies {
 
 gradlePlugin {
 	plugins {
+		objectiveCLanguageBase {
+			id = 'dev.nokee.objective-c-language-base'
+			implementationClass = 'dev.nokee.language.objectivec.internal.plugins.ObjectiveCLanguageBasePlugin'
+		}
 		objectiveCLanguage {
 			id = 'dev.nokee.objective-c-language'
 			implementationClass = 'dev.nokee.language.objectivec.internal.plugins.ObjectiveCLanguagePlugin'

--- a/subprojects/language-objective-c/src/functionalTest/groovy/dev/nokee/language/objectivec/ObjectiveCLanguageBasePluginWellBehavedPluginTest.java
+++ b/subprojects/language-objective-c/src/functionalTest/groovy/dev/nokee/language/objectivec/ObjectiveCLanguageBasePluginWellBehavedPluginTest.java
@@ -27,6 +27,7 @@ class ObjectiveCLanguageBasePluginWellBehavedPluginTest {
 	@TestFactory
 	Stream<DynamicTest> checkWellBehavedPlugin() {
 		return new WellBehavedPluginTester()
+			.qualifiedPluginId("dev.nokee.objective-c-language-base")
 			.pluginClass(ObjectiveCLanguageBasePlugin.class)
 			.stream().map(TestCaseUtils::toJUnit5DynamicTest);
 	}

--- a/subprojects/language-objective-c/src/test/groovy/dev/nokee/language/objectivec/ObjectiveCSourceSetTest.java
+++ b/subprojects/language-objective-c/src/test/groovy/dev/nokee/language/objectivec/ObjectiveCSourceSetTest.java
@@ -17,32 +17,31 @@ package dev.nokee.language.objectivec;
 
 import dev.nokee.internal.testing.util.ProjectTestUtils;
 import dev.nokee.language.base.internal.LanguageSourceSetIdentifier;
-import dev.nokee.language.base.internal.LanguageSourceSetRegistrationFactory;
-import dev.nokee.language.base.internal.SourceSetFactory;
 import dev.nokee.language.base.testers.LanguageSourceSetTester;
 import dev.nokee.language.objectivec.internal.plugins.ObjectiveCSourceSetRegistrationFactory;
-import dev.nokee.model.internal.registry.DefaultModelRegistry;
+import dev.nokee.model.internal.registry.ModelRegistry;
 import lombok.val;
 
 import java.io.File;
 
-import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
 import static dev.nokee.model.internal.ProjectIdentifier.ofRootProject;
 
 class ObjectiveCSourceSetTest extends LanguageSourceSetTester<ObjectiveCSourceSet> {
 	@Override
 	public ObjectiveCSourceSet createSubject() {
-		val objects = objectFactory();
-		val registry = new DefaultModelRegistry(objects::newInstance);
-		val factory = new ObjectiveCSourceSetRegistrationFactory(new LanguageSourceSetRegistrationFactory(objects, registry, new SourceSetFactory(objects)));
+		val project = ProjectTestUtils.rootProject();
+		project.getPluginManager().apply("dev.nokee.objective-c-language-base");
+		val registry = project.getExtensions().getByType(ModelRegistry.class);
+		val factory = project.getExtensions().getByType(ObjectiveCSourceSetRegistrationFactory.class);
 		return registry.register(factory.create(LanguageSourceSetIdentifier.of(ofRootProject(), "test"))).as(ObjectiveCSourceSet.class).get();
 	}
 
 	@Override
 	public ObjectiveCSourceSet createSubject(File temporaryDirectory) {
-		val objects = ProjectTestUtils.createRootProject(temporaryDirectory).getObjects();
-		val registry = new DefaultModelRegistry(objects::newInstance);
-		val factory = new ObjectiveCSourceSetRegistrationFactory(new LanguageSourceSetRegistrationFactory(objects, registry, new SourceSetFactory(objects)));
+		val project = ProjectTestUtils.createRootProject(temporaryDirectory);
+		project.getPluginManager().apply("dev.nokee.objective-c-language-base");
+		val registry = project.getExtensions().getByType(ModelRegistry.class);
+		val factory = project.getExtensions().getByType(ObjectiveCSourceSetRegistrationFactory.class);
 		return registry.register(factory.create(LanguageSourceSetIdentifier.of(ofRootProject(), "test"))).as(ObjectiveCSourceSet.class).get();
 	}
 }

--- a/subprojects/language-objective-cpp/language-objective-cpp.gradle
+++ b/subprojects/language-objective-cpp/language-objective-cpp.gradle
@@ -18,6 +18,10 @@ dependencies {
 
 gradlePlugin {
 	plugins {
+		objectiveCppLanguageBase {
+			id = 'dev.nokee.objective-cpp-language-base'
+			implementationClass = 'dev.nokee.language.objectivecpp.internal.plugins.ObjectiveCppLanguageBasePlugin'
+		}
 		objectiveCppLanguage {
 			id = 'dev.nokee.objective-cpp-language'
 			implementationClass = 'dev.nokee.language.objectivecpp.internal.plugins.ObjectiveCppLanguagePlugin'

--- a/subprojects/language-objective-cpp/src/functionalTest/groovy/dev/nokee/language/objectivecpp/ObjectiveCppLanguageBasePluginWellBehavedPluginTest.java
+++ b/subprojects/language-objective-cpp/src/functionalTest/groovy/dev/nokee/language/objectivecpp/ObjectiveCppLanguageBasePluginWellBehavedPluginTest.java
@@ -27,6 +27,7 @@ class ObjectiveCppLanguageBasePluginWellBehavedPluginTest {
 	@TestFactory
 	Stream<DynamicTest> checkWellBehavedPlugin() {
 		return new WellBehavedPluginTester()
+			.qualifiedPluginId("dev.nokee.objective-cpp-language-base")
 			.pluginClass(ObjectiveCppLanguageBasePlugin.class)
 			.stream().map(TestCaseUtils::toJUnit5DynamicTest);
 	}

--- a/subprojects/language-objective-cpp/src/test/groovy/dev/nokee/language/objectivecpp/ObjectiveCppSourceSetTest.java
+++ b/subprojects/language-objective-cpp/src/test/groovy/dev/nokee/language/objectivecpp/ObjectiveCppSourceSetTest.java
@@ -17,32 +17,31 @@ package dev.nokee.language.objectivecpp;
 
 import dev.nokee.internal.testing.util.ProjectTestUtils;
 import dev.nokee.language.base.internal.LanguageSourceSetIdentifier;
-import dev.nokee.language.base.internal.LanguageSourceSetRegistrationFactory;
-import dev.nokee.language.base.internal.SourceSetFactory;
 import dev.nokee.language.base.testers.LanguageSourceSetTester;
 import dev.nokee.language.objectivecpp.internal.plugins.ObjectiveCppSourceSetRegistrationFactory;
-import dev.nokee.model.internal.registry.DefaultModelRegistry;
+import dev.nokee.model.internal.registry.ModelRegistry;
 import lombok.val;
 
 import java.io.File;
 
-import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
 import static dev.nokee.model.internal.ProjectIdentifier.ofRootProject;
 
 class ObjectiveCppSourceSetTest extends LanguageSourceSetTester<ObjectiveCppSourceSet> {
 	@Override
 	public ObjectiveCppSourceSet createSubject() {
-		val objects = objectFactory();
-		val registry = new DefaultModelRegistry(objects::newInstance);
-		val factory = new ObjectiveCppSourceSetRegistrationFactory(new LanguageSourceSetRegistrationFactory(objects, registry, new SourceSetFactory(objects)));
+		val project = ProjectTestUtils.rootProject();
+		project.getPluginManager().apply("dev.nokee.objective-cpp-language-base");
+		val registry = project.getExtensions().getByType(ModelRegistry.class);
+		val factory = project.getExtensions().getByType(ObjectiveCppSourceSetRegistrationFactory.class);
 		return registry.register(factory.create(LanguageSourceSetIdentifier.of(ofRootProject(), "test"))).as(ObjectiveCppSourceSet.class).get();
 	}
 
 	@Override
 	public ObjectiveCppSourceSet createSubject(File temporaryDirectory) {
-		val objects = ProjectTestUtils.createRootProject(temporaryDirectory).getObjects();
-		val registry = new DefaultModelRegistry(objects::newInstance);
-		val factory = new ObjectiveCppSourceSetRegistrationFactory(new LanguageSourceSetRegistrationFactory(objects, registry, new SourceSetFactory(objects)));
+		val project = ProjectTestUtils.createRootProject(temporaryDirectory);
+		project.getPluginManager().apply("dev.nokee.objective-cpp-language-base");
+		val registry = project.getExtensions().getByType(ModelRegistry.class);
+		val factory = project.getExtensions().getByType(ObjectiveCppSourceSetRegistrationFactory.class);
 		return registry.register(factory.create(LanguageSourceSetIdentifier.of(ofRootProject(), "test"))).as(ObjectiveCppSourceSet.class).get();
 	}
 }

--- a/subprojects/language-swift/language-swift.gradle
+++ b/subprojects/language-swift/language-swift.gradle
@@ -18,6 +18,10 @@ dependencies {
 
 gradlePlugin {
 	plugins {
+		swiftLanguageBase {
+			id = "dev.nokee.swift-language-base"
+			implementationClass = "dev.nokee.language.swift.internal.plugins.SwiftLanguageBasePlugin"
+		}
 	}
 }
 

--- a/subprojects/language-swift/src/functionalTest/groovy/dev/nokee/language/swift/SwiftLanguageBasePluginWellBehavedPluginTest.java
+++ b/subprojects/language-swift/src/functionalTest/groovy/dev/nokee/language/swift/SwiftLanguageBasePluginWellBehavedPluginTest.java
@@ -27,6 +27,7 @@ class SwiftLanguageBasePluginWellBehavedPluginTest {
 	@TestFactory
 	Stream<DynamicTest> checkWellBehavedPlugin() {
 		return new WellBehavedPluginTester()
+			.qualifiedPluginId("dev.nokee.swift-language-base")
 			.pluginClass(SwiftLanguageBasePlugin.class)
 			.stream().map(TestCaseUtils::toJUnit5DynamicTest);
 	}

--- a/subprojects/language-swift/src/test/groovy/dev/nokee/language/swift/SwiftSourceSetTest.java
+++ b/subprojects/language-swift/src/test/groovy/dev/nokee/language/swift/SwiftSourceSetTest.java
@@ -17,32 +17,31 @@ package dev.nokee.language.swift;
 
 import dev.nokee.internal.testing.util.ProjectTestUtils;
 import dev.nokee.language.base.internal.LanguageSourceSetIdentifier;
-import dev.nokee.language.base.internal.LanguageSourceSetRegistrationFactory;
-import dev.nokee.language.base.internal.SourceSetFactory;
 import dev.nokee.language.base.testers.LanguageSourceSetTester;
 import dev.nokee.language.swift.internal.plugins.SwiftSourceSetRegistrationFactory;
-import dev.nokee.model.internal.registry.DefaultModelRegistry;
+import dev.nokee.model.internal.registry.ModelRegistry;
 import lombok.val;
 
 import java.io.File;
 
-import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
 import static dev.nokee.model.internal.ProjectIdentifier.ofRootProject;
 
 class SwiftSourceSetTest extends LanguageSourceSetTester<SwiftSourceSet> {
 	@Override
 	public SwiftSourceSet createSubject() {
-		val objects = objectFactory();
-		val registry = new DefaultModelRegistry(objects::newInstance);
-		val factory = new SwiftSourceSetRegistrationFactory(new LanguageSourceSetRegistrationFactory(objects, registry, new SourceSetFactory(objects)));
+		val project = ProjectTestUtils.rootProject();
+		project.getPluginManager().apply("dev.nokee.swift-language-base");
+		val registry = project.getExtensions().getByType(ModelRegistry.class);
+		val factory = project.getExtensions().getByType(SwiftSourceSetRegistrationFactory.class);
 		return registry.register(factory.create(LanguageSourceSetIdentifier.of(ofRootProject(), "test"))).as(SwiftSourceSet.class).get();
 	}
 
 	@Override
 	public SwiftSourceSet createSubject(File temporaryDirectory) {
-		val objects = ProjectTestUtils.createRootProject(temporaryDirectory).getObjects();
-		val registry = new DefaultModelRegistry(objects::newInstance);
-		val factory = new SwiftSourceSetRegistrationFactory(new LanguageSourceSetRegistrationFactory(objects, registry, new SourceSetFactory(objects)));
+		val project = ProjectTestUtils.createRootProject(temporaryDirectory);
+		project.getPluginManager().apply("dev.nokee.swift-language-base");
+		val registry = project.getExtensions().getByType(ModelRegistry.class);
+		val factory = project.getExtensions().getByType(SwiftSourceSetRegistrationFactory.class);
 		return registry.register(factory.create(LanguageSourceSetIdentifier.of(ofRootProject(), "test"))).as(SwiftSourceSet.class).get();
 	}
 }


### PR DESCRIPTION
Also, introduce plugin ids for all base language plugins. We want to open up those plugins but it's still unclear how it will look like. See https://github.com/nokeedev/gradle-native/issues/445.