### PR TITLE
Allow custom display for source set identifier

### DIFF
--- a/subprojects/language-base/src/main/java/dev/nokee/language/base/internal/LanguageSourceSetIdentifier.java
+++ b/subprojects/language-base/src/main/java/dev/nokee/language/base/internal/LanguageSourceSetIdentifier.java
@@ -43,7 +43,11 @@ public final class LanguageSourceSetIdentifier implements DomainObjectIdentifier
 	}
 
 	public static LanguageSourceSetIdentifier of(DomainObjectIdentifier ownerIdentifier, String name) {
-		return new LanguageSourceSetIdentifier(LanguageSourceSetIdentity.of(name), ownerIdentifier);
+		return new LanguageSourceSetIdentifier(LanguageSourceSetIdentity.of(name, "sources"), ownerIdentifier);
+	}
+
+	public static LanguageSourceSetIdentifier of(DomainObjectIdentifier ownerIdentifier, LanguageSourceSetIdentity identity) {
+		return new LanguageSourceSetIdentifier(identity, ownerIdentifier);
 	}
 
 	@Override
@@ -53,6 +57,6 @@ public final class LanguageSourceSetIdentifier implements DomainObjectIdentifier
 
 	@Override
 	public String toString() {
-		return String.format("sources '%s'", toGradlePath(this));
+		return String.format("%s '%s'", identity.getDisplayName(), toGradlePath(this));
 	}
 }

--- a/subprojects/language-base/src/main/java/dev/nokee/language/base/internal/LanguageSourceSetIdentity.java
+++ b/subprojects/language-base/src/main/java/dev/nokee/language/base/internal/LanguageSourceSetIdentity.java
@@ -18,20 +18,33 @@ package dev.nokee.language.base.internal;
 import dev.nokee.model.HasName;
 import lombok.EqualsAndHashCode;
 
+import static java.util.Objects.requireNonNull;
+
 @EqualsAndHashCode
 public final class LanguageSourceSetIdentity implements HasName {
 	private final LanguageSourceSetName name;
+	private final String displayName;
 
-	private LanguageSourceSetIdentity(LanguageSourceSetName name) {
+	private LanguageSourceSetIdentity(LanguageSourceSetName name, String displayName) {
 		this.name = name;
+		this.displayName = displayName;
 	}
 
-	public static LanguageSourceSetIdentity of(String name) {
-		return new LanguageSourceSetIdentity(LanguageSourceSetName.of(name));
+	public static LanguageSourceSetIdentity of(String name, String displayName) {
+		return new LanguageSourceSetIdentity(LanguageSourceSetName.of(name), requireNonNull(displayName));
 	}
 
 	@Override
 	public LanguageSourceSetName getName() {
 		return name;
+	}
+
+	public String getDisplayName() {
+		return displayName;
+	}
+
+	@Override
+	public String toString() {
+		return "sources '" + name + "'";
 	}
 }

--- a/subprojects/language-base/src/test/groovy/dev/nokee/language/base/LanguageSourceSetIdentifierNullTest.java
+++ b/subprojects/language-base/src/test/groovy/dev/nokee/language/base/LanguageSourceSetIdentifierNullTest.java
@@ -15,33 +15,18 @@
  */
 package dev.nokee.language.base;
 
+import com.google.common.testing.NullPointerTester;
 import dev.nokee.language.base.internal.LanguageSourceSetIdentifier;
 import dev.nokee.language.base.internal.LanguageSourceSetIdentity;
-import dev.nokee.model.internal.ProjectIdentifier;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-
-class LanguageSourceSetIdentifierTest {
-	@Nested
-	class NameOnly {
-		private final LanguageSourceSetIdentifier subject = LanguageSourceSetIdentifier.of(ProjectIdentifier.ofRootProject(), "tera");
-
-		@Test
-		void hasToString() {
-			assertThat(subject, Matchers.hasToString("sources ':tera'"));
-		}
-	}
-
-	@Nested
-	class WithCustomDisplayName {
-		private final LanguageSourceSetIdentifier subject = LanguageSourceSetIdentifier.of(ProjectIdentifier.ofRootProject(), LanguageSourceSetIdentity.of("feme", "Fome zutu"));
-
-		@Test
-		void hasToString() {
-			assertThat(subject, Matchers.hasToString("Fome zutu ':feme'"));
-		}
+class LanguageSourceSetIdentifierNullTest {
+	@Test
+	@SuppressWarnings("UnstableApiUsage")
+	void checkNulls() {
+		new NullPointerTester()
+			.setDefault(String.class, "default")
+			.setDefault(LanguageSourceSetIdentity.class, LanguageSourceSetIdentity.of("finu", "nife gaci"))
+			.testAllPublicStaticMethods(LanguageSourceSetIdentifier.class);
 	}
 }

--- a/subprojects/language-base/src/test/groovy/dev/nokee/language/base/LanguageSourceSetIdentityNullTest.java
+++ b/subprojects/language-base/src/test/groovy/dev/nokee/language/base/LanguageSourceSetIdentityNullTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.language.base;
+
+import com.google.common.testing.NullPointerTester;
+import dev.nokee.language.base.internal.LanguageSourceSetIdentity;
+import org.junit.jupiter.api.Test;
+
+class LanguageSourceSetIdentityNullTest {
+	@Test
+	@SuppressWarnings("UnstableApiUsage")
+	void checkNulls() {
+		new NullPointerTester().setDefault(String.class, "default").testAllPublicStaticMethods(LanguageSourceSetIdentity.class);
+	}
+}

--- a/subprojects/language-base/src/test/groovy/dev/nokee/language/base/LanguageSourceSetIdentityTest.java
+++ b/subprojects/language-base/src/test/groovy/dev/nokee/language/base/LanguageSourceSetIdentityTest.java
@@ -19,12 +19,15 @@ import com.google.common.testing.EqualsTester;
 import dev.nokee.language.base.internal.LanguageSourceSetIdentity;
 import dev.nokee.language.base.internal.LanguageSourceSetName;
 import dev.nokee.model.testers.HasNameTester;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
+import static dev.nokee.language.base.internal.LanguageSourceSetIdentity.of;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class LanguageSourceSetIdentityTest implements HasNameTester {
-	private final LanguageSourceSetIdentity subject = LanguageSourceSetIdentity.of("gofe");
+	private final LanguageSourceSetIdentity subject = of("gofe", "zewi duna");
 
 	@Override
 	public LanguageSourceSetIdentity subject() {
@@ -37,11 +40,22 @@ class LanguageSourceSetIdentityTest implements HasNameTester {
 	}
 
 	@Test
+	void hasDisplayName()  {
+		assertEquals("zewi duna", subject.getDisplayName());
+	}
+
+	@Test
 	@SuppressWarnings("UnstableApiUsage")
 	void checkEquals() {
 		new EqualsTester()
-			.addEqualityGroup(LanguageSourceSetIdentity.of("kofo"), LanguageSourceSetIdentity.of("kofo"))
-			.addEqualityGroup(LanguageSourceSetIdentity.of("tiri"))
+			.addEqualityGroup(of("kofo", "sources"), of("kofo", "sources"))
+			.addEqualityGroup(of("tiri", "sources"))
+			.addEqualityGroup(of("kofo", "other sources"))
 			.testEquals();
+	}
+
+	@Test
+	void hasToString() {
+		assertThat(subject, Matchers.hasToString("sources 'gofe'"));
 	}
 }


### PR DESCRIPTION
The commit also improve the test coverage of source set identifier and
identity.