### PR TITLE
Introduce SharedLibraryBinary registration factory

### DIFF
--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelPropertyRegistrationFactory.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelPropertyRegistrationFactory.java
@@ -37,25 +37,6 @@ public final class ModelPropertyRegistrationFactory {
 		this.objects = objects;
 	}
 
-	public ModelRegistration create(ModelPath path, ModelNode entity) {
-		return ModelRegistration.builder()
-			.withComponent(path)
-			.action(ModelActionWithInputs.of(ModelComponentReference.of(ModelPath.class), ModelComponentReference.of(ModelState.IsAtLeastRealized.class), (e, p, ignored) -> {
-				if (p.equals(path)) {
-					ModelStates.realize(entity);
-				} else if (p.equals(ModelNodeUtils.getPath(entity))) {
-					ModelStates.realize(lookup.get(path));
-				}
-			}))
-			.action(ModelActionWithInputs.of(ModelComponentReference.of(ModelPath.class), ModelComponentReference.of(ModelState.IsAtLeastCreated.class), (e, p, ignored) -> {
-				if (p.equals(path)) {
-					e.addComponent(IsModelProperty.tag());
-					e.addComponent(new DelegatedModelProjection(entity));
-				}
-			}))
-			.build();
-	}
-
 	public ModelRegistration create(ModelPropertyIdentifier identifier, ModelNode entity) {
 		assert entity.hasComponent(DomainObjectIdentifier.class);
 		val path = toPath(identifier);

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelPropertyRegistrationFactory.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelPropertyRegistrationFactory.java
@@ -75,13 +75,15 @@ public final class ModelPropertyRegistrationFactory {
 			.build();
 	}
 
-	public ModelRegistration createProperty(ModelPropertyIdentifier identifier, Class<?> type) {
+	public <T> ModelRegistration createProperty(ModelPropertyIdentifier identifier, Class<T> type) {
 		val path = toPath(identifier);
+		val property = objects.property(type);
 		return ModelRegistration.builder()
 			.withComponent(identifier)
 			.withComponent(path)
 			.withComponent(IsModelProperty.tag())
-			.withComponent(createdUsing(ModelType.of(Property.class), () -> objects.property(type)))
+			.withComponent(createdUsing(ModelType.of(type), property::getOrNull))
+			.withComponent(createdUsing(ModelType.of(Property.class), () -> property))
 			.build();
 	}
 }

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelPropertyRegistrationFactory.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelPropertyRegistrationFactory.java
@@ -15,26 +15,26 @@
  */
 package dev.nokee.model.internal.core;
 
-import com.google.common.collect.Streams;
 import dev.nokee.model.DomainObjectIdentifier;
-import dev.nokee.model.HasName;
 import dev.nokee.model.internal.ModelPropertyIdentifier;
-import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.model.internal.registry.ModelLookup;
 import dev.nokee.model.internal.state.ModelState;
 import dev.nokee.model.internal.state.ModelStates;
+import dev.nokee.model.internal.type.ModelType;
 import lombok.val;
-
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
 
 import static dev.nokee.model.internal.DomainObjectIdentifierUtils.toPath;
+import static dev.nokee.model.internal.core.ModelProjections.createdUsing;
 
 public final class ModelPropertyRegistrationFactory {
 	private final ModelLookup lookup;
+	private final ObjectFactory objects;
 
-	public ModelPropertyRegistrationFactory(ModelLookup lookup) {
+	public ModelPropertyRegistrationFactory(ModelLookup lookup, ObjectFactory objects) {
 		this.lookup = lookup;
+		this.objects = objects;
 	}
 
 	public ModelRegistration create(ModelPath path, ModelNode entity) {
@@ -78,6 +78,16 @@ public final class ModelPropertyRegistrationFactory {
 					e.addComponent(new DelegatedModelProjection(entity));
 				}
 			}))
+			.build();
+	}
+
+	public ModelRegistration createProperty(ModelPropertyIdentifier identifier, Class<?> type) {
+		val path = toPath(identifier);
+		return ModelRegistration.builder()
+			.withComponent(identifier)
+			.withComponent(path)
+			.withComponent(IsModelProperty.tag())
+			.withComponent(createdUsing(ModelType.of(Property.class), () -> objects.property(type)))
 			.build();
 	}
 }

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/plugins/ModelBasePlugin.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/plugins/ModelBasePlugin.java
@@ -46,7 +46,7 @@ public class ModelBasePlugin implements Plugin<Project> {
 		project.getExtensions().add(ModelRegistry.class, "__NOKEE_modelRegistry", modelRegistry);
 		project.getExtensions().add(ModelLookup.class, "__NOKEE_modelLookup", modelRegistry);
 		project.getExtensions().add(ModelConfigurer.class, "__NOKEE_modelConfigurer", modelRegistry);
-		project.getExtensions().add(ModelPropertyRegistrationFactory.class, "__NOKEE_modelPropertyRegistrationFactory", new ModelPropertyRegistrationFactory(modelRegistry));
+		project.getExtensions().add(ModelPropertyRegistrationFactory.class, "__NOKEE_modelPropertyRegistrationFactory", new ModelPropertyRegistrationFactory(modelRegistry, project.getObjects()));
 
 		project.getTasks().register("nokeeModel", ModelReportTask.class, TaskUtils.configureDescription("Displays the configuration model of %s.", project));
 	}

--- a/subprojects/core-utils/src/main/java/dev/nokee/utils/TaskDependencyUtils.java
+++ b/subprojects/core-utils/src/main/java/dev/nokee/utils/TaskDependencyUtils.java
@@ -98,6 +98,36 @@ public final class TaskDependencyUtils {
 	}
 
 	/**
+	 * Creates task dependency for specified iterable provider of tasks.
+	 * The provider is only realize when querying task dependency via {@link TaskDependency#getDependencies(Task)}.
+	 *
+	 * @param tasksProvider  the task provider to use as task dependency, must not be null
+	 * @return a task dependency for specified task provider, never null
+	 */
+	public static TaskDependency ofIterable(Provider<? extends Iterable<? extends Task>> tasksProvider) {
+		return new OfTasksDependency(tasksProvider);
+	}
+
+	@EqualsAndHashCode
+	private static final class OfTasksDependency implements TaskDependency {
+		private final Provider<? extends Iterable<? extends Task>> tasksProvider;
+
+		private OfTasksDependency(Provider<? extends Iterable<? extends Task>> tasksProvider) {
+			this.tasksProvider = requireNonNull(tasksProvider);
+		}
+
+		@Override
+		public Set<? extends Task> getDependencies(@Nullable Task task) {
+			return ImmutableSet.copyOf(tasksProvider.get());
+		}
+
+		@Override
+		public String toString() {
+			return "TaskDependencyUtils.ofIterable(" + tasksProvider + ")";
+		}
+	}
+
+	/**
 	 * Creates an empty {@link TaskDependency}.
 	 * It will always return an empty set.
 	 *

--- a/subprojects/core-utils/src/test/groovy/dev/nokee/utils/TaskDependencyUtils_OfIterableTest.java
+++ b/subprojects/core-utils/src/test/groovy/dev/nokee/utils/TaskDependencyUtils_OfIterableTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.utils;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
+import org.gradle.api.Task;
+import org.gradle.api.provider.Provider;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.concurrent.Callable;
+
+import static com.google.common.util.concurrent.Callables.returning;
+import static dev.nokee.internal.testing.util.ProjectTestUtils.providerFactory;
+import static dev.nokee.utils.TaskDependencyUtils.ofIterable;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasToString;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class TaskDependencyUtils_OfIterableTest {
+	private static final Task T0 = Mockito.mock(Task.class);
+	private static final Task T1 = Mockito.mock(Task.class);
+	private static final Provider<Iterable<Task>> P0 = providerFactory().provider(returning(ImmutableList.of(T0, T1)));
+	private static final Provider<Iterable<Task>> P1 = providerFactory().provider(returning(ImmutableList.of(T1)));
+	private static final Task ANY = Mockito.mock(Task.class);
+
+	@Test
+	void canCreateTaskDependencyFromIterableOfTaskProvider() {
+		assertThat(ofIterable(P0).getDependencies(ANY), contains(T0, T1));
+	}
+
+	@Test
+	void doesNotResolveProviderUponCreation() {
+		assertDoesNotThrow(() -> ofIterable(providerFactory().provider(throwingCallable())));
+	}
+
+	private static Callable<Iterable<Task>> throwingCallable() {
+		return () -> { throw new UnsupportedOperationException("do not realize"); };
+	}
+
+	@Test
+	@SuppressWarnings("UnstableApiUsage")
+	void checkEquals() {
+		new EqualsTester()
+			.addEqualityGroup(ofIterable(P0), ofIterable(P0))
+			.addEqualityGroup(ofIterable(P1))
+			.testEquals();
+	}
+
+	@Test
+	void checkToString() {
+		assertThat(ofIterable(P0),
+			hasToString("TaskDependencyUtils.ofIterable(provider(?))"));
+	}
+}

--- a/subprojects/core-utils/src/test/groovy/dev/nokee/utils/TransformerUtils_OnlyInstanceOfTest.java
+++ b/subprojects/core-utils/src/test/groovy/dev/nokee/utils/TransformerUtils_OnlyInstanceOfTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.utils;
+
+import com.google.common.testing.EqualsTester;
+import lombok.val;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static dev.nokee.utils.FunctionalInterfaceMatchers.*;
+import static dev.nokee.utils.TransformerTestUtils.aTransformer;
+import static dev.nokee.utils.TransformerTestUtils.anotherTransformer;
+import static dev.nokee.utils.TransformerUtils.noOpTransformer;
+import static dev.nokee.utils.TransformerUtils.onlyInstanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.emptyIterable;
+
+final class TransformerUtils_OnlyInstanceOfTest {
+	@Test
+	void returnsEmptyIterableWhenElementIsNotAnInstanceOfSpecifiedType() {
+		val obj = Mockito.mock(MyOtherType.class);
+		assertThat(onlyInstanceOf(MyType.class).transform(obj), emptyIterable());
+		assertThat(onlyInstanceOf(MyType.class, noOpTransformer()).transform(obj), emptyIterable());
+	}
+
+	@Test
+	void returnsSingletonIterableWhenElementIsAnInstanceOfSpecifiedType() {
+		val obj = Mockito.mock(MyType.class);
+		assertThat(onlyInstanceOf(MyType.class).transform(obj), contains(obj));
+		assertThat(onlyInstanceOf(MyType.class, noOpTransformer()).transform(obj), contains(obj));
+	}
+
+	@Test
+	void canTransformMatchingElements() {
+		val obj = Mockito.mock(MyType.class);
+		val transformer = TransformerTestUtils.mockTransformer().whenCalled(noOpTransformer());
+		onlyInstanceOf(MyType.class, transformer).transform(obj);
+		assertThat(transformer, calledOnceWith(singleArgumentOf(obj)));
+	}
+
+	@Test
+	void doesNotTransformNonMatchingElements() {
+		val obj = Mockito.mock(MyOtherType.class);
+		val transformer = TransformerTestUtils.mockTransformer().whenCalled(noOpTransformer());
+		onlyInstanceOf(MyType.class, transformer).transform(obj);
+		assertThat(transformer, neverCalled());
+	}
+
+	@Test
+	@SuppressWarnings("UnstableApiUsage")
+	void checkEquals() {
+		new EqualsTester()
+			.addEqualityGroup(onlyInstanceOf(MyType.class, aTransformer()), onlyInstanceOf(MyType.class, aTransformer()))
+			.addEqualityGroup(onlyInstanceOf(MyType.class, anotherTransformer()))
+			.addEqualityGroup(onlyInstanceOf(MyOtherType.class, aTransformer()))
+			.testEquals();
+	}
+
+	private interface MyType {}
+	private interface MyOtherType {}
+}

--- a/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/FileSystemMatchers.java
+++ b/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/FileSystemMatchers.java
@@ -91,4 +91,21 @@ public final class FileSystemMatchers {
 	public static Matcher<Object> aFileNamed(String fileName) {
 		return aFile(FileMatchers.aFileNamed(Matchers.equalTo(fileName)));
 	}
+
+	public static Matcher<Object> aFileNamed(Matcher<String> matcher) {
+		return aFile(FileMatchers.aFileNamed(matcher));
+	}
+
+	public static Matcher<Object> aFileBaseNamed(Matcher<String> matcher) {
+		return aFileNamed(withoutExtension(matcher));
+	}
+
+	private static Matcher<String> withoutExtension(Matcher<String> matcher) {
+		return new FeatureMatcher<String, String>(matcher, "", "") {
+			@Override
+			protected String featureValueOf(String actual) {
+				return FilenameUtils.removeExtension(actual);
+			}
+		};
+	}
 }

--- a/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/ProjectMatchers.java
+++ b/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/ProjectMatchers.java
@@ -116,11 +116,12 @@ public final class ProjectMatchers {
 	 * @param matcher  the build tasks matcher, must not be null
 	 * @return a buildable matcher, never null
 	 */
-	public static Matcher<Buildable> buildDependencies(Matcher<? super Iterable<? extends Task>> matcher) {
-		return new FeatureMatcher<Buildable, Iterable<? extends Task>>(matcher, "a buildable object with dependencies", "buildable object with dependencies") {
+	public static Matcher<Buildable> buildDependencies(Matcher<? super Iterable<Task>> matcher) {
+		return new FeatureMatcher<Buildable, Iterable<Task>>(matcher, "a buildable object with dependencies", "buildable object with dependencies") {
 			@Override
-			protected Iterable<? extends Task> featureValueOf(Buildable actual) {
-				return actual.getBuildDependencies().getDependencies(null);
+			@SuppressWarnings("unchecked")
+			protected Iterable<Task> featureValueOf(Buildable actual) {
+				return (Iterable<Task>) actual.getBuildDependencies().getDependencies(null);
 			}
 		};
 	}

--- a/subprojects/language-native/src/main/java/dev/nokee/language/nativebase/internal/FrameworkAwareIncomingArtifacts.java
+++ b/subprojects/language-native/src/main/java/dev/nokee/language/nativebase/internal/FrameworkAwareIncomingArtifacts.java
@@ -43,7 +43,7 @@ public final class FrameworkAwareIncomingArtifacts {
 	private static final Logger LOGGER = Logger.getLogger(HeaderSearchPathsConfigurationRegistrationAction.class.getCanonicalName());
 	private final Provider<ResolvableDependencies> incomingArtifacts;
 
-	public FrameworkAwareIncomingArtifacts(Provider<ResolvableDependencies> incomingArtifacts) {
+	private FrameworkAwareIncomingArtifacts(Provider<ResolvableDependencies> incomingArtifacts) {
 		this.incomingArtifacts = incomingArtifacts;
 	}
 

--- a/subprojects/language-native/src/main/java/dev/nokee/language/nativebase/internal/FrameworkAwareIncomingArtifacts.java
+++ b/subprojects/language-native/src/main/java/dev/nokee/language/nativebase/internal/FrameworkAwareIncomingArtifacts.java
@@ -39,7 +39,7 @@ import static dev.nokee.runtime.nativebase.internal.ArtifactCompressionState.ART
 import static dev.nokee.runtime.nativebase.internal.ArtifactCompressionState.UNCOMPRESSED;
 import static dev.nokee.utils.ConfigurationUtils.configureAttributes;
 
-public class FrameworkAwareIncomingArtifacts {
+public final class FrameworkAwareIncomingArtifacts {
 	private static final Logger LOGGER = Logger.getLogger(HeaderSearchPathsConfigurationRegistrationAction.class.getCanonicalName());
 	private final Provider<ResolvableDependencies> incomingArtifacts;
 

--- a/subprojects/language-native/src/main/java/dev/nokee/language/nativebase/internal/HeaderSearchPathsConfigurationRegistrationAction.java
+++ b/subprojects/language-native/src/main/java/dev/nokee/language/nativebase/internal/HeaderSearchPathsConfigurationRegistrationAction.java
@@ -46,7 +46,6 @@ import static dev.nokee.utils.TransformerUtils.transformEach;
 
 @AutoFactory
 public final class HeaderSearchPathsConfigurationRegistrationAction extends ModelActionWithInputs.ModelAction2<LanguageSourceSetIdentifier, ModelState.IsAtLeastRegistered> {
-	private static final Logger LOGGER = Logger.getLogger(HeaderSearchPathsConfigurationRegistrationAction.class.getCanonicalName());
 	private final LanguageSourceSetIdentifier identifier;
 	private final ModelRegistry registry;
 	private final ResolvableDependencyBucketRegistrationFactory resolvableFactory;

--- a/subprojects/language-native/src/testFixtures/groovy/dev/nokee/language/nativebase/NativeLanguageSourceSetIntegrationTester.java
+++ b/subprojects/language-native/src/testFixtures/groovy/dev/nokee/language/nativebase/NativeLanguageSourceSetIntegrationTester.java
@@ -128,7 +128,7 @@ public abstract class NativeLanguageSourceSetIntegrationTester<T extends Languag
 			);
 
 			headerSearchPaths().getDependencies().add(createDependency(frameworkProducer));
-			assertThat(subject().getHeaderSearchPaths(), providerOf(not(hasItem(aFile(artifact)))));
+			assertThat(subject().getHeaderSearchPaths(), providerOf(allOf(not(hasItem(aFile(artifact))), not(hasItem(aFile(artifact.getParentFile()))))));
 			assertThat(subject().getCompilerArgs(), providerOf(containsInRelativeOrder(
 				"-F", artifact.getParentFile().getAbsolutePath()
 				)));

--- a/subprojects/language-native/src/testFixtures/groovy/dev/nokee/language/nativebase/NativeSourceCompileTester.java
+++ b/subprojects/language-native/src/testFixtures/groovy/dev/nokee/language/nativebase/NativeSourceCompileTester.java
@@ -29,7 +29,7 @@ import static org.hamcrest.Matchers.notNullValue;
 public interface NativeSourceCompileTester extends SourceCompileTester, HasObjectFilesTester {
 	NativeSourceCompile subject();
 
-	@Override
+	@Test
 	default void hasToolChain() {
 		assertThat("provide NativeToolChain", subject().getToolChain(), providerOf(isA(NativeToolChain.class)));
 	}

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/Artifact.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/Artifact.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 package dev.nokee.platform.base;
 
 /**
- * A physical binary artifact, which can run on a particular platform or runtime.
+ * A physical artifact.
  *
- * @since 0.3
+ * @since 0.5
  */
-public interface Binary extends Artifact {
+public interface Artifact {
 }

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ComponentTasksPropertyRegistrationFactory.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ComponentTasksPropertyRegistrationFactory.java
@@ -79,4 +79,19 @@ public final class ComponentTasksPropertyRegistrationFactory {
 			}))
 			.build();
 	}
+
+	public ModelRegistration create(ModelPropertyIdentifier identifier, Class<? extends Task> elementType) {
+		val path = toPath(identifier);
+		assert path.getParent().isPresent();
+		val ownerPath = path.getParent().get();
+		return ModelRegistration.builder()
+			.withComponent(path)
+			.withComponent(identifier)
+			.withComponent(IsModelProperty.tag())
+			.withComponent(createdUsing(of(TaskView.class), () -> new TaskViewAdapter<>(new ViewAdapter<>(elementType, new ModelNodeBackedViewStrategy(providers, () -> {
+				ModelStates.realize(modelLookup.get(ownerPath));
+				ModelStates.finalize(modelLookup.get(ownerPath));
+			})))))
+			.build();
+	}
 }

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ModelBackedHasBaseNameMixIn.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ModelBackedHasBaseNameMixIn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,10 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.nokee.platform.base;
+package dev.nokee.platform.base.internal;
 
+import dev.nokee.model.internal.core.ModelNodeUtils;
+import dev.nokee.model.internal.core.ModelNodes;
+import dev.nokee.platform.base.HasBaseName;
 import org.gradle.api.provider.Property;
 
-public interface HasBaseName {
-	Property<String> getBaseName();
+public interface ModelBackedHasBaseNameMixIn extends HasBaseName {
+	default Property<String> getBaseName() {
+		return ModelNodeUtils.get(ModelNodes.of(this), BaseComponent.class).getBaseName();
+	}
 }

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/DependencyBucketIdentifier.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/DependencyBucketIdentifier.java
@@ -21,6 +21,7 @@ import dev.nokee.model.DomainObjectIdentifier;
 import dev.nokee.model.internal.DomainObjectIdentifierInternal;
 import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.platform.base.DependencyBucket;
+import dev.nokee.platform.base.internal.BinaryIdentifier;
 import dev.nokee.platform.base.internal.ComponentIdentifier;
 import dev.nokee.platform.base.internal.VariantIdentifier;
 import lombok.EqualsAndHashCode;
@@ -43,14 +44,14 @@ public class DependencyBucketIdentifier implements DomainObjectIdentifierInterna
 	private DependencyBucketIdentifier(DependencyBucketIdentity identity, Class<?> type, DomainObjectIdentifier ownerIdentifier) {
 		checkArgument(type != null, "Cannot construct a dependency identifier because the bucket type is null.");
 		checkArgument(ownerIdentifier != null, "Cannot construct a dependency identifier because the owner identifier is null.");
-		checkArgument(isValidOwner(ownerIdentifier), "Cannot construct a dependency identifier because the owner identifier is invalid, only ProjectIdentifier, ComponentIdentifier, VariantIdentifier and LanguageSourceSetIdentifier are accepted.");
+		checkArgument(isValidOwner(ownerIdentifier), "Cannot construct a dependency identifier because the owner identifier is invalid, only ProjectIdentifier, ComponentIdentifier, VariantIdentifier, LanguageSourceSetIdentifier and BinaryIdentifier are accepted.");
 		this.identity = identity;
 		this.type = type;
 		this.ownerIdentifier = ownerIdentifier;
 	}
 
 	private static boolean isValidOwner(DomainObjectIdentifier ownerIdentifier) {
-		return ownerIdentifier instanceof ProjectIdentifier || ownerIdentifier instanceof ComponentIdentifier || ownerIdentifier instanceof VariantIdentifier || ownerIdentifier instanceof LanguageSourceSetIdentifier;
+		return ownerIdentifier instanceof ProjectIdentifier || ownerIdentifier instanceof ComponentIdentifier || ownerIdentifier instanceof VariantIdentifier || ownerIdentifier instanceof LanguageSourceSetIdentifier || ownerIdentifier instanceof BinaryIdentifier;
 	}
 
 	public DependencyBucketName getName() {

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/DependencyBuckets.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/DependencyBuckets.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Streams;
 import dev.nokee.model.HasName;
 import dev.nokee.model.internal.DomainObjectIdentifierInternal;
 import dev.nokee.model.internal.ProjectIdentifier;
+import dev.nokee.platform.base.internal.BinaryIdentifier;
 import dev.nokee.platform.base.internal.ComponentIdentifier;
 import dev.nokee.platform.base.internal.ComponentIdentity;
 import dev.nokee.platform.base.internal.VariantIdentifier;
@@ -40,7 +41,9 @@ public final class DependencyBuckets {
 			builder.append("<unknown>");
 		} else {
 			val ownerIdentifier = identifier.getOwnerIdentifier();
-			if (ownerIdentifier instanceof DomainObjectIdentifierInternal) {
+			if (ownerIdentifier instanceof BinaryIdentifier) {
+				builder.append(ownerIdentifier);
+			} else if (ownerIdentifier instanceof DomainObjectIdentifierInternal) {
 				builder.append(((DomainObjectIdentifierInternal) ownerIdentifier).getDisplayName());
 			} else {
 				builder.append(ownerIdentifier);

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/TaskIdentifier.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/TaskIdentifier.java
@@ -72,6 +72,10 @@ public final class TaskIdentifier<T extends Task> implements DomainObjectIdentif
 		return new TaskIdentifier<>(TaskName.empty(), Task.class, ownerIdentifier);
 	}
 
+	public static TaskIdentifier<?> of(DomainObjectIdentifier ownerIdentifier, String name) {
+		return new TaskIdentifier<>(TaskName.of(name), Task.class, ownerIdentifier);
+	}
+
 	private static boolean isValidLifecycleOwner(DomainObjectIdentifier ownerIdentifier) {
 		if (ownerIdentifier instanceof VariantIdentifier) {
 			val variantIdentifier = (VariantIdentifier<?>) ownerIdentifier;

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/TaskIdentifier.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/TaskIdentifier.java
@@ -45,7 +45,7 @@ public final class TaskIdentifier<T extends Task> implements DomainObjectIdentif
 	@Getter private final Class<T> type;
 	@Getter private final DomainObjectIdentifier ownerIdentifier;
 
-	public TaskIdentifier(TaskName name, Class<T> type, DomainObjectIdentifier ownerIdentifier) {
+	private TaskIdentifier(TaskName name, Class<T> type, DomainObjectIdentifier ownerIdentifier) {
 		Preconditions.checkArgument(name != null, "Cannot construct a task identifier because the task name is null.");
 		Preconditions.checkArgument(type != null, "Cannot construct a task identifier because the task type is null.");
 		Preconditions.checkArgument(ownerIdentifier != null, "Cannot construct a task identifier because the owner identifier is null.");

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/TaskIdentifier.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/TaskIdentifier.java
@@ -47,7 +47,6 @@ public final class TaskIdentifier<T extends Task> implements DomainObjectIdentif
 
 	private TaskIdentifier(TaskName name, Class<T> type, DomainObjectIdentifier ownerIdentifier) {
 		Preconditions.checkArgument(name != null, "Cannot construct a task identifier because the task name is null.");
-		Preconditions.checkArgument(type != null, "Cannot construct a task identifier because the task type is null.");
 		Preconditions.checkArgument(ownerIdentifier != null, "Cannot construct a task identifier because the owner identifier is null.");
 		Preconditions.checkArgument(isValidOwner(ownerIdentifier), "Cannot construct a task identifier because the owner identifier is invalid, only ProjectIdentifier, ComponentIdentifier, VariantIdentifier, LanguageSourceSetIdentifier and BinaryIdentifier are accepted.");
 		this.name = name;
@@ -60,6 +59,7 @@ public final class TaskIdentifier<T extends Task> implements DomainObjectIdentif
 	}
 
 	public static <T extends Task> TaskIdentifier<T> of(TaskName name, Class<T> type, DomainObjectIdentifier ownerIdentifier) {
+		Preconditions.checkArgument(type != null, "Cannot construct a task identifier because the task type is null.");
 		return new TaskIdentifier<>(name, type, ownerIdentifier);
 	}
 

--- a/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/dependencies/DependencyBucketIdentifierTest.groovy
+++ b/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/dependencies/DependencyBucketIdentifierTest.groovy
@@ -112,7 +112,7 @@ class DependencyBucketIdentifierTest extends Specification {
 
 		then:
 		def ex = thrown(IllegalArgumentException)
-		ex.message == 'Cannot construct a dependency identifier because the owner identifier is invalid, only ProjectIdentifier, ComponentIdentifier, VariantIdentifier and LanguageSourceSetIdentifier are accepted.'
+		ex.message == 'Cannot construct a dependency identifier because the owner identifier is invalid, only ProjectIdentifier, ComponentIdentifier, VariantIdentifier, LanguageSourceSetIdentifier and BinaryIdentifier are accepted.'
 	}
 
 	def "has to string"() {

--- a/subprojects/platform-base/src/testFixtures/groovy/dev/nokee/platform/base/testers/ArtifactTester.java
+++ b/subprojects/platform-base/src/testFixtures/groovy/dev/nokee/platform/base/testers/ArtifactTester.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.platform.base.testers;
+
+import dev.nokee.model.testers.HasPublicTypeTester;
+import dev.nokee.platform.base.Artifact;
+
+public interface ArtifactTester<T extends Artifact> extends HasPublicTypeTester<T> {
+	T subject();
+}

--- a/subprojects/platform-c/src/main/java/dev/nokee/platform/c/internal/plugins/CApplicationPlugin.java
+++ b/subprojects/platform-c/src/main/java/dev/nokee/platform/c/internal/plugins/CApplicationPlugin.java
@@ -100,6 +100,7 @@ public class CApplicationPlugin implements Plugin<Project> {
 		, ModelBackedHasDevelopmentVariantMixIn<NativeApplication>
 		, ModelBackedTargetMachineAwareComponentMixIn
 		, ModelBackedTargetBuildTypeAwareComponentMixIn
+		, ModelBackedHasBaseNameMixIn
 	{
 		@Override
 		public CSourceSet getCSources() {

--- a/subprojects/platform-c/src/main/java/dev/nokee/platform/c/internal/plugins/CLibraryPlugin.java
+++ b/subprojects/platform-c/src/main/java/dev/nokee/platform/c/internal/plugins/CLibraryPlugin.java
@@ -104,6 +104,7 @@ public class CLibraryPlugin implements Plugin<Project> {
 		, ModelBackedTargetMachineAwareComponentMixIn
 		, ModelBackedTargetBuildTypeAwareComponentMixIn
 		, ModelBackedTargetLinkageAwareComponentMixIn
+		, ModelBackedHasBaseNameMixIn
 	{
 		@Override
 		public CSourceSet getCSources() {

--- a/subprojects/platform-cpp/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppApplicationPlugin.java
+++ b/subprojects/platform-cpp/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppApplicationPlugin.java
@@ -100,6 +100,7 @@ public class CppApplicationPlugin implements Plugin<Project> {
 		, ModelBackedHasDevelopmentVariantMixIn<NativeApplication>
 		, ModelBackedTargetMachineAwareComponentMixIn
 		, ModelBackedTargetBuildTypeAwareComponentMixIn
+		, ModelBackedHasBaseNameMixIn
 	{
 		@Override
 		public CppSourceSet getCppSources() {

--- a/subprojects/platform-cpp/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppLibraryPlugin.java
+++ b/subprojects/platform-cpp/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppLibraryPlugin.java
@@ -104,6 +104,7 @@ public class CppLibraryPlugin implements Plugin<Project> {
 		, ModelBackedTargetMachineAwareComponentMixIn
 		, ModelBackedTargetBuildTypeAwareComponentMixIn
 		, ModelBackedTargetLinkageAwareComponentMixIn
+		, ModelBackedHasBaseNameMixIn
 	{
 		@Override
 		public CppSourceSet getCppSources() {

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/ObjectiveCIosApplicationPlugin.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/ObjectiveCIosApplicationPlugin.java
@@ -137,6 +137,7 @@ public class ObjectiveCIosApplicationPlugin implements Plugin<Project> {
 		, ModelBackedSourceAwareComponentMixIn<ObjectiveCIosApplicationSources>
 		, ModelBackedBinaryAwareComponentMixIn
 		, ModelBackedTaskAwareComponentMixIn
+		, ModelBackedHasBaseNameMixIn
 	{
 		@Override
 		public ObjectiveCSourceSet getObjectiveCSources() {

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/SwiftIosApplicationPlugin.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/SwiftIosApplicationPlugin.java
@@ -92,6 +92,7 @@ public class SwiftIosApplicationPlugin implements Plugin<Project> {
 		, ModelBackedSourceAwareComponentMixIn<SwiftIosApplicationSources>
 		, ModelBackedBinaryAwareComponentMixIn
 		, ModelBackedTaskAwareComponentMixIn
+		, ModelBackedHasBaseNameMixIn
 	{
 		@Override
 		public SwiftSourceSet getSwiftSources() {

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/JavaNativeInterfaceLibrary.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/JavaNativeInterfaceLibrary.java
@@ -15,10 +15,14 @@
  */
 package dev.nokee.platform.jni;
 
+import dev.nokee.model.internal.core.ModelNodeUtils;
+import dev.nokee.model.internal.core.ModelNodes;
 import dev.nokee.model.internal.core.ModelProperties;
 import dev.nokee.platform.base.*;
+import dev.nokee.platform.base.internal.BaseComponent;
 import dev.nokee.platform.nativebase.TargetMachineAwareComponent;
 import dev.nokee.runtime.nativebase.TargetMachine;
+import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
 
 /**
@@ -42,5 +46,12 @@ public interface JavaNativeInterfaceLibrary extends JniLibraryExtension, Compone
 	@Override
 	default SetProperty<TargetMachine> getTargetMachines() {
 		return ModelProperties.getProperty(this, "targetMachines").as(SetProperty.class).get();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	default Property<String> getBaseName() {
+		return ModelNodeUtils.get(ModelNodes.of(this), BaseComponent.class).getBaseName();
 	}
 }

--- a/subprojects/platform-native/platform-native.gradle
+++ b/subprojects/platform-native/platform-native.gradle
@@ -18,6 +18,8 @@ dependencies {
 	implementation "commons-io:commons-io:${commonsIoVersion}"
 	implementation project(':coreExec')
 	implementation project(':runtimeDarwin')
+	implementation "com.google.auto.factory:auto-factory:${autoFactoryVersion}"
+	annotationProcessor "com.google.auto.factory:auto-factory:${autoFactoryVersion}"
 
 	testFixturesImplementation project(':internalTesting')
 	testFixturesImplementation project(':runtimeNative')

--- a/subprojects/platform-native/platform-native.gradle
+++ b/subprojects/platform-native/platform-native.gradle
@@ -28,6 +28,7 @@ dependencies {
 	testFixturesImplementation testFixtures(project(':languageObjectiveC'))
 	testFixturesImplementation testFixtures(project(':languageObjectiveCpp'))
 	testFixturesImplementation testFixtures(project(':languageSwift'))
+	testFixturesImplementation testFixtures(project(':platformBase'))
 	testFixturesApi 'dev.nokee:templates:latest.integration'
 }
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/SharedLibraryBinary.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/SharedLibraryBinary.java
@@ -18,6 +18,7 @@ package dev.nokee.platform.nativebase;
 import dev.nokee.language.base.tasks.SourceCompile;
 import dev.nokee.platform.base.TaskView;
 import dev.nokee.platform.nativebase.tasks.LinkSharedLibrary;
+import org.gradle.api.Buildable;
 import org.gradle.api.tasks.TaskProvider;
 
 /**
@@ -25,7 +26,7 @@ import org.gradle.api.tasks.TaskProvider;
  *
  * @since 0.3
  */
-public interface SharedLibraryBinary extends NativeBinary {
+public interface SharedLibraryBinary extends NativeBinary, Buildable {
 	/**
 	 * Returns a view of all the compile tasks that participate to compiling all the object files for this binary.
 	 *

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/SharedLibraryBinary.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/SharedLibraryBinary.java
@@ -16,6 +16,7 @@
 package dev.nokee.platform.nativebase;
 
 import dev.nokee.language.base.tasks.SourceCompile;
+import dev.nokee.platform.base.HasBaseName;
 import dev.nokee.platform.base.TaskView;
 import dev.nokee.platform.nativebase.tasks.LinkSharedLibrary;
 import org.gradle.api.Buildable;
@@ -26,7 +27,7 @@ import org.gradle.api.tasks.TaskProvider;
  *
  * @since 0.3
  */
-public interface SharedLibraryBinary extends NativeBinary, Buildable {
+public interface SharedLibraryBinary extends NativeBinary, Buildable, HasBaseName {
 	/**
 	 * Returns a view of all the compile tasks that participate to compiling all the object files for this binary.
 	 *

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/AttachLinkLibrariesToLinkTaskRule.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/AttachLinkLibrariesToLinkTaskRule.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.platform.nativebase.internal;
+
+import com.google.common.collect.ImmutableList;
+import dev.nokee.model.internal.core.ModelActionWithInputs;
+import dev.nokee.model.internal.core.ModelNode;
+import dev.nokee.platform.base.internal.BinaryIdentifier;
+import dev.nokee.platform.base.internal.util.PropertyUtils;
+import dev.nokee.platform.nativebase.tasks.ObjectLink;
+import dev.nokee.utils.ActionUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.gradle.api.Action;
+import org.gradle.api.Task;
+import org.gradle.api.Transformer;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.provider.Provider;
+import org.gradle.nativeplatform.tasks.AbstractLinkTask;
+
+import java.nio.file.Path;
+import java.util.function.BiConsumer;
+
+import static dev.nokee.platform.base.internal.util.PropertyUtils.*;
+import static dev.nokee.utils.TransformerUtils.flatTransformEach;
+
+public final class AttachLinkLibrariesToLinkTaskRule extends ModelActionWithInputs.ModelAction4<BinaryIdentifier<?>, DependentLinkLibraries, DependentFrameworks, NativeLinkTask> {
+	private final BinaryIdentifier<?> identifier;
+
+	public AttachLinkLibrariesToLinkTaskRule(BinaryIdentifier<?> identifier) {
+		this.identifier = identifier;
+	}
+
+	@Override
+	protected void execute(ModelNode entity, BinaryIdentifier<?> identifier, DependentLinkLibraries incomingLibraries, DependentFrameworks incomingFrameworks, NativeLinkTask linkTask) {
+		if (identifier.equals(this.identifier)) {
+			linkTask.configure(ObjectLink.class, configureLibraries(from(incomingLibraries)));
+			linkTask.configure(ObjectLink.class, configureLinkerArgs(addAll(asFrameworkFlags(incomingFrameworks))));
+		}
+	}
+
+	//region Link libraries
+	public static <SELF extends Task> ActionUtils.Action<SELF> configureLibraries(BiConsumer<? super SELF, ? super PropertyUtils.FileCollectionProperty> action) {
+		return task -> action.accept(task, wrap(librariesProperty(task)));
+	}
+
+	private static ConfigurableFileCollection librariesProperty(Task task) {
+		if (task instanceof AbstractLinkTask) {
+			return ((AbstractLinkTask) task).getLibs();
+		} else {
+			throw new IllegalArgumentException();
+		}
+	}
+	//endregion
+
+	//region Compiler arguments
+	private static Action<ObjectLink> configureLinkerArgs(BiConsumer<? super ObjectLink, ? super PropertyUtils.CollectionProperty<String>> action) {
+		return task -> action.accept(task, wrap(task.getLinkerArgs()));
+	}
+
+	private static Transformer<Iterable<String>, Path> toFrameworkSearchPathFlags() {
+		return it -> ImmutableList.of("-F", it.getParent().toString());
+	}
+
+	private static Transformer<Iterable<String>, Path> toFrameworkFlags() {
+		return it -> ImmutableList.of("-framework", FilenameUtils.removeExtension(it.getFileName().toString()));
+	}
+
+	private static Provider<Iterable<String>> asFrameworkFlags(DependentFrameworks frameworksSearchPaths) {
+		return frameworksSearchPaths.getAsProvider().map(flatTransformEach(it -> {
+			return ImmutableList.<String>builder()
+				.addAll(toFrameworkSearchPathFlags().transform(it))
+				.addAll(toFrameworkFlags().transform(it))
+				.build();
+		}));
+	}
+	//endregion
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/AttachObjectFilesToLinkTaskRule.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/AttachObjectFilesToLinkTaskRule.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.platform.nativebase.internal;
+
+import dev.nokee.model.internal.core.ModelActionWithInputs;
+import dev.nokee.model.internal.core.ModelNode;
+import dev.nokee.platform.base.internal.BinaryIdentifier;
+import dev.nokee.platform.base.internal.util.PropertyUtils;
+import dev.nokee.platform.nativebase.tasks.ObjectLink;
+import dev.nokee.utils.ActionUtils;
+import org.gradle.api.Task;
+import org.gradle.nativeplatform.tasks.AbstractLinkTask;
+import org.gradle.nativeplatform.tasks.CreateStaticLibrary;
+
+import java.util.function.BiConsumer;
+
+import static dev.nokee.platform.base.internal.util.PropertyUtils.from;
+import static dev.nokee.platform.base.internal.util.PropertyUtils.wrap;
+
+public final class AttachObjectFilesToLinkTaskRule extends ModelActionWithInputs.ModelAction3<BinaryIdentifier<?>, ObjectFiles, NativeLinkTask> {
+	private final BinaryIdentifier<?> identifier;
+
+	public AttachObjectFilesToLinkTaskRule(BinaryIdentifier<?> identifier) {
+		this.identifier = identifier;
+	}
+
+	@Override
+	protected void execute(ModelNode entity, BinaryIdentifier<?> identifier, ObjectFiles objectFiles, NativeLinkTask linkTask) {
+		if (identifier.equals(this.identifier)) {
+			linkTask.configure(ObjectLink.class, configureSource(from(objectFiles)));
+		}
+	}
+
+	//region Task sources
+	public static <SELF extends Task> ActionUtils.Action<SELF> configureSource(BiConsumer<? super SELF, ? super PropertyUtils.FileCollectionProperty> action) {
+		return self -> action.accept(self, sourceProperty(self));
+	}
+
+	private static PropertyUtils.FileCollectionProperty sourceProperty(Task task) {
+		if (task instanceof AbstractLinkTask) {
+			return wrap(((AbstractLinkTask) task).getSource());
+		} else if (task instanceof CreateStaticLibrary) {
+			return new PropertyUtils.FileCollectionProperty() {
+				private final CreateStaticLibrary createTask = (CreateStaticLibrary) task;
+
+				@Override
+				public void from(Object... paths) {
+					createTask.source(paths);
+				}
+
+				@Override
+				public void add(Object value) {
+					createTask.source(value);
+				}
+
+				@Override
+				public void addAll(Iterable<?> values) {
+					createTask.source(values);
+				}
+
+				@Override
+				public void set(Object value) {
+					throw new UnsupportedOperationException();
+				}
+
+				@Override
+				public void finalizeValue() {
+					// do nothing
+				}
+
+				@Override
+				public void finalizeValueOnRead() {
+					// do nothing
+				}
+
+				@Override
+				public void disallowChanges() {
+					// do nothing
+				}
+			};
+		} else {
+			throw new IllegalArgumentException("Could not configure the source of " + task);
+		}
+	}
+	//endregion
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseName.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,23 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.nokee.platform.nativebase.tasks.internal;
+package dev.nokee.platform.nativebase.internal;
 
-import dev.nokee.platform.nativebase.tasks.LinkSharedLibrary;
-import org.gradle.api.file.RegularFile;
+import dev.nokee.model.DomainObjectProvider;
+import org.gradle.api.Transformer;
 import org.gradle.api.provider.Provider;
-import org.gradle.api.tasks.CacheableTask;
 
-import java.io.File;
+import java.util.function.Supplier;
 
-@CacheableTask
-public abstract class LinkSharedLibraryTask extends org.gradle.nativeplatform.tasks.LinkSharedLibrary implements LinkSharedLibrary, ObjectFilesToBinaryTask {
-	public LinkSharedLibraryTask() {
-		getDestinationDirectory().set((File) null);
+public final class BaseName implements Supplier<String> {
+	private final DomainObjectProvider<String> value;
+
+	public BaseName(DomainObjectProvider<String> value) {
+		this.value = value;
+	}
+
+	public String get() {
+		return value.get();
+	}
+
+	public <S> Provider<S> map(Transformer<? extends S, ? super String> mapper) {
+		return value.map(mapper);
 	}
 
 	@Override
-	public Provider<RegularFile> getBinaryFile() {
-		return getLinkedFile();
+	public String toString() {
+		return get();
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNamePropertyRegistrationAction.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNamePropertyRegistrationAction.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.platform.nativebase.internal;
+
+import com.google.auto.factory.AutoFactory;
+import com.google.auto.factory.Provided;
+import dev.nokee.model.internal.ModelPropertyIdentifier;
+import dev.nokee.model.internal.core.ModelActionWithInputs;
+import dev.nokee.model.internal.core.ModelNode;
+import dev.nokee.model.internal.core.ModelPropertyRegistrationFactory;
+import dev.nokee.model.internal.registry.ModelRegistry;
+import dev.nokee.model.internal.state.ModelState;
+import dev.nokee.platform.base.internal.BinaryIdentifier;
+import lombok.val;
+import org.gradle.api.provider.Property;
+
+@AutoFactory
+public final class BaseNamePropertyRegistrationAction extends ModelActionWithInputs.ModelAction2<BinaryIdentifier<?>, ModelState.IsAtLeastRegistered> {
+	private final BinaryIdentifier<?> identifier;
+	private final ModelRegistry registry;
+	private final ModelPropertyRegistrationFactory propertyRegistrationFactory;
+
+	public BaseNamePropertyRegistrationAction(BinaryIdentifier<?> identifier, @Provided ModelRegistry registry, @Provided ModelPropertyRegistrationFactory propertyRegistrationFactory) {
+		this.identifier = identifier;
+		this.registry = registry;
+		this.propertyRegistrationFactory = propertyRegistrationFactory;
+	}
+
+	@Override
+	protected void execute(ModelNode entity, BinaryIdentifier<?> identifier, ModelState.IsAtLeastRegistered ignored) {
+		if (identifier.equals(this.identifier)) {
+			val baseNameProperty = registry.register(propertyRegistrationFactory.createProperty(ModelPropertyIdentifier.of(identifier, "baseName"), String.class));
+			baseNameProperty.configure(Property.class, it -> it.convention(identifier.getName().get()));
+			entity.addComponent(new BaseName(baseNameProperty.as(String.class)));
+		}
+	}
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/ConfigureLinkTaskDefaultsRule.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/ConfigureLinkTaskDefaultsRule.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.platform.nativebase.internal;
+
+import dev.nokee.model.internal.core.ModelActionWithInputs;
+import dev.nokee.model.internal.core.ModelNode;
+import dev.nokee.platform.base.internal.BinaryIdentifier;
+import dev.nokee.platform.base.internal.util.PropertyUtils;
+import dev.nokee.platform.nativebase.tasks.internal.LinkSharedLibraryTask;
+import org.gradle.api.Action;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.provider.Provider;
+
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import static dev.nokee.platform.base.internal.util.PropertyUtils.*;
+
+final class ConfigureLinkTaskDefaultsRule extends ModelActionWithInputs.ModelAction2<BinaryIdentifier<?>, NativeLinkTask> {
+	private final BinaryIdentifier<?> identifier;
+
+	public ConfigureLinkTaskDefaultsRule(BinaryIdentifier<?> identifier) {
+		this.identifier = identifier;
+	}
+
+	@Override
+	protected void execute(ModelNode entity, BinaryIdentifier<?> identifier, NativeLinkTask linkTask) {
+		if (identifier.equals(this.identifier)) {
+			linkTask.configure(LinkSharedLibraryTask.class, configureInstallName(convention(ofLinkedFileFileName())));
+			linkTask.configure(LinkSharedLibraryTask.class, configureImportLibrary(lockProperty())); // Already has sensible default in task implementation)
+		}
+	}
+
+	//region Install name
+	private static Action<LinkSharedLibraryTask> configureInstallName(BiConsumer<? super LinkSharedLibraryTask, ? super PropertyUtils.Property<String>> action) {
+		return task -> action.accept(task, wrap(task.getInstallName()));
+	}
+
+	private static Function<LinkSharedLibraryTask, Provider<String>> ofLinkedFileFileName() {
+		return task -> task.getLinkedFile().getLocationOnly().map(linkedFile -> linkedFile.getAsFile().getName());
+	}
+	//endregion
+
+	//region Import library
+	private static Action<LinkSharedLibraryTask> configureImportLibrary(BiConsumer<? super LinkSharedLibraryTask, ? super PropertyUtils.Property<? extends RegularFile>> action) {
+		return task -> action.accept(task, wrap(task.getImportLibrary()));
+	}
+	//endregion
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/ConfigureLinkTaskFromBaseNameRule.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/ConfigureLinkTaskFromBaseNameRule.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.platform.nativebase.internal;
+
+import com.google.common.collect.ImmutableList;
+import dev.nokee.model.DomainObjectProvider;
+import dev.nokee.model.internal.core.ModelActionWithInputs;
+import dev.nokee.model.internal.core.ModelNode;
+import dev.nokee.platform.base.internal.BinaryIdentifier;
+import dev.nokee.platform.base.internal.util.PropertyUtils;
+import dev.nokee.platform.nativebase.tasks.ObjectLink;
+import org.gradle.api.Action;
+import org.gradle.api.Task;
+import org.gradle.api.Transformer;
+import org.gradle.api.file.Directory;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.nativeplatform.platform.NativePlatform;
+import org.gradle.nativeplatform.platform.internal.NativePlatformInternal;
+import org.gradle.nativeplatform.tasks.AbstractLinkTask;
+import org.gradle.nativeplatform.toolchain.NativeToolChain;
+import org.gradle.nativeplatform.toolchain.Swiftc;
+import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
+import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
+import org.gradle.util.GUtil;
+
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import static dev.nokee.platform.base.internal.util.PropertyUtils.*;
+
+public final class ConfigureLinkTaskFromBaseNameRule extends ModelActionWithInputs.ModelAction3<BinaryIdentifier<?>, BaseName, NativeLinkTask> {
+	private final BinaryIdentifier<?> identifier;
+
+	public ConfigureLinkTaskFromBaseNameRule(BinaryIdentifier<?> identifier) {
+		this.identifier = identifier;
+	}
+
+	@Override
+	protected void execute(ModelNode entity, BinaryIdentifier<?> objects, BaseName baseName, NativeLinkTask linkTask) {
+		if (identifier.equals(this.identifier)) {
+			linkTask.configure(ObjectLink.class, configureLinkerArgs(addAll(forSwiftModuleName(baseName))));
+			linkTask.configure(ObjectLink.class, configureLinkedFile(convention(asSharedLibraryFile(baseName))));
+		}
+	}
+
+	//region Linker arguments
+	private static Action<ObjectLink> configureLinkerArgs(BiConsumer<? super ObjectLink, ? super PropertyUtils.CollectionProperty<String>> action) {
+		return task -> action.accept(task, wrap(task.getLinkerArgs()));
+	}
+
+	private static Function<ObjectLink, Object> forSwiftModuleName(BaseName baseName) {
+		return task -> ((AbstractLinkTask) task).getToolChain().map(it -> {
+			if (it instanceof Swiftc) {
+				return ImmutableList.of("-module-name", baseName.map(toModuleName()).get());
+			} else {
+				return ImmutableList.of();
+			}
+		}).orElse(ImmutableList.of());
+	}
+
+	private static Transformer<String, String> toModuleName() {
+		return GUtil::toCamelCase;
+	}
+	//endregion
+
+	//region Linked file
+	private static <T extends Task> Action<T> configureLinkedFile(BiConsumer<? super T, ? super PropertyUtils.Property<RegularFile>> action) {
+		return task -> action.accept(task, PropertyUtils.wrap(linkedFileProperty(task)));
+	}
+
+	private static Function<ObjectLink, Object> asSharedLibraryFile(BaseName baseName) {
+		return task -> toolChainProperty(task)
+			.map(selectToolProvider(targetPlatformProperty(task)))
+			.map(it -> fileNamer(it))
+			.orElse(targetPlatformProperty(task).map(it -> fileNamer(it)))
+			.flatMap(sharedLibraryLinkedFile(task.getDestinationDirectory(), baseName));
+	}
+
+	private interface FileNamer {
+		String getSharedLibraryName(String libraryPath);
+	}
+
+	private static FileNamer fileNamer(PlatformToolProvider toolProvider) {
+		return new PlatformToolFileNamer(toolProvider);
+	}
+
+	private static FileNamer fileNamer(NativePlatform targetPlatform) {
+		return new TargetPlatformFileNamer(targetPlatform);
+	}
+
+	private static final class PlatformToolFileNamer implements FileNamer {
+		private final PlatformToolProvider toolProvider;
+
+		private PlatformToolFileNamer(PlatformToolProvider toolProvider) {
+			this.toolProvider = toolProvider;
+		}
+
+		@Override
+		public String getSharedLibraryName(String libraryPath) {
+			return toolProvider.getSharedLibraryName(libraryPath);
+		}
+	}
+
+	private static final class TargetPlatformFileNamer implements FileNamer {
+		private final NativePlatform targetPlatform;
+
+		private TargetPlatformFileNamer(NativePlatform targetPlatform) {
+			this.targetPlatform = targetPlatform;
+		}
+
+		@Override
+		public String getSharedLibraryName(String libraryPath) {
+			return ((NativePlatformInternal) targetPlatform).getOperatingSystem().getInternalOs().getSharedLibraryName(libraryPath);
+		}
+	}
+
+	private static Transformer<Provider<RegularFile>, FileNamer> sharedLibraryLinkedFile(Provider<Directory> destinationDirectory, BaseName baseName) {
+		return toolProvider -> destinationDirectory.flatMap(dir -> dir.file(baseName.map(toolProvider::getSharedLibraryName)));
+	}
+
+	private static Transformer<PlatformToolProvider, NativeToolChain> selectToolProvider(Provider<NativePlatform> nativePlatform) {
+		return toolChain -> {
+			NativeToolChainInternal toolChainInternal = (NativeToolChainInternal) toolChain;
+			return toolChainInternal.select((NativePlatformInternal) nativePlatform.get());
+		};
+	}
+
+	private static RegularFileProperty linkedFileProperty(Task task) {
+		if (task instanceof AbstractLinkTask) {
+			return ((AbstractLinkTask) task).getLinkedFile();
+		} else {
+			throw new IllegalArgumentException();
+		}
+	}
+
+	private static Property<NativePlatform> targetPlatformProperty(Task task) {
+		if (task instanceof AbstractLinkTask) {
+			return ((AbstractLinkTask) task).getTargetPlatform();
+		} else {
+			throw new IllegalArgumentException();
+		}
+	}
+
+	private static Property<NativeToolChain> toolChainProperty(Task task) {
+		if (task instanceof AbstractLinkTask) {
+			return ((AbstractLinkTask) task).getToolChain();
+		} else {
+			throw new IllegalArgumentException();
+		}
+	}
+	//endregion
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DependentFrameworks.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DependentFrameworks.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.platform.nativebase.internal;
+
+import org.gradle.api.provider.Provider;
+
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.concurrent.Callable;
+
+public final class DependentFrameworks implements Callable<Object> {
+	private final Provider<Set<Path>> delegate;
+
+	public DependentFrameworks(Provider<Set<Path>> delegate) {
+		this.delegate = delegate;
+	}
+
+	public Set<Path> get() {
+		return delegate.get();
+	}
+
+	public Provider<Set<Path>> getAsProvider() {
+		return delegate;
+	}
+
+	@Override
+	public Object call() throws Exception {
+		return delegate;
+	}
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DependentLinkLibraries.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DependentLinkLibraries.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.platform.nativebase.internal;
+
+import org.gradle.api.provider.Provider;
+
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.concurrent.Callable;
+
+final class DependentLinkLibraries implements Callable<Object> {
+	private final Provider<Set<Path>> delegate;
+
+	DependentLinkLibraries(Provider<Set<Path>> delegate) {
+		this.delegate = delegate;
+	}
+
+	public Set<Path> get() {
+		return delegate.get();
+	}
+
+	@Override
+	public Object call() throws Exception {
+		return delegate;
+	}
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/LinkLibrariesConfigurationRegistrationAction.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/LinkLibrariesConfigurationRegistrationAction.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.platform.nativebase.internal;
+
+import com.google.auto.factory.AutoFactory;
+import com.google.auto.factory.Provided;
+import dev.nokee.language.nativebase.internal.FrameworkAwareIncomingArtifacts;
+import dev.nokee.model.internal.core.ModelActionWithInputs;
+import dev.nokee.model.internal.core.ModelElement;
+import dev.nokee.model.internal.core.ModelNode;
+import dev.nokee.model.internal.registry.ModelRegistry;
+import dev.nokee.model.internal.state.ModelState;
+import dev.nokee.platform.base.internal.BinaryIdentifier;
+import dev.nokee.platform.base.internal.dependencies.DependencyBucketIdentifier;
+import dev.nokee.platform.base.internal.dependencies.ResolvableDependencyBucketRegistrationFactory;
+import lombok.val;
+import org.gradle.api.Action;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ResolvableDependencies;
+import org.gradle.api.attributes.Usage;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Provider;
+
+import static dev.nokee.language.nativebase.internal.FrameworkAwareIncomingArtifacts.frameworks;
+import static dev.nokee.platform.base.internal.dependencies.DependencyBucketIdentity.resolvable;
+import static dev.nokee.utils.ConfigurationUtils.configureAttributes;
+
+@AutoFactory
+public final class LinkLibrariesConfigurationRegistrationAction extends ModelActionWithInputs.ModelAction2<BinaryIdentifier<?>, ModelState.IsAtLeastRegistered> {
+	private final BinaryIdentifier<?> identifier;
+	private final ModelRegistry registry;
+	private final ResolvableDependencyBucketRegistrationFactory resolvableFactory;
+	private final ObjectFactory objects;
+
+	LinkLibrariesConfigurationRegistrationAction(BinaryIdentifier<?> identifier, @Provided ModelRegistry registry, @Provided ResolvableDependencyBucketRegistrationFactory resolvableFactory, @Provided ObjectFactory objects) {
+		this.identifier = identifier;
+		this.registry = registry;
+		this.resolvableFactory = resolvableFactory;
+		this.objects = objects;
+	}
+
+	@Override
+	protected void execute(ModelNode entity, BinaryIdentifier<?> identifier, ModelState.IsAtLeastRegistered isAtLeastRegistered) {
+		if (identifier.equals(this.identifier)) {
+			val linkLibraries = registry.register(resolvableFactory.create(DependencyBucketIdentifier.of(resolvable("linkLibraries"), identifier)));
+			linkLibraries.configure(Configuration.class, forNativeLinkUsage());
+			val incomingArtifacts = FrameworkAwareIncomingArtifacts.from(incomingArtifactsOf(linkLibraries));
+			entity.addComponent(new DependentFrameworks(incomingArtifacts.getAs(frameworks())));
+			entity.addComponent(new DependentLinkLibraries(incomingArtifacts.getAs(frameworks().negate())));
+		}
+	}
+
+	private Action<Configuration> forNativeLinkUsage() {
+		return configureAttributes(builder -> builder.usage(objects.named(Usage.class, Usage.NATIVE_LINK)));
+	}
+
+	private Provider<ResolvableDependencies> incomingArtifactsOf(ModelElement element) {
+		return element.as(Configuration.class).map(Configuration::getIncoming);
+	}
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/NativeBinaryBuildable.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/NativeBinaryBuildable.java
@@ -1,0 +1,101 @@
+package dev.nokee.platform.nativebase.internal;
+
+import com.google.common.base.Suppliers;
+import dev.nokee.language.base.tasks.SourceCompile;
+import dev.nokee.language.swift.tasks.internal.SwiftCompileTask;
+import dev.nokee.platform.nativebase.*;
+import dev.nokee.platform.nativebase.tasks.CreateStaticLibrary;
+import dev.nokee.platform.nativebase.tasks.LinkBundle;
+import dev.nokee.platform.nativebase.tasks.LinkExecutable;
+import dev.nokee.platform.nativebase.tasks.LinkSharedLibrary;
+import dev.nokee.platform.nativebase.tasks.internal.CreateStaticLibraryTask;
+import org.gradle.language.nativeplatform.tasks.AbstractNativeCompileTask;
+import org.gradle.nativeplatform.platform.NativePlatform;
+import org.gradle.nativeplatform.platform.internal.NativePlatformInternal;
+import org.gradle.nativeplatform.tasks.AbstractLinkTask;
+import org.gradle.nativeplatform.tasks.LinkMachOBundle;
+import org.gradle.nativeplatform.toolchain.NativeToolChain;
+import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
+import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
+
+import java.util.function.Supplier;
+
+public final class NativeBinaryBuildable {
+	private final NativeBinary delegate;
+	private final Supplier<Boolean> value = Suppliers.memoize(this::isBuildable);
+
+	public NativeBinaryBuildable(NativeBinary delegate) {
+		this.delegate = delegate;
+	}
+
+	public boolean get() {
+		return value.get();
+	}
+
+	private boolean isBuildable() {
+		try {
+			if (delegate instanceof BundleBinary) {
+				return isBuildable(delegate) && isBuildable(((BundleBinary) delegate).getLinkTask().get());
+			} else if (delegate instanceof StaticLibraryBinary) {
+				return isBuildable(delegate) && isBuildable(((StaticLibraryBinary) delegate).getCreateTask().get());
+			} else if (delegate instanceof SharedLibraryBinary) {
+				return isBuildable(delegate) && isBuildable(((SharedLibraryBinary) delegate).getLinkTask().get());
+			} else if (delegate instanceof ExecutableBinary) {
+				return isBuildable(delegate) && isBuildable(((ExecutableBinary) delegate).getLinkTask().get());
+			} else {
+				throw new UnsupportedOperationException(String.format("Native binary type '%s' is not known.", delegate));
+			}
+		} catch (Throwable ex) { // because toolchain selection calls xcrun for macOS which doesn't exists on non-mac system
+			return false;
+		}
+	}
+
+	private static boolean isBuildable(CreateStaticLibrary createTask) {
+		CreateStaticLibraryTask createTaskInternal = (CreateStaticLibraryTask)createTask;
+		return isBuildable(createTaskInternal.getToolChain().get(), createTaskInternal.getTargetPlatform().get());
+	}
+
+	private static boolean isBuildable(LinkBundle linkTask) {
+		LinkMachOBundle linkTaskInternal = (LinkMachOBundle)linkTask;
+		return isBuildable(linkTaskInternal.getToolChain().get(), linkTaskInternal.getTargetPlatform().get());
+	}
+
+	private static boolean isBuildable(LinkSharedLibrary linkTask) {
+		AbstractLinkTask linkTaskInternal = (AbstractLinkTask)linkTask;
+		return isBuildable(linkTaskInternal.getToolChain().get(), linkTaskInternal.getTargetPlatform().get());
+	}
+
+	private static boolean isBuildable(LinkExecutable linkTask) {
+		AbstractLinkTask linkTaskInternal = (AbstractLinkTask)linkTask;
+		return isBuildable(linkTaskInternal.getToolChain().get(), linkTaskInternal.getTargetPlatform().get());
+	}
+
+	private static boolean isBuildable(NativeBinary binary) {
+		return binary.getCompileTasks().get().stream().allMatch(NativeBinaryBuildable::isBuildable);
+	}
+
+	private static boolean isBuildable(SourceCompile task) {
+		if (task instanceof AbstractNativeCompileTask) {
+			return isBuildable((AbstractNativeCompileTask) task);
+		} else if (task instanceof SwiftCompileTask) {
+			return isBuildable((SwiftCompileTask) task);
+		} else {
+			return true; // assume buildable
+		}
+	}
+
+	private static boolean isBuildable(AbstractNativeCompileTask compileTask) {
+		return isBuildable(compileTask.getToolChain().get(), compileTask.getTargetPlatform().get());
+	}
+
+	private static boolean isBuildable(SwiftCompileTask compileTask) {
+		return isBuildable(compileTask.getToolChain().get(), compileTask.getTargetPlatform().get());
+	}
+
+	private static boolean isBuildable(NativeToolChain toolchain, NativePlatform platform) {
+		NativeToolChainInternal toolchainInternal = (NativeToolChainInternal)toolchain;
+		NativePlatformInternal platformInternal = (NativePlatformInternal)platform;
+		PlatformToolProvider toolProvider = toolchainInternal.select(platformInternal);
+		return toolProvider.isAvailable();
+	}
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/NativeLinkTask.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/NativeLinkTask.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.platform.nativebase.internal;
+
+import dev.nokee.model.internal.core.ModelElement;
+import dev.nokee.platform.nativebase.tasks.ObjectLink;
+import org.gradle.api.Action;
+
+public final class NativeLinkTask {
+	private final ModelElement delegate;
+
+	NativeLinkTask(ModelElement delegate) {
+		this.delegate = delegate;
+	}
+
+	public <T extends ObjectLink> void configure(Class<T> type, Action<? super T> action) {
+		delegate.configure(type, action);
+	}
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/NativeLinkTaskRegistrationAction.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/NativeLinkTaskRegistrationAction.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.platform.nativebase.internal;
+
+import com.google.auto.factory.AutoFactory;
+import com.google.auto.factory.Provided;
+import com.google.common.collect.ImmutableList;
+import dev.nokee.core.exec.CommandLine;
+import dev.nokee.core.exec.ProcessBuilderEngine;
+import dev.nokee.language.base.HasDestinationDirectory;
+import dev.nokee.language.nativebase.internal.NativeToolChainSelector;
+import dev.nokee.model.DomainObjectIdentifier;
+import dev.nokee.model.DomainObjectProvider;
+import dev.nokee.model.internal.ModelPropertyIdentifier;
+import dev.nokee.model.internal.core.ModelActionWithInputs;
+import dev.nokee.model.internal.core.ModelNode;
+import dev.nokee.model.internal.core.ModelNodes;
+import dev.nokee.model.internal.core.ModelPropertyRegistrationFactory;
+import dev.nokee.model.internal.registry.ModelRegistry;
+import dev.nokee.model.internal.state.ModelState;
+import dev.nokee.platform.base.internal.BinaryIdentifier;
+import dev.nokee.platform.base.internal.TaskRegistrationFactory;
+import dev.nokee.platform.base.internal.tasks.TaskIdentifier;
+import dev.nokee.platform.base.internal.tasks.TaskName;
+import dev.nokee.platform.base.internal.util.PropertyUtils;
+import dev.nokee.platform.nativebase.tasks.ObjectLink;
+import lombok.val;
+import org.gradle.api.Action;
+import org.gradle.api.Task;
+import org.gradle.api.Transformer;
+import org.gradle.api.file.Directory;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.language.nativeplatform.tasks.AbstractNativeCompileTask;
+import org.gradle.language.swift.tasks.SwiftCompile;
+import org.gradle.nativeplatform.platform.NativePlatform;
+import org.gradle.nativeplatform.platform.internal.NativePlatformInternal;
+import org.gradle.nativeplatform.tasks.AbstractLinkTask;
+import org.gradle.nativeplatform.tasks.CreateStaticLibrary;
+import org.gradle.nativeplatform.toolchain.NativeToolChain;
+import org.gradle.nativeplatform.toolchain.Swiftc;
+import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
+import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
+import org.gradle.util.GUtil;
+
+import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import static dev.nokee.model.internal.DomainObjectIdentifierUtils.toDirectoryPath;
+import static dev.nokee.platform.base.internal.util.PropertyUtils.*;
+import static dev.nokee.utils.TaskUtils.configureDescription;
+
+@AutoFactory
+public final class NativeLinkTaskRegistrationAction extends ModelActionWithInputs.ModelAction2<BinaryIdentifier<?>, ModelState.IsAtLeastRegistered> {
+	private final BinaryIdentifier<?> identifier;
+	private final Class<? extends ObjectLink> publicType;
+	private final Class<? extends ObjectLink> implementationType;
+	private final ModelRegistry registry;
+	private final TaskRegistrationFactory taskRegistrationFactory;
+	private final ModelPropertyRegistrationFactory propertyRegistrationFactory;
+	private final NativeToolChainSelector toolChainSelector;
+
+	public <T extends ObjectLink> NativeLinkTaskRegistrationAction(BinaryIdentifier<?> identifier, Class<T> publicType, Class<? extends T> implementationType, @Provided ModelRegistry registry, @Provided TaskRegistrationFactory taskRegistrationFactory, @Provided ModelPropertyRegistrationFactory propertyRegistrationFactory, @Provided NativeToolChainSelector toolChainSelector) {
+		this.identifier = identifier;
+		this.publicType = publicType;
+		this.implementationType = implementationType;
+		this.registry = registry;
+		this.taskRegistrationFactory = taskRegistrationFactory;
+		this.propertyRegistrationFactory = propertyRegistrationFactory;
+		this.toolChainSelector = toolChainSelector;
+	}
+
+	@Override
+	protected void execute(ModelNode entity, BinaryIdentifier<?> identifier, ModelState.IsAtLeastRegistered isAtLeastRegistered) {
+		if (identifier.equals(this.identifier)) {
+			val linkTask = registry.register(taskRegistrationFactory.create(TaskIdentifier.of(TaskName.of("link"), publicType, identifier), implementationType).build());
+			linkTask.configure(publicType, configureDescription("Links the %s.", identifier));
+			linkTask.configure(publicType, configureLinkerArgs(addAll(forMacOsSdkIfAvailable())));
+			linkTask.configure(publicType, configureToolChain(convention(selectToolChainUsing(toolChainSelector)).andThen(lockProperty())));
+			linkTask.configure(publicType, configureDestinationDirectory(convention(forLibrary(identifier))));
+			registry.register(propertyRegistrationFactory.create(ModelPropertyIdentifier.of(identifier, "linkTask"), ModelNodes.of(linkTask)));
+			entity.addComponent(new NativeLinkTask(linkTask));
+		}
+	}
+
+	//region Destination directory
+	private static <SELF extends Task & HasDestinationDirectory> Action<SELF> configureDestinationDirectory(BiConsumer<? super SELF, ? super PropertyUtils.Property<? extends Directory>> action) {
+		return task -> action.accept(task, wrap(task.getDestinationDirectory()));
+	}
+
+	private static Function<Task, Provider<Directory>> forLibrary(DomainObjectIdentifier identifier) {
+		return task -> task.getProject().getLayout().getBuildDirectory().dir("libs/" + toDirectoryPath(identifier));
+	}
+	//endregion
+
+	//region Toolchain
+	private static Action<Task> configureToolChain(BiConsumer<? super Task, ? super PropertyUtils.Property<? extends NativeToolChain>> action) {
+		return task -> action.accept(task, wrap(toolChainProperty(task)));
+	}
+
+	private static Function<Task, Object> selectToolChainUsing(NativeToolChainSelector toolChainSelector) {
+		Objects.requireNonNull(toolChainSelector);
+		return toolChainSelector::select;
+	}
+
+	private static Property<NativeToolChain> toolChainProperty(Task task) {
+		if (task instanceof AbstractLinkTask) {
+			return ((AbstractLinkTask) task).getToolChain();
+		} else {
+			throw new IllegalArgumentException();
+		}
+	}
+	//endregion
+
+	//region Linker arguments
+	private static Action<ObjectLink> configureLinkerArgs(BiConsumer<? super ObjectLink, ? super PropertyUtils.CollectionProperty<String>> action) {
+		return task -> action.accept(task, wrap(task.getLinkerArgs()));
+	}
+
+	private static Function<ObjectLink, Object> forMacOsSdkIfAvailable() {
+		return task -> ((AbstractLinkTask) task).getTargetPlatform().map(it -> {
+			if (((AbstractLinkTask) task).getToolChain().isPresent()) {
+				if (((AbstractLinkTask) task).getToolChain().get() instanceof Swiftc && it.getOperatingSystem().isMacOsX()) {
+					// TODO: Support DEVELOPER_DIR or request the xcrun tool from backend
+					return ImmutableList.of("-sdk", CommandLine.of("xcrun", "--show-sdk-path").execute(new ProcessBuilderEngine()).waitFor().assertNormalExitValue().getStandardOutput().getAsString().trim());
+				} else {
+					return ImmutableList.of();
+				}
+			} else {
+				return ImmutableList.of();
+			}
+		}).orElse(ImmutableList.of());
+	}
+
+	private static Function<ObjectLink, Object> forSwiftModuleName(DomainObjectProvider<String> baseName) {
+		return task -> ((AbstractLinkTask) task).getToolChain().map(it -> {
+			if (it instanceof Swiftc) {
+				return ImmutableList.of("-module-name", baseName.map(toModuleName()).get());
+			} else {
+				return ImmutableList.of();
+			}
+		});
+	}
+
+	private static Transformer<String, String> toModuleName() {
+		return GUtil::toCamelCase;
+	}
+	//endregion
+
+	//region Linked file
+	public static <T extends Task> Action<T> configureLinkedFile(BiConsumer<? super T, ? super PropertyUtils.Property<RegularFile>> action) {
+		return task -> action.accept(task, PropertyUtils.wrap(linkedFileProperty(task)));
+	}
+
+	public static Function<ObjectLink, Object> asSharedLibraryFile(Provider<String> baseNameProvider) {
+		return task -> toolChainProperty(task)
+			.map(selectToolProvider(targetPlatformProperty(task)))
+			.flatMap(sharedLibraryLinkedFile(task.getDestinationDirectory(), baseNameProvider));
+	}
+
+	private static Transformer<Provider<RegularFile>, PlatformToolProvider> sharedLibraryLinkedFile(Provider<Directory> destinationDirectory, Provider<String> baseName) {
+		return toolProvider -> destinationDirectory.flatMap(dir -> dir.file(baseName.map(toolProvider::getSharedLibraryName)));
+	}
+
+	private static Transformer<PlatformToolProvider, NativeToolChain> selectToolProvider(Provider<NativePlatform> nativePlatform) {
+		return toolChain -> {
+			NativeToolChainInternal toolChainInternal = (NativeToolChainInternal) toolChain;
+			return toolChainInternal.select((NativePlatformInternal) nativePlatform.get());
+		};
+	}
+
+	private static RegularFileProperty linkedFileProperty(Task task) {
+		if (task instanceof AbstractLinkTask) {
+			return ((AbstractLinkTask) task).getLinkedFile();
+		} else {
+			throw new IllegalArgumentException();
+		}
+	}
+
+	public static Property<NativePlatform> targetPlatformProperty(Task task) {
+		if (task instanceof AbstractLinkTask) {
+			return ((AbstractLinkTask) task).getTargetPlatform();
+		} else {
+			throw new IllegalArgumentException();
+		}
+	}
+	//endregion
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/ObjectFiles.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/ObjectFiles.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.platform.nativebase.internal;
+
+import org.gradle.api.provider.Provider;
+
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.concurrent.Callable;
+
+public final class ObjectFiles implements Callable<Object> {
+	private final Provider<Set<Path>> delegate;
+
+	public ObjectFiles(Provider<Set<Path>> delegate) {
+		this.delegate = delegate;
+	}
+
+	public Set<Path> get() {
+		return delegate.get();
+	}
+
+	@Override
+	public Object call() throws Exception {
+		return delegate;
+	}
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/RegisterCompileTasksPropertyAction.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/RegisterCompileTasksPropertyAction.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.platform.nativebase.internal;
+
+import com.google.auto.factory.AutoFactory;
+import com.google.auto.factory.Provided;
+import dev.nokee.language.base.tasks.SourceCompile;
+import dev.nokee.model.internal.ModelPropertyIdentifier;
+import dev.nokee.model.internal.core.ModelActionWithInputs;
+import dev.nokee.model.internal.core.ModelNode;
+import dev.nokee.model.internal.registry.ModelRegistry;
+import dev.nokee.model.internal.state.ModelState;
+import dev.nokee.platform.base.internal.BinaryIdentifier;
+import dev.nokee.platform.base.internal.ComponentTasksPropertyRegistrationFactory;
+
+@AutoFactory
+public final class RegisterCompileTasksPropertyAction extends ModelActionWithInputs.ModelAction2<BinaryIdentifier<?>, ModelState.IsAtLeastRegistered> {
+	private final BinaryIdentifier<?> identifier;
+	private final ModelRegistry registry;
+	private final ComponentTasksPropertyRegistrationFactory tasksPropertyRegistrationFactory;
+
+	public RegisterCompileTasksPropertyAction(BinaryIdentifier<?> identifier, @Provided ModelRegistry registry, @Provided ComponentTasksPropertyRegistrationFactory tasksPropertyRegistrationFactory) {
+		this.identifier = identifier;
+		this.registry = registry;
+		this.tasksPropertyRegistrationFactory = tasksPropertyRegistrationFactory;
+	}
+
+	@Override
+	protected void execute(ModelNode entity, BinaryIdentifier<?> identifier, ModelState.IsAtLeastRegistered isAtLeastRegistered) {
+		if (identifier.equals(this.identifier)) {
+			registry.register(tasksPropertyRegistrationFactory.create(ModelPropertyIdentifier.of(identifier, "compileTasks"), SourceCompile.class));
+		}
+	}
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/RegisterCompileTasksPropertyAction.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/RegisterCompileTasksPropertyAction.java
@@ -18,16 +18,33 @@ package dev.nokee.platform.nativebase.internal;
 import com.google.auto.factory.AutoFactory;
 import com.google.auto.factory.Provided;
 import dev.nokee.language.base.tasks.SourceCompile;
+import dev.nokee.language.nativebase.HasObjectFiles;
 import dev.nokee.model.internal.ModelPropertyIdentifier;
 import dev.nokee.model.internal.core.ModelActionWithInputs;
 import dev.nokee.model.internal.core.ModelNode;
 import dev.nokee.model.internal.registry.ModelRegistry;
 import dev.nokee.model.internal.state.ModelState;
+import dev.nokee.model.internal.type.ModelType;
+import dev.nokee.model.internal.type.TypeOf;
+import dev.nokee.platform.base.TaskView;
 import dev.nokee.platform.base.internal.BinaryIdentifier;
 import dev.nokee.platform.base.internal.ComponentTasksPropertyRegistrationFactory;
+import lombok.val;
+import org.gradle.api.Transformer;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.provider.Provider;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static dev.nokee.utils.TransformerUtils.onlyInstanceOf;
+import static dev.nokee.utils.TransformerUtils.stream;
 
 @AutoFactory
 public final class RegisterCompileTasksPropertyAction extends ModelActionWithInputs.ModelAction2<BinaryIdentifier<?>, ModelState.IsAtLeastRegistered> {
+	private static final ModelType<TaskView<SourceCompile>> TASK_VIEW_MODEL_TYPE = ModelType.of(new TypeOf<TaskView<SourceCompile>>() {});
 	private final BinaryIdentifier<?> identifier;
 	private final ModelRegistry registry;
 	private final ComponentTasksPropertyRegistrationFactory tasksPropertyRegistrationFactory;
@@ -41,7 +58,20 @@ public final class RegisterCompileTasksPropertyAction extends ModelActionWithInp
 	@Override
 	protected void execute(ModelNode entity, BinaryIdentifier<?> identifier, ModelState.IsAtLeastRegistered isAtLeastRegistered) {
 		if (identifier.equals(this.identifier)) {
-			registry.register(tasksPropertyRegistrationFactory.create(ModelPropertyIdentifier.of(identifier, "compileTasks"), SourceCompile.class));
+			val compileTasks = registry.register(tasksPropertyRegistrationFactory.create(ModelPropertyIdentifier.of(identifier, "compileTasks"), SourceCompile.class));
+			entity.addComponent(new ObjectFiles(compileTasks.as(TASK_VIEW_MODEL_TYPE).flatMap(toObjectFiles())));
 		}
+	}
+
+	private static Transformer<Provider<Set<Path>>, TaskView<SourceCompile>> toObjectFiles() {
+		return view -> view.flatMap(onlyInstanceOf(HasObjectFiles.class, asObjectFiles())).map(asFlattenPathSet());
+	}
+
+	private static Transformer<FileCollection, HasObjectFiles> asObjectFiles() {
+		return HasObjectFiles::getObjectFiles;
+	}
+
+	private static Transformer<Set<Path>, Iterable<FileCollection>> asFlattenPathSet() {
+		return stream(s -> s.flatMap(it -> it.getFiles().stream()).map(File::toPath).collect(toImmutableSet()));
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/RuntimeLibrariesConfigurationRegistrationAction.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/RuntimeLibrariesConfigurationRegistrationAction.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.platform.nativebase.internal;
+
+import com.google.auto.factory.AutoFactory;
+import com.google.auto.factory.Provided;
+import dev.nokee.language.base.internal.LanguageSourceSetIdentifier;
+import dev.nokee.model.internal.core.ModelActionWithInputs;
+import dev.nokee.model.internal.core.ModelNode;
+import dev.nokee.model.internal.registry.ModelRegistry;
+import dev.nokee.model.internal.state.ModelState;
+import dev.nokee.platform.base.internal.BinaryIdentifier;
+import dev.nokee.platform.base.internal.dependencies.DependencyBucketIdentifier;
+import dev.nokee.platform.base.internal.dependencies.ResolvableDependencyBucketRegistrationFactory;
+import lombok.val;
+import org.gradle.api.Action;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.attributes.Usage;
+import org.gradle.api.model.ObjectFactory;
+
+import static dev.nokee.platform.base.internal.dependencies.DependencyBucketIdentity.resolvable;
+import static dev.nokee.utils.ConfigurationUtils.configureAttributes;
+
+@AutoFactory
+public final class RuntimeLibrariesConfigurationRegistrationAction extends ModelActionWithInputs.ModelAction2<BinaryIdentifier<?>, ModelState.IsAtLeastRegistered> {
+	private final BinaryIdentifier<?> identifier;
+	private final ModelRegistry registry;
+	private final ResolvableDependencyBucketRegistrationFactory resolvableFactory;
+	private final ObjectFactory objects;
+
+	RuntimeLibrariesConfigurationRegistrationAction(BinaryIdentifier<?> identifier, @Provided ModelRegistry registry, @Provided ResolvableDependencyBucketRegistrationFactory resolvableFactory, @Provided ObjectFactory objects) {
+		this.identifier = identifier;
+		this.registry = registry;
+		this.resolvableFactory = resolvableFactory;
+		this.objects = objects;
+	}
+
+	@Override
+	protected void execute(ModelNode entity, BinaryIdentifier<?> identifier, ModelState.IsAtLeastRegistered isAtLeastRegistered) {
+		if (identifier.equals(this.identifier)) {
+			val runtimeLibraries = registry.register(resolvableFactory.create(DependencyBucketIdentifier.of(resolvable("runtimeLibraries"), identifier)));
+			runtimeLibraries.configure(Configuration.class, forNativeRuntimeUsage());
+		}
+	}
+
+	private Action<Configuration> forNativeRuntimeUsage() {
+		return configureAttributes(builder -> builder.usage(objects.named(Usage.class, Usage.NATIVE_RUNTIME)));
+	}
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/SharedLibraryBinaryRegistrationFactory.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/SharedLibraryBinaryRegistrationFactory.java
@@ -21,27 +21,18 @@ import dev.nokee.model.internal.type.ModelType;
 import dev.nokee.platform.base.TaskView;
 import dev.nokee.platform.base.internal.BinaryIdentifier;
 import dev.nokee.platform.base.internal.IsBinary;
-import dev.nokee.platform.base.internal.util.PropertyUtils;
 import dev.nokee.platform.nativebase.SharedLibraryBinary;
 import dev.nokee.platform.nativebase.tasks.LinkSharedLibrary;
 import dev.nokee.platform.nativebase.tasks.internal.LinkSharedLibraryTask;
-import dev.nokee.utils.ActionUtils;
 import dev.nokee.utils.TaskDependencyUtils;
-import org.gradle.api.Action;
 import org.gradle.api.provider.Property;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.reflect.HasPublicType;
 import org.gradle.api.reflect.TypeOf;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.api.tasks.TaskProvider;
 
-import java.util.function.BiConsumer;
-import java.util.function.Function;
-
 import static dev.nokee.model.internal.DomainObjectIdentifierUtils.toPath;
 import static dev.nokee.model.internal.core.ModelProjections.createdUsing;
-import static dev.nokee.platform.base.internal.util.PropertyUtils.convention;
-import static dev.nokee.platform.base.internal.util.PropertyUtils.wrap;
 
 public final class SharedLibraryBinaryRegistrationFactory {
 	private final LinkLibrariesConfigurationRegistrationActionFactory linkLibrariesRegistrationFactory;
@@ -78,6 +69,7 @@ public final class SharedLibraryBinaryRegistrationFactory {
 
 	private static final class ModelBackedSharedLibraryBinary implements SharedLibraryBinary, HasPublicType, ModelNodeAware {
 		private final ModelNode node = ModelNodeContext.getCurrentModelNode();
+		private final NativeBinaryBuildable isBuildable = new NativeBinaryBuildable(this);
 
 		@Override
 		public TaskView<SourceCompile> getCompileTasks() {
@@ -91,7 +83,7 @@ public final class SharedLibraryBinaryRegistrationFactory {
 
 		@Override
 		public boolean isBuildable() {
-			return false; // FIXME: Should correctly check buildable
+			return isBuildable.get();
 		}
 
 		@Override

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/SharedLibraryBinaryRegistrationFactory.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/SharedLibraryBinaryRegistrationFactory.java
@@ -16,20 +16,15 @@
 package dev.nokee.platform.nativebase.internal;
 
 import dev.nokee.language.base.tasks.SourceCompile;
-import dev.nokee.model.internal.ModelPropertyIdentifier;
 import dev.nokee.model.internal.core.*;
-import dev.nokee.model.internal.registry.ModelRegistry;
-import dev.nokee.model.internal.state.ModelState;
 import dev.nokee.model.internal.type.ModelType;
 import dev.nokee.platform.base.TaskView;
 import dev.nokee.platform.base.internal.BinaryIdentifier;
-import dev.nokee.platform.base.internal.ComponentTasksPropertyRegistrationFactory;
 import dev.nokee.platform.base.internal.IsBinary;
 import dev.nokee.platform.nativebase.SharedLibraryBinary;
 import dev.nokee.platform.nativebase.tasks.LinkSharedLibrary;
 import dev.nokee.platform.nativebase.tasks.internal.LinkSharedLibraryTask;
 import dev.nokee.utils.TaskDependencyUtils;
-import lombok.val;
 import org.gradle.api.provider.Property;
 import org.gradle.api.reflect.HasPublicType;
 import org.gradle.api.reflect.TypeOf;
@@ -67,6 +62,7 @@ public final class SharedLibraryBinaryRegistrationFactory {
 			.action(new ConfigureLinkTaskFromBaseNameRule(identifier))
 			.action(linkLibrariesRegistrationFactory.create(identifier))
 			.action(runtimeLibrariesRegistrationFactory.create(identifier))
+			.action(new AttachObjectFilesToLinkTaskRule(identifier))
 			.build();
 	}
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/SharedLibraryBinaryRegistrationFactory.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/SharedLibraryBinaryRegistrationFactory.java
@@ -40,22 +40,18 @@ import static dev.nokee.model.internal.DomainObjectIdentifierUtils.toPath;
 import static dev.nokee.model.internal.core.ModelProjections.createdUsing;
 
 public final class SharedLibraryBinaryRegistrationFactory {
-	private final ModelPropertyRegistrationFactory propertyRegistrationFactory;
-	private final ModelRegistry registry;
-	private final ComponentTasksPropertyRegistrationFactory tasksPropertyRegistrationFactory;
 	private final LinkLibrariesConfigurationRegistrationActionFactory linkLibrariesRegistrationFactory;
 	private final RuntimeLibrariesConfigurationRegistrationActionFactory runtimeLibrariesRegistrationFactory;
 	private final NativeLinkTaskRegistrationActionFactory linkTaskRegistrationActionFactory;
 	private final BaseNamePropertyRegistrationActionFactory baseNamePropertyRegistrationActionFactory;
+	private final RegisterCompileTasksPropertyActionFactory compileTasksPropertyActionFactory;
 
-	public SharedLibraryBinaryRegistrationFactory(ModelPropertyRegistrationFactory propertyRegistrationFactory, ModelRegistry registry, ComponentTasksPropertyRegistrationFactory tasksPropertyRegistrationFactory, LinkLibrariesConfigurationRegistrationActionFactory linkLibrariesRegistrationFactory, RuntimeLibrariesConfigurationRegistrationActionFactory runtimeLibrariesRegistrationFactory, NativeLinkTaskRegistrationActionFactory linkTaskRegistrationActionFactory, BaseNamePropertyRegistrationActionFactory baseNamePropertyRegistrationActionFactory) {
-		this.propertyRegistrationFactory = propertyRegistrationFactory;
-		this.registry = registry;
-		this.tasksPropertyRegistrationFactory = tasksPropertyRegistrationFactory;
+	public SharedLibraryBinaryRegistrationFactory(LinkLibrariesConfigurationRegistrationActionFactory linkLibrariesRegistrationFactory, RuntimeLibrariesConfigurationRegistrationActionFactory runtimeLibrariesRegistrationFactory, NativeLinkTaskRegistrationActionFactory linkTaskRegistrationActionFactory, BaseNamePropertyRegistrationActionFactory baseNamePropertyRegistrationActionFactory, RegisterCompileTasksPropertyActionFactory compileTasksPropertyActionFactory) {
 		this.linkLibrariesRegistrationFactory = linkLibrariesRegistrationFactory;
 		this.runtimeLibrariesRegistrationFactory = runtimeLibrariesRegistrationFactory;
 		this.linkTaskRegistrationActionFactory = linkTaskRegistrationActionFactory;
 		this.baseNamePropertyRegistrationActionFactory = baseNamePropertyRegistrationActionFactory;
+		this.compileTasksPropertyActionFactory = compileTasksPropertyActionFactory;
 	}
 
 	public ModelRegistration create(BinaryIdentifier<?> identifier) {
@@ -67,11 +63,7 @@ public final class SharedLibraryBinaryRegistrationFactory {
 			.action(new AttachLinkLibrariesToLinkTaskRule(identifier))
 			.action(linkTaskRegistrationActionFactory.create(identifier, LinkSharedLibrary.class, LinkSharedLibraryTask.class))
 			.action(baseNamePropertyRegistrationActionFactory.create(identifier))
-			.action(ModelActionWithInputs.of(ModelComponentReference.of(BinaryIdentifier.class), ModelComponentReference.of(ModelState.IsAtLeastRegistered.class), (entity, id, ignored) -> {
-				if (id.equals(identifier)) {
-					registry.register(tasksPropertyRegistrationFactory.create(ModelPropertyIdentifier.of(identifier, "compileTasks"), SourceCompile.class));
-				}
-			}))
+			.action(compileTasksPropertyActionFactory.create(identifier))
 			.action(new ConfigureLinkTaskFromBaseNameRule(identifier))
 			.action(linkLibrariesRegistrationFactory.create(identifier))
 			.action(runtimeLibrariesRegistrationFactory.create(identifier))

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/SharedLibraryBinaryRegistrationFactory.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/SharedLibraryBinaryRegistrationFactory.java
@@ -21,18 +21,27 @@ import dev.nokee.model.internal.type.ModelType;
 import dev.nokee.platform.base.TaskView;
 import dev.nokee.platform.base.internal.BinaryIdentifier;
 import dev.nokee.platform.base.internal.IsBinary;
+import dev.nokee.platform.base.internal.util.PropertyUtils;
 import dev.nokee.platform.nativebase.SharedLibraryBinary;
 import dev.nokee.platform.nativebase.tasks.LinkSharedLibrary;
 import dev.nokee.platform.nativebase.tasks.internal.LinkSharedLibraryTask;
+import dev.nokee.utils.ActionUtils;
 import dev.nokee.utils.TaskDependencyUtils;
+import org.gradle.api.Action;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.reflect.HasPublicType;
 import org.gradle.api.reflect.TypeOf;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.api.tasks.TaskProvider;
 
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
 import static dev.nokee.model.internal.DomainObjectIdentifierUtils.toPath;
 import static dev.nokee.model.internal.core.ModelProjections.createdUsing;
+import static dev.nokee.platform.base.internal.util.PropertyUtils.convention;
+import static dev.nokee.platform.base.internal.util.PropertyUtils.wrap;
 
 public final class SharedLibraryBinaryRegistrationFactory {
 	private final LinkLibrariesConfigurationRegistrationActionFactory linkLibrariesRegistrationFactory;
@@ -63,6 +72,7 @@ public final class SharedLibraryBinaryRegistrationFactory {
 			.action(linkLibrariesRegistrationFactory.create(identifier))
 			.action(runtimeLibrariesRegistrationFactory.create(identifier))
 			.action(new AttachObjectFilesToLinkTaskRule(identifier))
+			.action(new ConfigureLinkTaskDefaultsRule(identifier))
 			.build();
 	}
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/SharedLibraryBinaryRegistrationFactory.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/SharedLibraryBinaryRegistrationFactory.java
@@ -33,6 +33,7 @@ import dev.nokee.platform.nativebase.tasks.internal.LinkSharedLibraryTask;
 import dev.nokee.utils.TaskDependencyUtils;
 import lombok.val;
 import org.gradle.api.Task;
+import org.gradle.api.provider.Property;
 import org.gradle.api.reflect.HasPublicType;
 import org.gradle.api.reflect.TypeOf;
 import org.gradle.api.tasks.TaskDependency;
@@ -74,6 +75,8 @@ public final class SharedLibraryBinaryRegistrationFactory {
 					entity.addComponent(new NativeLinkTask(linkTask));
 
 					registry.register(tasksPropertyRegistrationFactory.create(ModelPropertyIdentifier.of(identifier, "compileTasks"), SourceCompile.class));
+
+					registry.register(propertyRegistrationFactory.createProperty(ModelPropertyIdentifier.of(identifier, "baseName"), String.class));
 				}
 			}))
 			.action(linkLibrariesRegistrationFactory.create(identifier))
@@ -112,6 +115,11 @@ public final class SharedLibraryBinaryRegistrationFactory {
 		@Override
 		public ModelNode getNode() {
 			return node;
+		}
+
+		@Override
+		public Property<String> getBaseName() {
+			return ModelProperties.getProperty(this, "baseName").as(Property.class).get();
 		}
 	}
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/SharedLibraryBinaryRegistrationFactory.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/SharedLibraryBinaryRegistrationFactory.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.platform.nativebase.internal;
+
+import dev.nokee.language.base.tasks.SourceCompile;
+import dev.nokee.model.internal.ModelPropertyIdentifier;
+import dev.nokee.model.internal.core.*;
+import dev.nokee.model.internal.registry.ModelRegistry;
+import dev.nokee.model.internal.state.ModelState;
+import dev.nokee.model.internal.type.ModelType;
+import dev.nokee.platform.base.TaskView;
+import dev.nokee.platform.base.internal.BinaryIdentifier;
+import dev.nokee.platform.base.internal.ComponentTasksPropertyRegistrationFactory;
+import dev.nokee.platform.base.internal.IsBinary;
+import dev.nokee.platform.base.internal.TaskRegistrationFactory;
+import dev.nokee.platform.base.internal.tasks.TaskIdentifier;
+import dev.nokee.platform.nativebase.SharedLibraryBinary;
+import dev.nokee.platform.nativebase.tasks.LinkSharedLibrary;
+import dev.nokee.platform.nativebase.tasks.internal.LinkSharedLibraryTask;
+import dev.nokee.utils.TaskDependencyUtils;
+import lombok.val;
+import org.gradle.api.reflect.HasPublicType;
+import org.gradle.api.reflect.TypeOf;
+import org.gradle.api.tasks.TaskDependency;
+import org.gradle.api.tasks.TaskProvider;
+
+import static dev.nokee.model.internal.DomainObjectIdentifierUtils.toPath;
+import static dev.nokee.model.internal.core.ModelProjections.createdUsing;
+
+public final class SharedLibraryBinaryRegistrationFactory {
+	private final TaskRegistrationFactory taskRegistrationFactory;
+	private final ModelPropertyRegistrationFactory propertyRegistrationFactory;
+	private final ModelRegistry registry;
+	private final ComponentTasksPropertyRegistrationFactory tasksPropertyRegistrationFactory;
+
+	public SharedLibraryBinaryRegistrationFactory(TaskRegistrationFactory taskRegistrationFactory, ModelPropertyRegistrationFactory propertyRegistrationFactory, ModelRegistry registry, ComponentTasksPropertyRegistrationFactory tasksPropertyRegistrationFactory) {
+		this.taskRegistrationFactory = taskRegistrationFactory;
+		this.propertyRegistrationFactory = propertyRegistrationFactory;
+		this.registry = registry;
+		this.tasksPropertyRegistrationFactory = tasksPropertyRegistrationFactory;
+	}
+
+	public ModelRegistration create(BinaryIdentifier<?> identifier) {
+		return ModelRegistration.builder()
+			.withComponent(identifier)
+			.withComponent(toPath(identifier))
+			.withComponent(IsBinary.tag())
+			.withComponent(createdUsing(ModelType.of(SharedLibraryBinary.class), ModelBackedSharedLibraryBinary::new))
+			.action(ModelActionWithInputs.of(ModelComponentReference.of(BinaryIdentifier.class), ModelComponentReference.of(ModelState.IsAtLeastRegistered.class), (entity, id, ignored) -> {
+				if (id.equals(identifier)) {
+					val linkTask = registry.register(taskRegistrationFactory.create(TaskIdentifier.of(identifier, "link"), LinkSharedLibraryTask.class).build());
+					registry.register(propertyRegistrationFactory.create(ModelPropertyIdentifier.of(identifier, "linkTask"), ModelNodes.of(linkTask)));
+					registry.register(tasksPropertyRegistrationFactory.create(ModelPropertyIdentifier.of(identifier, "compileTasks"), SourceCompile.class));
+				}
+			}))
+			.build();
+	}
+
+	private static final class ModelBackedSharedLibraryBinary implements SharedLibraryBinary, HasPublicType, ModelNodeAware {
+		private final ModelNode node = ModelNodeContext.getCurrentModelNode();
+
+		@Override
+		public TaskView<SourceCompile> getCompileTasks() {
+			return ModelProperties.getProperty(this, "compileTasks").as(TaskView.class).get();
+		}
+
+		@Override
+		public TaskProvider<LinkSharedLibrary> getLinkTask() {
+			return ModelProperties.getProperty(this, "linkTask").as(TaskProvider.class).get();
+		}
+
+		@Override
+		public boolean isBuildable() {
+			return false; // FIXME: Should correctly check buildable
+		}
+
+		@Override
+		public TaskDependency getBuildDependencies() {
+			return TaskDependencyUtils.of(getLinkTask());
+		}
+
+		@Override
+		public TypeOf<?> getPublicType() {
+			return TypeOf.typeOf(SharedLibraryBinary.class);
+		}
+
+		@Override
+		public ModelNode getNode() {
+			return node;
+		}
+	}
+}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/SharedLibraryBinaryRegistrationFactory.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/SharedLibraryBinaryRegistrationFactory.java
@@ -65,11 +65,13 @@ public final class SharedLibraryBinaryRegistrationFactory {
 			.withComponent(toPath(identifier))
 			.withComponent(IsBinary.tag())
 			.withComponent(createdUsing(ModelType.of(SharedLibraryBinary.class), ModelBackedSharedLibraryBinary::new))
+			.action(new AttachLinkLibrariesToLinkTaskRule(identifier))
 			.action(ModelActionWithInputs.of(ModelComponentReference.of(BinaryIdentifier.class), ModelComponentReference.of(ModelState.IsAtLeastRegistered.class), (entity, id, ignored) -> {
 				if (id.equals(identifier)) {
 					val linkTask = registry.register(taskRegistrationFactory.create(TaskIdentifier.of(identifier, "link"), LinkSharedLibraryTask.class).build());
 					registry.register(propertyRegistrationFactory.create(ModelPropertyIdentifier.of(identifier, "linkTask"), ModelNodes.of(linkTask)));
 					linkTask.configure(Task.class, configureDescription("Links the %s.", identifier));
+					entity.addComponent(new NativeLinkTask(linkTask));
 
 					registry.register(tasksPropertyRegistrationFactory.create(ModelPropertyIdentifier.of(identifier, "compileTasks"), SourceCompile.class));
 				}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeApplicationPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeApplicationPlugin.java
@@ -212,6 +212,7 @@ public class NativeApplicationPlugin implements Plugin<Project> {
 		, ModelBackedHasDevelopmentVariantMixIn<NativeApplication>
 		, ModelBackedTargetMachineAwareComponentMixIn
 		, ModelBackedTargetBuildTypeAwareComponentMixIn
+		, ModelBackedHasBaseNameMixIn
 	{
 	}
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeComponentBasePlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeComponentBasePlugin.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Streams;
 import dev.nokee.internal.Factory;
+import dev.nokee.language.nativebase.internal.DefaultNativeToolChainSelector;
 import dev.nokee.model.internal.DomainObjectEventPublisher;
 import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.model.internal.core.ModelNodeUtils;
@@ -49,6 +50,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Transformer;
+import org.gradle.api.internal.project.ProjectInternal;
 
 import java.util.Set;
 import java.util.function.BiConsumer;
@@ -69,7 +71,6 @@ public class NativeComponentBasePlugin implements Plugin<Project> {
 		project.getPluginManager().apply(ComponentModelBasePlugin.class);
 
 		project.getExtensions().add("__nokee_sharedLibraryFactory", new SharedLibraryBinaryRegistrationFactory(
-			project.getExtensions().getByType(TaskRegistrationFactory.class),
 			project.getExtensions().getByType(ModelPropertyRegistrationFactory.class),
 			project.getExtensions().getByType(ModelRegistry.class),
 			project.getExtensions().getByType(ComponentTasksPropertyRegistrationFactory.class),
@@ -82,6 +83,16 @@ public class NativeComponentBasePlugin implements Plugin<Project> {
 				() -> project.getExtensions().getByType(ModelRegistry.class),
 				() -> project.getExtensions().getByType(ResolvableDependencyBucketRegistrationFactory.class),
 				() -> project.getObjects()
+			),
+			new NativeLinkTaskRegistrationActionFactory(
+				() -> project.getExtensions().getByType(ModelRegistry.class),
+				() -> project.getExtensions().getByType(TaskRegistrationFactory.class),
+				() -> project.getExtensions().getByType(ModelPropertyRegistrationFactory.class),
+				() -> new DefaultNativeToolChainSelector(((ProjectInternal) project).getModelRegistry(), project.getProviders())
+			),
+			new BaseNamePropertyRegistrationActionFactory(
+				() -> project.getExtensions().getByType(ModelRegistry.class),
+				() -> project.getExtensions().getByType(ModelPropertyRegistrationFactory.class)
 			)
 		));
 	}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeComponentBasePlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeComponentBasePlugin.java
@@ -28,15 +28,14 @@ import dev.nokee.model.internal.registry.ModelRegistry;
 import dev.nokee.model.internal.state.ModelStates;
 import dev.nokee.platform.base.Component;
 import dev.nokee.platform.base.internal.*;
+import dev.nokee.platform.base.internal.dependencies.ResolvableDependencyBucketRegistrationFactory;
 import dev.nokee.platform.base.internal.plugins.ComponentModelBasePlugin;
 import dev.nokee.platform.base.internal.tasks.TaskRegistry;
 import dev.nokee.platform.base.internal.tasks.TaskViewFactory;
 import dev.nokee.platform.nativebase.TargetBuildTypeAwareComponent;
 import dev.nokee.platform.nativebase.TargetLinkageAwareComponent;
 import dev.nokee.platform.nativebase.TargetMachineAwareComponent;
-import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
-import dev.nokee.platform.nativebase.internal.DefaultNativeLibraryComponent;
-import dev.nokee.platform.nativebase.internal.SharedLibraryBinaryRegistrationFactory;
+import dev.nokee.platform.nativebase.internal.*;
 import dev.nokee.runtime.core.CoordinateSet;
 import dev.nokee.runtime.core.Coordinates;
 import dev.nokee.runtime.darwin.internal.DarwinRuntimePlugin;
@@ -73,7 +72,18 @@ public class NativeComponentBasePlugin implements Plugin<Project> {
 			project.getExtensions().getByType(TaskRegistrationFactory.class),
 			project.getExtensions().getByType(ModelPropertyRegistrationFactory.class),
 			project.getExtensions().getByType(ModelRegistry.class),
-			project.getExtensions().getByType(ComponentTasksPropertyRegistrationFactory.class)));
+			project.getExtensions().getByType(ComponentTasksPropertyRegistrationFactory.class),
+			new LinkLibrariesConfigurationRegistrationActionFactory(
+				() -> project.getExtensions().getByType(ModelRegistry.class),
+				() -> project.getExtensions().getByType(ResolvableDependencyBucketRegistrationFactory.class),
+				() -> project.getObjects()
+			),
+			new RuntimeLibrariesConfigurationRegistrationActionFactory(
+				() -> project.getExtensions().getByType(ModelRegistry.class),
+				() -> project.getExtensions().getByType(ResolvableDependencyBucketRegistrationFactory.class),
+				() -> project.getObjects()
+			)
+		));
 	}
 
 	public static Factory<DefaultNativeApplicationComponent> nativeApplicationProjection(String name, Project project) {

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeComponentBasePlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeComponentBasePlugin.java
@@ -23,13 +23,11 @@ import dev.nokee.model.internal.DomainObjectEventPublisher;
 import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.model.internal.core.ModelNodeUtils;
 import dev.nokee.model.internal.core.ModelNodes;
+import dev.nokee.model.internal.core.ModelPropertyRegistrationFactory;
+import dev.nokee.model.internal.registry.ModelRegistry;
 import dev.nokee.model.internal.state.ModelStates;
 import dev.nokee.platform.base.Component;
-import dev.nokee.platform.base.internal.BaseComponent;
-import dev.nokee.platform.base.internal.ComponentIdentifier;
-import dev.nokee.platform.base.internal.ComponentName;
-import dev.nokee.platform.base.internal.DefaultBuildVariant;
-import dev.nokee.platform.base.internal.binaries.BinaryViewFactory;
+import dev.nokee.platform.base.internal.*;
 import dev.nokee.platform.base.internal.plugins.ComponentModelBasePlugin;
 import dev.nokee.platform.base.internal.tasks.TaskRegistry;
 import dev.nokee.platform.base.internal.tasks.TaskViewFactory;
@@ -38,6 +36,7 @@ import dev.nokee.platform.nativebase.TargetLinkageAwareComponent;
 import dev.nokee.platform.nativebase.TargetMachineAwareComponent;
 import dev.nokee.platform.nativebase.internal.DefaultNativeApplicationComponent;
 import dev.nokee.platform.nativebase.internal.DefaultNativeLibraryComponent;
+import dev.nokee.platform.nativebase.internal.SharedLibraryBinaryRegistrationFactory;
 import dev.nokee.runtime.core.CoordinateSet;
 import dev.nokee.runtime.core.Coordinates;
 import dev.nokee.runtime.darwin.internal.DarwinRuntimePlugin;
@@ -69,6 +68,12 @@ public class NativeComponentBasePlugin implements Plugin<Project> {
 		project.getPluginManager().apply(NativeRuntimePlugin.class);
 		project.getPluginManager().apply(DarwinRuntimePlugin.class); // for now, later we will be more smart
 		project.getPluginManager().apply(ComponentModelBasePlugin.class);
+
+		project.getExtensions().add("__nokee_sharedLibraryFactory", new SharedLibraryBinaryRegistrationFactory(
+			project.getExtensions().getByType(TaskRegistrationFactory.class),
+			project.getExtensions().getByType(ModelPropertyRegistrationFactory.class),
+			project.getExtensions().getByType(ModelRegistry.class),
+			project.getExtensions().getByType(ComponentTasksPropertyRegistrationFactory.class)));
 	}
 
 	public static Factory<DefaultNativeApplicationComponent> nativeApplicationProjection(String name, Project project) {

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeComponentBasePlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeComponentBasePlugin.java
@@ -71,9 +71,6 @@ public class NativeComponentBasePlugin implements Plugin<Project> {
 		project.getPluginManager().apply(ComponentModelBasePlugin.class);
 
 		project.getExtensions().add("__nokee_sharedLibraryFactory", new SharedLibraryBinaryRegistrationFactory(
-			project.getExtensions().getByType(ModelPropertyRegistrationFactory.class),
-			project.getExtensions().getByType(ModelRegistry.class),
-			project.getExtensions().getByType(ComponentTasksPropertyRegistrationFactory.class),
 			new LinkLibrariesConfigurationRegistrationActionFactory(
 				() -> project.getExtensions().getByType(ModelRegistry.class),
 				() -> project.getExtensions().getByType(ResolvableDependencyBucketRegistrationFactory.class),
@@ -93,6 +90,10 @@ public class NativeComponentBasePlugin implements Plugin<Project> {
 			new BaseNamePropertyRegistrationActionFactory(
 				() -> project.getExtensions().getByType(ModelRegistry.class),
 				() -> project.getExtensions().getByType(ModelPropertyRegistrationFactory.class)
+			),
+			new RegisterCompileTasksPropertyActionFactory(
+				() -> project.getExtensions().getByType(ModelRegistry.class),
+				() -> project.getExtensions().getByType(ComponentTasksPropertyRegistrationFactory.class)
 			)
 		));
 	}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeLibraryPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeLibraryPlugin.java
@@ -123,6 +123,7 @@ public class NativeLibraryPlugin implements Plugin<Project> {
 		, ModelBackedTargetMachineAwareComponentMixIn
 		, ModelBackedTargetBuildTypeAwareComponentMixIn
 		, ModelBackedTargetLinkageAwareComponentMixIn
+		, ModelBackedHasBaseNameMixIn
 	{
 	}
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/tasks/ObjectLink.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/tasks/ObjectLink.java
@@ -15,16 +15,19 @@
  */
 package dev.nokee.platform.nativebase.tasks;
 
+import dev.nokee.language.base.HasDestinationDirectory;
 import org.gradle.api.Task;
+import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.nativeplatform.toolchain.NativeToolChain;
 
-public interface ObjectLink extends Task {
+public interface ObjectLink extends Task, HasDestinationDirectory {
 	/**
 	 * The tool chain used for the compilation.
 	 *
@@ -51,4 +54,11 @@ public interface ObjectLink extends Task {
 	 */
 	@OutputFile
 	Provider<RegularFile> getLinkedFile();
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	@OutputDirectory
+	DirectoryProperty getDestinationDirectory();
 }

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/tasks/ObjectLink.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/tasks/ObjectLink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,12 +24,7 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.nativeplatform.toolchain.NativeToolChain;
 
-/**
- * Links a shared library binary from object files and imported libraries.
- *
- * @version 0.3
- */
-public interface LinkSharedLibrary extends ObjectLink {
+public interface ObjectLink extends Task {
 	/**
 	 * The tool chain used for the compilation.
 	 *

--- a/subprojects/platform-native/src/test/groovy/dev/nokee/platform/nativebase/SharedLibraryBinaryTest.java
+++ b/subprojects/platform-native/src/test/groovy/dev/nokee/platform/nativebase/SharedLibraryBinaryTest.java
@@ -32,11 +32,16 @@ import lombok.val;
 import org.gradle.api.Project;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
+import static dev.nokee.internal.testing.GradleProviderMatchers.providerOf;
 import static dev.nokee.language.nativebase.internal.NativePlatformFactory.create;
 import static dev.nokee.model.internal.DomainObjectIdentifierUtils.toPath;
 import static dev.nokee.runtime.nativebase.internal.TargetMachines.of;
 import static org.apache.commons.lang3.StringUtils.capitalize;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.is;
 
 @PluginRequirement.Require(type = NativeComponentBasePlugin.class)
 class SharedLibraryBinaryTest extends AbstractPluginTest {
@@ -80,6 +85,33 @@ class SharedLibraryBinaryTest extends AbstractPluginTest {
 		@Override
 		public String displayName() {
 			return "binary ':nuli:cuzu:ruca'";
+		}
+
+		@Test
+		void noCompileTasksByDefault() {
+			assertThat(subject().getCompileTasks().get(), emptyIterable());
+		}
+
+		@Nested
+		class LinkSharedLibraryTaskTest {
+			public LinkSharedLibraryTask subject() {
+				return (LinkSharedLibraryTask) project().getTasks().getByName("link" + capitalize(variantName()));
+			}
+
+			@Test
+			void isNotDebuggableByDefault() {
+				assertThat(subject().isDebuggable(), is(false));
+			}
+
+			@Test
+			void hasNoLinkerArgumentsByDefault() {
+				assertThat(subject().getLinkerArgs(), providerOf(emptyIterable()));
+			}
+
+			@Test
+			void hasNoSourcesByDefault() {
+				assertThat(subject().getSource(), emptyIterable());
+			}
 		}
 	}
 }

--- a/subprojects/platform-native/src/test/groovy/dev/nokee/platform/nativebase/SharedLibraryBinaryTest.java
+++ b/subprojects/platform-native/src/test/groovy/dev/nokee/platform/nativebase/SharedLibraryBinaryTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.platform.nativebase;
+
+import dev.nokee.internal.testing.AbstractPluginTest;
+import dev.nokee.internal.testing.PluginRequirement;
+import dev.nokee.model.internal.ProjectIdentifier;
+import dev.nokee.model.internal.core.ModelRegistration;
+import dev.nokee.model.internal.registry.ModelRegistry;
+import dev.nokee.platform.base.Variant;
+import dev.nokee.platform.base.internal.BinaryIdentifier;
+import dev.nokee.platform.base.internal.ComponentIdentifier;
+import dev.nokee.platform.base.internal.VariantIdentifier;
+import dev.nokee.platform.nativebase.internal.SharedLibraryBinaryRegistrationFactory;
+import dev.nokee.platform.nativebase.internal.plugins.NativeComponentBasePlugin;
+import dev.nokee.platform.nativebase.testers.SharedLibraryBinaryIntegrationTester;
+import lombok.val;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+
+import static dev.nokee.model.internal.DomainObjectIdentifierUtils.toPath;
+
+@PluginRequirement.Require(type = NativeComponentBasePlugin.class)
+class SharedLibraryBinaryTest extends AbstractPluginTest {
+	private SharedLibraryBinary subject;
+
+	@BeforeEach
+	void createSubject() {
+		val factory = project.getExtensions().getByType(SharedLibraryBinaryRegistrationFactory.class);
+		val registry = project.getExtensions().getByType(ModelRegistry.class);
+		val projectIdentifier = ProjectIdentifier.of(project);
+		val componentIdentifier = ComponentIdentifier.of("nuli", projectIdentifier);
+		registry.register(ModelRegistration.builder().withComponent(toPath(componentIdentifier)).build());
+		val variantIdentifier = VariantIdentifier.of("cuzu", Variant.class, componentIdentifier);
+		registry.register(ModelRegistration.builder().withComponent(toPath(variantIdentifier)).build());
+		subject = registry.register(factory.create(BinaryIdentifier.of(variantIdentifier, "ruca"))).as(SharedLibraryBinary.class).get();
+	}
+
+	@Nested
+	class BinaryTest extends SharedLibraryBinaryIntegrationTester {
+		@Override
+		public SharedLibraryBinary subject() {
+			return subject;
+		}
+	}
+}

--- a/subprojects/platform-native/src/test/groovy/dev/nokee/platform/nativebase/SharedLibraryBinaryTest.java
+++ b/subprojects/platform-native/src/test/groovy/dev/nokee/platform/nativebase/SharedLibraryBinaryTest.java
@@ -26,13 +26,17 @@ import dev.nokee.platform.base.internal.ComponentIdentifier;
 import dev.nokee.platform.base.internal.VariantIdentifier;
 import dev.nokee.platform.nativebase.internal.SharedLibraryBinaryRegistrationFactory;
 import dev.nokee.platform.nativebase.internal.plugins.NativeComponentBasePlugin;
+import dev.nokee.platform.nativebase.tasks.internal.LinkSharedLibraryTask;
 import dev.nokee.platform.nativebase.testers.SharedLibraryBinaryIntegrationTester;
 import lombok.val;
 import org.gradle.api.Project;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 
+import static dev.nokee.language.nativebase.internal.NativePlatformFactory.create;
 import static dev.nokee.model.internal.DomainObjectIdentifierUtils.toPath;
+import static dev.nokee.runtime.nativebase.internal.TargetMachines.of;
+import static org.apache.commons.lang3.StringUtils.capitalize;
 
 @PluginRequirement.Require(type = NativeComponentBasePlugin.class)
 class SharedLibraryBinaryTest extends AbstractPluginTest {
@@ -52,6 +56,12 @@ class SharedLibraryBinaryTest extends AbstractPluginTest {
 
 	@Nested
 	class BinaryTest extends SharedLibraryBinaryIntegrationTester {
+		@BeforeEach
+		public void configureTargetPlatform() {
+			((LinkSharedLibraryTask) project.getTasks().getByName("link" + capitalize(variantName()))).getTargetPlatform()
+				.set(create(of("macos-x64")));
+		}
+
 		@Override
 		public SharedLibraryBinary subject() {
 			return subject;

--- a/subprojects/platform-native/src/test/groovy/dev/nokee/platform/nativebase/SharedLibraryBinaryTest.java
+++ b/subprojects/platform-native/src/test/groovy/dev/nokee/platform/nativebase/SharedLibraryBinaryTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import static dev.nokee.internal.testing.FileSystemMatchers.aFileNamed;
 import static dev.nokee.internal.testing.GradleProviderMatchers.providerOf;
 import static dev.nokee.internal.testing.ProjectMatchers.buildDependencies;
 import static dev.nokee.language.nativebase.internal.NativePlatformFactory.create;
@@ -142,6 +143,11 @@ class SharedLibraryBinaryTest extends AbstractPluginTest {
 			@Test
 			void hasNoSourcesByDefault() {
 				assertThat(subject().getSource(), emptyIterable());
+			}
+
+			@Test
+			void includesBinaryNameInDestinationDirectory() {
+				assertThat(subject().getDestinationDirectory(), providerOf(aFileNamed("ruca")));
 			}
 		}
 	}

--- a/subprojects/platform-native/src/test/groovy/dev/nokee/platform/nativebase/SharedLibraryBinaryTest.java
+++ b/subprojects/platform-native/src/test/groovy/dev/nokee/platform/nativebase/SharedLibraryBinaryTest.java
@@ -28,6 +28,7 @@ import dev.nokee.platform.nativebase.internal.SharedLibraryBinaryRegistrationFac
 import dev.nokee.platform.nativebase.internal.plugins.NativeComponentBasePlugin;
 import dev.nokee.platform.nativebase.testers.SharedLibraryBinaryIntegrationTester;
 import lombok.val;
+import org.gradle.api.Project;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 
@@ -54,6 +55,21 @@ class SharedLibraryBinaryTest extends AbstractPluginTest {
 		@Override
 		public SharedLibraryBinary subject() {
 			return subject;
+		}
+
+		@Override
+		public Project project() {
+			return project;
+		}
+
+		@Override
+		public String variantName() {
+			return "nuliCuzuRuca";
+		}
+
+		@Override
+		public String displayName() {
+			return "binary ':nuli:cuzu:ruca'";
 		}
 	}
 }

--- a/subprojects/platform-native/src/test/groovy/dev/nokee/platform/nativebase/SharedLibraryBinaryTest.java
+++ b/subprojects/platform-native/src/test/groovy/dev/nokee/platform/nativebase/SharedLibraryBinaryTest.java
@@ -92,6 +92,12 @@ class SharedLibraryBinaryTest extends AbstractPluginTest {
 			assertThat(subject().getCompileTasks().get(), emptyIterable());
 		}
 
+		@Test
+		void usesBinaryNameAsBaseNameByDefault() {
+			subject().getBaseName().set((String) null); // force convention
+			assertThat(subject().getBaseName(), providerOf("ruca"));
+		}
+
 		@Nested
 		class LinkSharedLibraryTaskTest {
 			public LinkSharedLibraryTask subject() {

--- a/subprojects/platform-native/src/testFixtures/groovy/dev/nokee/platform/nativebase/testers/SharedLibraryBinaryIntegrationTester.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/dev/nokee/platform/nativebase/testers/SharedLibraryBinaryIntegrationTester.java
@@ -15,8 +15,106 @@
  */
 package dev.nokee.platform.nativebase.testers;
 
+import dev.nokee.internal.testing.ConfigurationMatchers;
+import dev.nokee.internal.testing.TaskMatchers;
 import dev.nokee.platform.nativebase.SharedLibraryBinary;
+import dev.nokee.platform.nativebase.tasks.LinkSharedLibrary;
+import dev.nokee.platform.nativebase.tasks.internal.LinkSharedLibraryTask;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.attributes.Usage;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.nativeplatform.toolchain.NativeToolChain;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.internal.testing.FileSystemMatchers.aFile;
+import static dev.nokee.internal.testing.FileSystemMatchers.withAbsolutePath;
+import static dev.nokee.internal.testing.GradleNamedMatchers.named;
+import static dev.nokee.internal.testing.GradleProviderMatchers.presentProvider;
+import static dev.nokee.internal.testing.GradleProviderMatchers.providerOf;
+import static dev.nokee.internal.testing.util.ProjectTestUtils.createDependency;
+import static org.apache.commons.lang3.StringUtils.capitalize;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 
 public abstract class SharedLibraryBinaryIntegrationTester implements SharedLibraryBinaryTester {
 	public abstract SharedLibraryBinary subject();
+
+	public abstract Project project();
+
+	public abstract String variantName();
+
+	public abstract String displayName();
+
+	private Configuration linkLibraries() {
+		return project().getConfigurations().getByName(variantName() + "LinkLibraries");
+	}
+
+	@Test
+	void linkTasksPointsToTheExpectedTask() {
+		assertThat(subject().getLinkTask(), providerOf(allOf(named("link" + capitalize(variantName())), isA(LinkSharedLibrary.class))));
+	}
+
+	@Nested
+	class LinkTaskTest {
+		public LinkSharedLibraryTask subject() {
+			return (LinkSharedLibraryTask) project().getTasks().getByName("link" + capitalize(variantName()));
+		}
+
+		@Test
+		void hasLinkerArgs() {
+			assertThat("not null as per contract", subject().getLinkerArgs(), notNullValue(ListProperty.class));
+			assertThat("there should be a value", subject().getLinkerArgs(), presentProvider());
+		}
+
+		@Test
+		void hasDescription() {
+			assertThat(subject(), TaskMatchers.description("Links the " + displayName() + "."));
+		}
+	}
+
+	@Nested
+	class LinkLibrariesConfigurationTest {
+		public Configuration subject() {
+			return linkLibraries();
+		}
+
+		@Test
+		void hasDescription() {
+			assertThat(subject(), ConfigurationMatchers.description("Link libraries for " + displayName() + "."));
+		}
+
+		@Test
+		void isResolvable() {
+			assertThat(subject(), ConfigurationMatchers.resolvable());
+		}
+
+		@Test
+		void hasNativeLinkUsage() {
+			assertThat(subject(), ConfigurationMatchers.attributes(hasEntry(is(Usage.USAGE_ATTRIBUTE), named("native-link"))));
+		}
+	}
+
+	@Nested
+	class RuntimeLibrariesConfigurationTest {
+		public Configuration subject() {
+			return project().getConfigurations().getByName(variantName() + "RuntimeLibraries");
+		}
+
+		@Test
+		void hasDescription() {
+			assertThat(subject(), ConfigurationMatchers.description("Runtime libraries for " + displayName() + "."));
+		}
+
+		@Test
+		void isResolvable() {
+			assertThat(subject(), ConfigurationMatchers.resolvable());
+		}
+
+		@Test
+		void hasNativeRuntimeUsage() {
+			assertThat(subject(), ConfigurationMatchers.attributes(hasEntry(is(Usage.USAGE_ATTRIBUTE), named("native-runtime"))));
+		}
+	}
 }

--- a/subprojects/platform-native/src/testFixtures/groovy/dev/nokee/platform/nativebase/testers/SharedLibraryBinaryIntegrationTester.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/dev/nokee/platform/nativebase/testers/SharedLibraryBinaryIntegrationTester.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.platform.nativebase.testers;
+
+import dev.nokee.platform.nativebase.SharedLibraryBinary;
+
+public abstract class SharedLibraryBinaryIntegrationTester implements SharedLibraryBinaryTester {
+	public abstract SharedLibraryBinary subject();
+}

--- a/subprojects/platform-native/src/testFixtures/groovy/dev/nokee/platform/nativebase/testers/SharedLibraryBinaryIntegrationTester.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/dev/nokee/platform/nativebase/testers/SharedLibraryBinaryIntegrationTester.java
@@ -124,6 +124,13 @@ public abstract class SharedLibraryBinaryIntegrationTester implements SharedLibr
 		}
 
 		@Test
+		void usesDestinationDirectoryAsLinkedFileParentDirectory() {
+			val newDestinationDirectory = project().file("some-new-destination-directory");
+			subject().getDestinationDirectory().set(newDestinationDirectory);
+			assertThat(subject().getLinkedFile(), providerOf(aFile(parentFile(is(newDestinationDirectory)))));
+		}
+
+		@Test
 		void addsMacOsSdkPathToLinkerArguments() {
 			project().getPluginManager().apply(SwiftCompilerPlugin.class); // only for Swiftc, at the moment
 			subject().getTargetPlatform().set(create(of("macos-x64")));

--- a/subprojects/platform-native/src/testFixtures/groovy/dev/nokee/platform/nativebase/testers/SharedLibraryBinaryIntegrationTester.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/dev/nokee/platform/nativebase/testers/SharedLibraryBinaryIntegrationTester.java
@@ -33,8 +33,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import static dev.nokee.internal.testing.FileSystemMatchers.aFile;
-import static dev.nokee.internal.testing.FileSystemMatchers.withAbsolutePath;
+import static dev.nokee.internal.testing.FileSystemMatchers.*;
 import static dev.nokee.internal.testing.GradleNamedMatchers.named;
 import static dev.nokee.internal.testing.GradleProviderMatchers.presentProvider;
 import static dev.nokee.internal.testing.GradleProviderMatchers.providerOf;
@@ -103,6 +102,12 @@ public abstract class SharedLibraryBinaryIntegrationTester implements SharedLibr
 			assertThat(subject().getLinkerArgs(), providerOf(containsInRelativeOrder(
 				"-F", artifact.getParentFile().getAbsolutePath(), "-framework", "Vufa"
 			)));
+		}
+
+		@Test
+		void usesBinaryBaseNameForLinkTaskLinkedFileBaseName() {
+			binary().getBaseName().set("da-bo");
+			assertThat(subject().getLinkedFile(), providerOf(aFileBaseNamed(endsWith("da-bo"))));
 		}
 	}
 

--- a/subprojects/platform-native/src/testFixtures/groovy/dev/nokee/platform/nativebase/testers/SharedLibraryBinaryIntegrationTester.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/dev/nokee/platform/nativebase/testers/SharedLibraryBinaryIntegrationTester.java
@@ -17,16 +17,21 @@ package dev.nokee.platform.nativebase.testers;
 
 import dev.nokee.internal.testing.ConfigurationMatchers;
 import dev.nokee.internal.testing.TaskMatchers;
+import dev.nokee.internal.testing.util.ProjectTestUtils;
 import dev.nokee.platform.nativebase.SharedLibraryBinary;
 import dev.nokee.platform.nativebase.tasks.LinkSharedLibrary;
 import dev.nokee.platform.nativebase.tasks.internal.LinkSharedLibraryTask;
+import lombok.val;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.provider.ListProperty;
-import org.gradle.nativeplatform.toolchain.NativeToolChain;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
 
 import static dev.nokee.internal.testing.FileSystemMatchers.aFile;
 import static dev.nokee.internal.testing.FileSystemMatchers.withAbsolutePath;
@@ -34,6 +39,7 @@ import static dev.nokee.internal.testing.GradleNamedMatchers.named;
 import static dev.nokee.internal.testing.GradleProviderMatchers.presentProvider;
 import static dev.nokee.internal.testing.GradleProviderMatchers.providerOf;
 import static dev.nokee.internal.testing.util.ProjectTestUtils.createDependency;
+import static dev.nokee.utils.ConfigurationUtils.*;
 import static org.apache.commons.lang3.StringUtils.capitalize;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -71,6 +77,32 @@ public abstract class SharedLibraryBinaryIntegrationTester implements SharedLibr
 		@Test
 		void hasDescription() {
 			assertThat(subject(), TaskMatchers.description("Links the " + displayName() + "."));
+		}
+
+		@Test
+		void attachesLinkLibrariesToLinkTaskLibraries() {
+			// We mock the resolution process by forcing a file dependency on the configuration
+			linkLibraries().getDependencies().add(createDependency(project().files().from("libfoo.a")));
+			assertThat(subject().getLibs(), contains(aFile(withAbsolutePath(endsWith("libfoo.a")))));
+		}
+
+		@Test
+		void linksLinkLibrariesConfigurationToLinkTaskAsFrameworkLinkArguments() throws IOException {
+			val artifact = Files.createTempDirectory("Vufa.framework").toFile();
+			val frameworkProducer = ProjectTestUtils.createChildProject(project());
+			frameworkProducer.getConfigurations().create("linkElements",
+				configureAsConsumable()
+					.andThen(configureAttributes(forUsage(project().getObjects().named(Usage.class, Usage.NATIVE_LINK))))
+					.andThen(configureAttributes(it -> it.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
+						project().getObjects().named(LibraryElements.class, "framework-bundle"))))
+					.andThen(it -> it.getOutgoing().artifact(artifact, t -> t.setType("framework")))
+			);
+
+			linkLibraries().getDependencies().add(createDependency(frameworkProducer));
+			assertThat(subject().getLibs(), not(hasItem(aFile(artifact))));
+			assertThat(subject().getLinkerArgs(), providerOf(containsInRelativeOrder(
+				"-F", artifact.getParentFile().getAbsolutePath(), "-framework", "Vufa"
+			)));
 		}
 	}
 

--- a/subprojects/platform-native/src/testFixtures/groovy/dev/nokee/platform/nativebase/testers/SharedLibraryBinaryTester.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/dev/nokee/platform/nativebase/testers/SharedLibraryBinaryTester.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.platform.nativebase.testers;
+
+import dev.nokee.platform.base.TaskView;
+import dev.nokee.platform.base.testers.ArtifactTester;
+import dev.nokee.platform.nativebase.SharedLibraryBinary;
+import dev.nokee.platform.nativebase.tasks.LinkSharedLibrary;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.internal.testing.GradleProviderMatchers.providerOf;
+import static dev.nokee.internal.testing.ProjectMatchers.buildDependencies;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public interface SharedLibraryBinaryTester extends ArtifactTester<SharedLibraryBinary> {
+	@Test
+	default void hasCompileTasks() {
+		assertThat(subject().getCompileTasks(), notNullValue(TaskView.class));
+	}
+
+	@Test
+	default void hasLinkTask() {
+		assertThat(subject().getLinkTask(), providerOf(isA(LinkSharedLibrary.class)));
+	}
+
+	@Test
+	default void includesLinkTaskAsBuildable() {
+		assertThat(subject(), buildDependencies(hasItem(subject().getLinkTask().get())));
+	}
+
+	@Test
+	default void doesNotThrowAnyExceptionWhenCheckingBuildability() {
+		assertDoesNotThrow(() -> subject().isBuildable());
+	}
+}

--- a/subprojects/platform-native/src/testFixtures/groovy/dev/nokee/platform/nativebase/testers/SharedLibraryBinaryTester.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/dev/nokee/platform/nativebase/testers/SharedLibraryBinaryTester.java
@@ -41,7 +41,7 @@ public interface SharedLibraryBinaryTester extends ArtifactTester<SharedLibraryB
 	}
 
 	@Test
-	default void includesLinkTaskAsBuildable() {
+	default void includesLinkTaskAsBuildDependencies() {
 		assertThat(subject(), buildDependencies(hasItem(subject().getLinkTask().get())));
 	}
 

--- a/subprojects/platform-native/src/testFixtures/groovy/dev/nokee/platform/nativebase/testers/SharedLibraryBinaryTester.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/dev/nokee/platform/nativebase/testers/SharedLibraryBinaryTester.java
@@ -17,6 +17,7 @@ package dev.nokee.platform.nativebase.testers;
 
 import dev.nokee.platform.base.TaskView;
 import dev.nokee.platform.base.testers.ArtifactTester;
+import dev.nokee.platform.base.testers.HasBaseNameTester;
 import dev.nokee.platform.nativebase.SharedLibraryBinary;
 import dev.nokee.platform.nativebase.tasks.LinkSharedLibrary;
 import org.junit.jupiter.api.Assertions;
@@ -28,7 +29,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
-public interface SharedLibraryBinaryTester extends ArtifactTester<SharedLibraryBinary> {
+public interface SharedLibraryBinaryTester extends ArtifactTester<SharedLibraryBinary>, HasBaseNameTester {
 	@Test
 	default void hasCompileTasks() {
 		assertThat(subject().getCompileTasks(), notNullValue(TaskView.class));

--- a/subprojects/platform-objective-c/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCApplicationPlugin.java
+++ b/subprojects/platform-objective-c/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCApplicationPlugin.java
@@ -110,6 +110,7 @@ public class ObjectiveCApplicationPlugin implements Plugin<Project> {
 		, ModelBackedHasDevelopmentVariantMixIn<NativeApplication>
 		, ModelBackedTargetMachineAwareComponentMixIn
 		, ModelBackedTargetBuildTypeAwareComponentMixIn
+		, ModelBackedHasBaseNameMixIn
 	{
 		@Override
 		public ObjectiveCSourceSet getObjectiveCSources() {

--- a/subprojects/platform-objective-c/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCLibraryPlugin.java
+++ b/subprojects/platform-objective-c/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCLibraryPlugin.java
@@ -115,6 +115,7 @@ public class ObjectiveCLibraryPlugin implements Plugin<Project> {
 		, ModelBackedTargetMachineAwareComponentMixIn
 		, ModelBackedTargetBuildTypeAwareComponentMixIn
 		, ModelBackedTargetLinkageAwareComponentMixIn
+		, ModelBackedHasBaseNameMixIn
 	{
 		@Override
 		public ObjectiveCSourceSet getObjectiveCSources() {

--- a/subprojects/platform-objective-cpp/src/main/java/dev/nokee/platform/objectivecpp/internal/plugins/ObjectiveCppApplicationPlugin.java
+++ b/subprojects/platform-objective-cpp/src/main/java/dev/nokee/platform/objectivecpp/internal/plugins/ObjectiveCppApplicationPlugin.java
@@ -112,6 +112,7 @@ public class ObjectiveCppApplicationPlugin implements Plugin<Project> {
 		, ModelBackedHasDevelopmentVariantMixIn<NativeApplication>
 		, ModelBackedTargetMachineAwareComponentMixIn
 		, ModelBackedTargetBuildTypeAwareComponentMixIn
+		, ModelBackedHasBaseNameMixIn
 	{
 		@Override
 		public ObjectiveCppSourceSet getObjectiveCppSources() {

--- a/subprojects/platform-objective-cpp/src/main/java/dev/nokee/platform/objectivecpp/internal/plugins/ObjectiveCppLibraryPlugin.java
+++ b/subprojects/platform-objective-cpp/src/main/java/dev/nokee/platform/objectivecpp/internal/plugins/ObjectiveCppLibraryPlugin.java
@@ -116,6 +116,7 @@ public class ObjectiveCppLibraryPlugin implements Plugin<Project> {
 		, ModelBackedTargetMachineAwareComponentMixIn
 		, ModelBackedTargetBuildTypeAwareComponentMixIn
 		, ModelBackedTargetLinkageAwareComponentMixIn
+		, ModelBackedHasBaseNameMixIn
 	{
 		@Override
 		public ObjectiveCppSourceSet getObjectiveCppSources() {

--- a/subprojects/platform-swift/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftApplicationPlugin.java
+++ b/subprojects/platform-swift/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftApplicationPlugin.java
@@ -96,6 +96,7 @@ public class SwiftApplicationPlugin implements Plugin<Project> {
 		, ModelBackedHasDevelopmentVariantMixIn<NativeApplication>
 		, ModelBackedTargetMachineAwareComponentMixIn
 		, ModelBackedTargetBuildTypeAwareComponentMixIn
+		, ModelBackedHasBaseNameMixIn
 	{
 		@Override
 		public SwiftSourceSet getSwiftSources() {

--- a/subprojects/platform-swift/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftLibraryPlugin.java
+++ b/subprojects/platform-swift/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftLibraryPlugin.java
@@ -98,6 +98,7 @@ public class SwiftLibraryPlugin implements Plugin<Project> {
 		, ModelBackedTargetMachineAwareComponentMixIn
 		, ModelBackedTargetBuildTypeAwareComponentMixIn
 		, ModelBackedTargetLinkageAwareComponentMixIn
+		, ModelBackedHasBaseNameMixIn
 	{
 		@Override
 		public SwiftSourceSet getSwiftSources() {


### PR DESCRIPTION
The registration factory will ultimately replace the current shared library binary implementation and registration process. For now, we only introduce the registration factory so we can unblock the JNI library refactoring work. We also introduce integration test coverage for the shared library binary. This PR also includes some misc improvements around identifier, utilities, etc.