### PR TITLE
Introduce Named implementation for all domain object

### DIFF
--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/Artifact.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/Artifact.java
@@ -15,10 +15,12 @@
  */
 package dev.nokee.platform.base;
 
+import org.gradle.api.Named;
+
 /**
  * A physical artifact.
  *
  * @since 0.5
  */
-public interface Artifact {
+public interface Artifact extends Named {
 }

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/Variant.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/Variant.java
@@ -15,6 +15,7 @@
  */
 package dev.nokee.platform.base;
 
+import org.gradle.api.Named;
 import org.gradle.api.provider.Provider;
 
 /**
@@ -22,7 +23,7 @@ import org.gradle.api.provider.Provider;
  *
  * @since 0.2
  */
-public interface Variant extends BinaryAwareComponent {
+public interface Variant extends Named, BinaryAwareComponent {
 	/**
 	 * Configure the binaries of this variant.
 	 * The view contains only the binaries participating to this variant.

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/BinaryNamer.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/BinaryNamer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.platform.base.internal;
+
+import com.google.common.collect.Streams;
+import dev.nokee.model.HasName;
+import org.apache.commons.lang3.StringUtils;
+import org.gradle.api.Namer;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public final class BinaryNamer implements Namer<BinaryIdentifier<?>> {
+	public static final BinaryNamer INSTANCE = new BinaryNamer();
+
+	@Override
+	public String determineName(BinaryIdentifier<?> identifier) {
+		return StringUtils.uncapitalize(Streams.stream(identifier).flatMap(it -> {
+			if (it instanceof ComponentIdentifier) {
+				return Stream.of((ComponentIdentifier) it).filter(t -> !t.isMainComponent()).map(t -> t.getName().get());
+			} else if (it instanceof BinaryIdentity) {
+				return Stream.of((BinaryIdentity) it).filter(t -> !t.isMain()).map(t -> t.getName().get());
+			} else if (it instanceof HasName) {
+				return Stream.of(((HasName) it).getName().toString());
+			} else {
+				return Stream.empty();
+			}
+		}).map(StringUtils::capitalize).collect(Collectors.joining()));
+	}
+}

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ComponentNamer.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ComponentNamer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.nokee.platform.base;
+package dev.nokee.platform.base.internal;
 
-import org.gradle.api.Named;
+import org.gradle.api.Namer;
 
-/**
- * A software component that is built by the Nokee plugins.
- *
- * @since 0.5
- */
-public interface Component extends Named {
+public final class ComponentNamer implements Namer<ComponentIdentifier> {
+	public static final ComponentNamer INSTANCE = new ComponentNamer();
+
+	@Override
+	public String determineName(ComponentIdentifier identifier) {
+		return identifier.getName().get();
+	}
 }

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ConfigurationNamer.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ConfigurationNamer.java
@@ -15,16 +15,46 @@
  */
 package dev.nokee.platform.base.internal;
 
+import com.google.common.collect.Streams;
+import dev.nokee.model.HasName;
+import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.platform.base.internal.dependencies.DependencyBucketIdentifier;
+import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.Namer;
 
-import static dev.nokee.platform.base.internal.dependencies.DependencyBuckets.configurationName;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public final class ConfigurationNamer implements Namer<DependencyBucketIdentifier> {
 	public static final ConfigurationNamer INSTANCE = new ConfigurationNamer();
 
 	@Override
 	public String determineName(DependencyBucketIdentifier identifier) {
-		return configurationName(identifier);
+		return StringUtils.uncapitalize(Streams.stream(identifier)
+			.flatMap(it -> {
+				if (it instanceof ProjectIdentifier) {
+					return Stream.empty();
+				} else if (it instanceof ComponentIdentifier) {
+					if (((ComponentIdentifier) it).isMainComponent()) {
+						return Stream.empty();
+					} else {
+						return Stream.of(((ComponentIdentifier) it).getName().get());
+					}
+				} else if (it instanceof ComponentIdentity) {
+					if (((ComponentIdentity) it).isMainComponent()) {
+						return Stream.empty();
+					} else {
+						return Stream.of(((ComponentIdentity) it).getName().get());
+					}
+				} else if (it instanceof VariantIdentifier) {
+					return Stream.of(((VariantIdentifier<?>) it).getUnambiguousName());
+				} else if (it instanceof HasName) {
+					return Stream.of(((HasName) it).getName().toString());
+				} else {
+					throw new UnsupportedOperationException();
+				}
+			})
+			.map(StringUtils::capitalize)
+			.collect(Collectors.joining()));
 	}
 }

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ConfigurationNamer.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ConfigurationNamer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.platform.base.internal;
+
+import dev.nokee.platform.base.internal.dependencies.DependencyBucketIdentifier;
+import org.gradle.api.Namer;
+
+import static dev.nokee.platform.base.internal.dependencies.DependencyBuckets.configurationName;
+
+public final class ConfigurationNamer implements Namer<DependencyBucketIdentifier> {
+	public static final ConfigurationNamer INSTANCE = new ConfigurationNamer();
+
+	@Override
+	public String determineName(DependencyBucketIdentifier identifier) {
+		return configurationName(identifier);
+	}
+}

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/FullyQualifiedName.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/FullyQualifiedName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,22 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.nokee.platform.jni.internal;
+package dev.nokee.platform.base.internal;
 
-import dev.nokee.platform.jni.JniJarBinary;
-import org.gradle.api.tasks.TaskProvider;
-import org.gradle.api.tasks.bundling.Jar;
+public final class FullyQualifiedName {
+	private final String name;
 
-import javax.inject.Inject;
+	public FullyQualifiedName(String name) {
+		this.name = name;
+	}
 
-public class DefaultJniJarBinary extends AbstractJarBinary implements JniJarBinary {
-	@Inject
-	public DefaultJniJarBinary(TaskProvider<Jar> jarTask) {
-		super(jarTask);
+	public String get() {
+		return name;
 	}
 
 	@Override
-	public String getName() {
-		throw new UnsupportedOperationException();
+	public String toString() {
+		return name;
 	}
 }

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ModelBackedNamedMixIn.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ModelBackedNamedMixIn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,22 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.nokee.platform.jni.internal;
+package dev.nokee.platform.base.internal;
 
-import dev.nokee.platform.jni.JniJarBinary;
-import org.gradle.api.tasks.TaskProvider;
-import org.gradle.api.tasks.bundling.Jar;
+import dev.nokee.model.internal.core.ModelNodes;
+import org.gradle.api.Named;
 
-import javax.inject.Inject;
-
-public class DefaultJniJarBinary extends AbstractJarBinary implements JniJarBinary {
-	@Inject
-	public DefaultJniJarBinary(TaskProvider<Jar> jarTask) {
-		super(jarTask);
-	}
-
+public interface ModelBackedNamedMixIn extends Named {
 	@Override
-	public String getName() {
-		throw new UnsupportedOperationException();
+	default String getName() {
+		return ModelNodes.of(this).getComponent(FullyQualifiedName.class).get();
 	}
 }

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/TaskNamer.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/TaskNamer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.platform.base.internal;
+
+import com.google.common.collect.Streams;
+import dev.nokee.model.HasName;
+import dev.nokee.model.internal.ProjectIdentifier;
+import dev.nokee.platform.base.internal.tasks.TaskIdentifier;
+import dev.nokee.platform.base.internal.tasks.TaskName;
+import lombok.val;
+import org.apache.commons.lang3.StringUtils;
+import org.gradle.api.Namer;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public final class TaskNamer implements Namer<TaskIdentifier<?>> {
+	public static final TaskNamer INSTANCE = new TaskNamer();
+
+	@Override
+	public String determineName(TaskIdentifier<?> identifier) {
+		return identifier.getName().getVerb() + Streams.stream(identifier)
+			.flatMap(it -> {
+				if (it instanceof ProjectIdentifier) {
+					return Stream.empty();
+				} else if (it instanceof ComponentIdentifier) {
+					if (((ComponentIdentifier) it).isMainComponent()) {
+						return Stream.empty();
+					} else {
+						return Stream.of(((ComponentIdentifier) it).getName().get());
+					}
+				} else if (it instanceof ComponentIdentity) {
+					if (((ComponentIdentity) it).isMainComponent()) {
+						return Stream.empty();
+					} else {
+						return Stream.of(((ComponentIdentity) it).getName().get());
+					}
+				} else if (it instanceof VariantIdentifier) {
+					return Stream.of(((VariantIdentifier<?>) it).getUnambiguousName());
+				} else if (it instanceof BinaryIdentity) {
+					return Stream.of((BinaryIdentity) it).filter(t -> !t.isMain()).map(t -> t.getName().toString());
+				} else if (it instanceof HasName) {
+					val name = ((HasName) it).getName();
+					if (name instanceof TaskName) {
+						return Streams.stream(((TaskName) name).getObject());
+					} else {
+						return Stream.of(name.toString());
+					}
+				} else {
+					throw new UnsupportedOperationException();
+				}
+			})
+			.map(StringUtils::capitalize)
+			.collect(Collectors.joining());
+	}
+}

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantNamer.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/VariantNamer.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.platform.base.internal;
+
+import com.google.common.collect.Streams;
+import dev.nokee.model.HasName;
+import org.apache.commons.lang3.StringUtils;
+import org.gradle.api.Namer;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public final class VariantNamer implements Namer<VariantIdentifier<?>> {
+	public static final VariantNamer INSTANCE = new VariantNamer();
+
+	@Override
+	public String determineName(VariantIdentifier<?> identifier) {
+		return StringUtils.uncapitalize(Streams.stream(identifier).flatMap(it -> {
+			if (it instanceof ComponentIdentifier) {
+				return Stream.of((ComponentIdentifier) it).filter(t -> !t.isMainComponent()).map(t -> t.getName().get());
+			} else if (it instanceof HasName) {
+				return Stream.of(((HasName) it).getName().toString());
+			} else {
+				return Stream.empty();
+			}
+		}).map(StringUtils::capitalize).collect(Collectors.joining()));
+	}
+}

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/ConsumableDependencyBucketRegistrationFactory.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/ConsumableDependencyBucketRegistrationFactory.java
@@ -46,7 +46,6 @@ import static dev.nokee.model.internal.DomainObjectIdentifierUtils.toPath;
 import static dev.nokee.model.internal.core.ModelProjections.createdUsing;
 import static dev.nokee.model.internal.core.ModelProjections.ofInstance;
 import static dev.nokee.model.internal.type.ModelType.of;
-import static dev.nokee.platform.base.internal.dependencies.DependencyBuckets.configurationName;
 import static dev.nokee.platform.base.internal.dependencies.DependencyBuckets.toDescription;
 
 public final class ConsumableDependencyBucketRegistrationFactory {

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/DeclarableDependencyBucketRegistrationFactory.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/DeclarableDependencyBucketRegistrationFactory.java
@@ -40,7 +40,6 @@ import static dev.nokee.model.internal.DomainObjectIdentifierUtils.toPath;
 import static dev.nokee.model.internal.core.ModelProjections.createdUsing;
 import static dev.nokee.model.internal.core.ModelProjections.createdUsingNoInject;
 import static dev.nokee.model.internal.type.ModelType.of;
-import static dev.nokee.platform.base.internal.dependencies.DependencyBuckets.configurationName;
 import static dev.nokee.platform.base.internal.dependencies.DependencyBuckets.toDescription;
 
 public final class DeclarableDependencyBucketRegistrationFactory {

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/DefaultDependencyBucketFactory.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/DefaultDependencyBucketFactory.java
@@ -18,10 +18,9 @@ package dev.nokee.platform.base.internal.dependencies;
 import dev.nokee.model.DependencyFactory;
 import dev.nokee.model.NamedDomainObjectRegistry;
 import dev.nokee.platform.base.DependencyBucket;
+import dev.nokee.platform.base.internal.ConfigurationNamer;
 import lombok.val;
 import org.gradle.api.artifacts.Configuration;
-
-import static dev.nokee.platform.base.internal.dependencies.DependencyBuckets.configurationName;
 
 public class DefaultDependencyBucketFactory implements DependencyBucketFactory {
 	private final NamedDomainObjectRegistry<Configuration> configurationRegistry;
@@ -34,7 +33,7 @@ public class DefaultDependencyBucketFactory implements DependencyBucketFactory {
 
 	@Override
 	public DependencyBucket create(DependencyBucketIdentifier identifier) {
-		val configurationProvider = configurationRegistry.registerIfAbsent(configurationName(identifier));
+		val configurationProvider = configurationRegistry.registerIfAbsent(ConfigurationNamer.INSTANCE.determineName(identifier));
 		return new DefaultDependencyBucket(identifier.getName().get(), configurationProvider, dependencyFactory);
 	}
 }

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/DependencyBucketFactoryImpl.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/DependencyBucketFactoryImpl.java
@@ -18,11 +18,11 @@ package dev.nokee.platform.base.internal.dependencies;
 import dev.nokee.model.DependencyFactory;
 import dev.nokee.model.NamedDomainObjectRegistry;
 import dev.nokee.platform.base.DependencyBucket;
+import dev.nokee.platform.base.internal.ConfigurationNamer;
 import lombok.val;
 import org.gradle.api.artifacts.Configuration;
 
 import static dev.nokee.model.internal.DomainObjectIdentifierUtils.mapDisplayName;
-import static dev.nokee.platform.base.internal.dependencies.DependencyBuckets.configurationName;
 import static dev.nokee.utils.ConfigurationUtils.configureDescription;
 
 public final class DependencyBucketFactoryImpl implements DependencyBucketFactory {
@@ -36,7 +36,7 @@ public final class DependencyBucketFactoryImpl implements DependencyBucketFactor
 
 	@Override
 	public DependencyBucket create(DependencyBucketIdentifier identifier) {
-		val configurationProvider = configurationRegistry.registerIfAbsent(configurationName(identifier));
+		val configurationProvider = configurationRegistry.registerIfAbsent(ConfigurationNamer.INSTANCE.determineName(identifier));
 		configurationProvider.configure(bucketTypeOf(identifier.getType())::configure);
 		configurationProvider.configure(configureDescription(mapDisplayName(identifier)));
 

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/DependencyBuckets.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/DependencyBuckets.java
@@ -16,19 +16,10 @@
 package dev.nokee.platform.base.internal.dependencies;
 
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Streams;
-import dev.nokee.model.HasName;
 import dev.nokee.model.internal.DomainObjectIdentifierInternal;
-import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.platform.base.internal.BinaryIdentifier;
-import dev.nokee.platform.base.internal.ComponentIdentifier;
-import dev.nokee.platform.base.internal.ComponentIdentity;
-import dev.nokee.platform.base.internal.VariantIdentifier;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
-
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public final class DependencyBuckets {
 	public static String toDescription(DependencyBucketIdentifier identifier) {
@@ -51,34 +42,5 @@ public final class DependencyBuckets {
 		}
 		builder.append(".");
 		return builder.toString();
-	}
-
-	public static String configurationName(DependencyBucketIdentifier identifier) {
-		return StringUtils.uncapitalize(Streams.stream(identifier)
-			.flatMap(it -> {
-				if (it instanceof ProjectIdentifier) {
-					return Stream.empty();
-				} else if (it instanceof ComponentIdentifier) {
-					if (((ComponentIdentifier) it).isMainComponent()) {
-						return Stream.empty();
-					} else {
-						return Stream.of(((ComponentIdentifier) it).getName().get());
-					}
-				} else if (it instanceof ComponentIdentity) {
-					if (((ComponentIdentity) it).isMainComponent()) {
-						return Stream.empty();
-					} else {
-						return Stream.of(((ComponentIdentity) it).getName().get());
-					}
-				} else if (it instanceof VariantIdentifier) {
-					return Stream.of(((VariantIdentifier<?>) it).getUnambiguousName());
-				} else if (it instanceof HasName) {
-					return Stream.of(((HasName) it).getName().toString());
-				} else {
-					throw new UnsupportedOperationException();
-				}
-			})
-			.map(StringUtils::capitalize)
-			.collect(Collectors.joining()));
 	}
 }

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/ResolvableDependencyBucketRegistrationFactory.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/ResolvableDependencyBucketRegistrationFactory.java
@@ -42,7 +42,6 @@ import static dev.nokee.model.internal.DomainObjectIdentifierUtils.toPath;
 import static dev.nokee.model.internal.core.ModelProjections.createdUsing;
 import static dev.nokee.model.internal.core.ModelProjections.ofInstance;
 import static dev.nokee.model.internal.type.ModelType.of;
-import static dev.nokee.platform.base.internal.dependencies.DependencyBuckets.configurationName;
 import static dev.nokee.platform.base.internal.dependencies.DependencyBuckets.toDescription;
 
 public final class ResolvableDependencyBucketRegistrationFactory {

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/plugins/ComponentModelBasePlugin.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/plugins/ComponentModelBasePlugin.java
@@ -15,12 +15,10 @@
  */
 package dev.nokee.platform.base.internal.plugins;
 
-import com.google.common.collect.Streams;
 import dev.nokee.internal.Factory;
 import dev.nokee.language.base.LanguageSourceSet;
 import dev.nokee.language.base.internal.plugins.LanguageBasePlugin;
 import dev.nokee.model.DependencyFactory;
-import dev.nokee.model.HasName;
 import dev.nokee.model.NamedDomainObjectRegistry;
 import dev.nokee.model.PolymorphicDomainObjectRegistry;
 import dev.nokee.model.internal.ModelPropertyIdentifier;
@@ -41,16 +39,11 @@ import dev.nokee.platform.base.internal.dependencies.ConsumableDependencyBucketR
 import dev.nokee.platform.base.internal.dependencies.DeclarableDependencyBucketRegistrationFactory;
 import dev.nokee.platform.base.internal.dependencies.DefaultDependencyBucketFactory;
 import dev.nokee.platform.base.internal.dependencies.ResolvableDependencyBucketRegistrationFactory;
-import dev.nokee.platform.base.internal.tasks.TaskIdentifier;
-import dev.nokee.platform.base.internal.tasks.TaskName;
 import lombok.val;
-import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static dev.nokee.model.internal.BaseNamedDomainObjectContainer.namedContainer;
 import static dev.nokee.model.internal.BaseNamedDomainObjectView.namedView;
@@ -94,44 +87,7 @@ public class ComponentModelBasePlugin implements Plugin<Project> {
 		project.getExtensions().add("__nokee_consumableBucketFactory", new ConsumableDependencyBucketRegistrationFactory(NamedDomainObjectRegistry.of(project.getConfigurations()), new DefaultDependencyBucketFactory(NamedDomainObjectRegistry.of(project.getConfigurations()), DependencyFactory.forProject(project)), project.getObjects()));
 
 		project.getExtensions().add(DimensionPropertyRegistrationFactory.class, "__nokee_dimensionPropertyFactory", new DimensionPropertyRegistrationFactory(project.getObjects(), project.getExtensions().getByType(ModelLookup.class)));
-		project.getExtensions().add(TaskRegistrationFactory.class, "__nokee_taskRegistrationFactory", new TaskRegistrationFactory(PolymorphicDomainObjectRegistry.of(project.getTasks()), identifier -> taskName(identifier)));
-	}
-
-	// TODO: Move Namer into its own class. We should also do the same for configuration name
-	public static String taskName(TaskIdentifier<?> identifier) {
-		return identifier.getName().getVerb() + Streams.stream(identifier)
-			.flatMap(it -> {
-				if (it instanceof ProjectIdentifier) {
-					return Stream.empty();
-				} else if (it instanceof ComponentIdentifier) {
-					if (((ComponentIdentifier) it).isMainComponent()) {
-						return Stream.empty();
-					} else {
-						return Stream.of(((ComponentIdentifier) it).getName().get());
-					}
-				} else if (it instanceof ComponentIdentity) {
-					if (((ComponentIdentity) it).isMainComponent()) {
-						return Stream.empty();
-					} else {
-						return Stream.of(((ComponentIdentity) it).getName().get());
-					}
-				} else if (it instanceof VariantIdentifier) {
-					return Stream.of(((VariantIdentifier<?>) it).getUnambiguousName());
-				} else if (it instanceof BinaryIdentity) {
-					return Stream.of((BinaryIdentity) it).filter(t -> !t.isMain()).map(t -> t.getName().toString());
-				} else if (it instanceof HasName) {
-					val name = ((HasName) it).getName();
-					if (name instanceof TaskName) {
-						return Streams.stream(((TaskName) name).getObject());
-					} else {
-						return Stream.of(name.toString());
-					}
-				} else {
-					throw new UnsupportedOperationException();
-				}
-			})
-			.map(StringUtils::capitalize)
-			.collect(Collectors.joining());
+		project.getExtensions().add(TaskRegistrationFactory.class, "__nokee_taskRegistrationFactory", new TaskRegistrationFactory(PolymorphicDomainObjectRegistry.of(project.getTasks()), TaskNamer.INSTANCE));
 	}
 
 	private static NodeRegistration components() {

--- a/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/binaries/BinaryFixture.groovy
+++ b/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/binaries/BinaryFixture.groovy
@@ -64,7 +64,12 @@ trait BinaryFixture {
 		return MyBinary
 	}
 
-	static class MyBinary implements Binary {}
+	static class MyBinary implements Binary {
+		@Override
+		String getName() {
+			throw new UnsupportedOperationException()
+		}
+	}
 
 	Class<? extends Binary> getMyEntityChildType() {
 		return MyBinaryChild
@@ -72,5 +77,10 @@ trait BinaryFixture {
 
 	static class MyBinaryChild extends MyBinary {}
 
-	static class BinaryImpl implements Binary {}
+	static class BinaryImpl implements Binary {
+		@Override
+		String getName() {
+			throw new UnsupportedOperationException()
+		}
+	}
 }

--- a/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/components/DefaultComponentContainerTest.java
+++ b/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/components/DefaultComponentContainerTest.java
@@ -77,5 +77,10 @@ class DefaultComponentContainerTest {
 		public TestSuiteComponent testedComponent(Object component) {
 			throw new UnsupportedOperationException();
 		}
+
+		@Override
+		public String getName() {
+			throw new UnsupportedOperationException();
+		}
 	}
 }

--- a/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/dependencies/DependencyBucketConfigurationNameTest.java
+++ b/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/dependencies/DependencyBucketConfigurationNameTest.java
@@ -16,6 +16,7 @@
 package dev.nokee.platform.base.internal.dependencies;
 
 import dev.nokee.platform.base.internal.ComponentIdentifier;
+import dev.nokee.platform.base.internal.ConfigurationNamer;
 import dev.nokee.platform.base.internal.VariantIdentifier;
 import org.junit.jupiter.api.Test;
 
@@ -23,10 +24,13 @@ import static dev.nokee.model.internal.ProjectIdentifier.ofRootProject;
 import static dev.nokee.platform.base.internal.ComponentIdentifier.ofMain;
 import static dev.nokee.platform.base.internal.dependencies.DependencyBucketIdentifier.of;
 import static dev.nokee.platform.base.internal.dependencies.DependencyBucketIdentity.*;
-import static dev.nokee.platform.base.internal.dependencies.DependencyBuckets.configurationName;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class DependencyBucketConfigurationNameTest {
+	private static String configurationName(DependencyBucketIdentifier identifier) {
+		return ConfigurationNamer.INSTANCE.determineName(identifier);
+	}
+
 	@Test
 	void canGenerateConfigurationNameForProjectOwnedIdentifierIsTheSameAsBucketName() {
 		assertEquals("implementation", configurationName(of(declarable("implementation"), ofRootProject())));

--- a/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/variants/VariantFixture.groovy
+++ b/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/variants/VariantFixture.groovy
@@ -17,7 +17,10 @@ package dev.nokee.platform.base.internal.variants
 
 import dev.nokee.model.DomainObjectIdentifier
 import dev.nokee.model.internal.*
-import dev.nokee.platform.base.*
+import dev.nokee.platform.base.Binary
+import dev.nokee.platform.base.BinaryView
+import dev.nokee.platform.base.BuildVariant
+import dev.nokee.platform.base.Variant
 import dev.nokee.platform.base.internal.ComponentIdentifier
 import dev.nokee.platform.base.internal.ComponentName
 import dev.nokee.platform.base.internal.VariantIdentifier
@@ -92,6 +95,11 @@ trait VariantFixture {
         BuildVariant getBuildVariant() {
 			throw new UnsupportedOperationException()
 		}
+
+		@Override
+		String getName() {
+			throw new UnsupportedOperationException()
+		}
 	}
 
 	Class<? extends Variant> getMyEntityChildType() {
@@ -122,6 +130,11 @@ trait VariantFixture {
 
 		@Override
         BuildVariant getBuildVariant() {
+			throw new UnsupportedOperationException()
+		}
+
+		@Override
+		String getName() {
 			throw new UnsupportedOperationException()
 		}
 	}

--- a/subprojects/platform-c/src/main/java/dev/nokee/platform/c/internal/plugins/CApplicationPlugin.java
+++ b/subprojects/platform-c/src/main/java/dev/nokee/platform/c/internal/plugins/CApplicationPlugin.java
@@ -101,6 +101,7 @@ public class CApplicationPlugin implements Plugin<Project> {
 		, ModelBackedTargetMachineAwareComponentMixIn
 		, ModelBackedTargetBuildTypeAwareComponentMixIn
 		, ModelBackedHasBaseNameMixIn
+		, ModelBackedNamedMixIn
 	{
 		@Override
 		public CSourceSet getCSources() {

--- a/subprojects/platform-c/src/main/java/dev/nokee/platform/c/internal/plugins/CLibraryPlugin.java
+++ b/subprojects/platform-c/src/main/java/dev/nokee/platform/c/internal/plugins/CLibraryPlugin.java
@@ -105,6 +105,7 @@ public class CLibraryPlugin implements Plugin<Project> {
 		, ModelBackedTargetBuildTypeAwareComponentMixIn
 		, ModelBackedTargetLinkageAwareComponentMixIn
 		, ModelBackedHasBaseNameMixIn
+		, ModelBackedNamedMixIn
 	{
 		@Override
 		public CSourceSet getCSources() {

--- a/subprojects/platform-cpp/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppApplicationPlugin.java
+++ b/subprojects/platform-cpp/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppApplicationPlugin.java
@@ -101,6 +101,7 @@ public class CppApplicationPlugin implements Plugin<Project> {
 		, ModelBackedTargetMachineAwareComponentMixIn
 		, ModelBackedTargetBuildTypeAwareComponentMixIn
 		, ModelBackedHasBaseNameMixIn
+		, ModelBackedNamedMixIn
 	{
 		@Override
 		public CppSourceSet getCppSources() {

--- a/subprojects/platform-cpp/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppLibraryPlugin.java
+++ b/subprojects/platform-cpp/src/main/java/dev/nokee/platform/cpp/internal/plugins/CppLibraryPlugin.java
@@ -105,6 +105,7 @@ public class CppLibraryPlugin implements Plugin<Project> {
 		, ModelBackedTargetBuildTypeAwareComponentMixIn
 		, ModelBackedTargetLinkageAwareComponentMixIn
 		, ModelBackedHasBaseNameMixIn
+		, ModelBackedNamedMixIn
 	{
 		@Override
 		public CppSourceSet getCppSources() {

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationComponent.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationComponent.java
@@ -76,6 +76,7 @@ public class DefaultIosApplicationComponent extends BaseNativeComponent<DefaultI
 	, ModelBackedBinaryAwareComponentMixIn
 	, ModelBackedTaskAwareComponentMixIn
 	, ModelBackedHasDevelopmentVariantMixIn<DefaultIosApplicationVariant>
+	, ModelBackedNamedMixIn
 {
 	@Getter private final Property<GroupId> groupId;
 	private final DependencyHandler dependencyHandler;

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationVariant.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationVariant.java
@@ -44,6 +44,7 @@ public class DefaultIosApplicationVariant extends BaseNativeVariant implements I
 	, ModelBackedDependencyAwareComponentMixIn<NativeComponentDependencies>
 	, ModelBackedBinaryAwareComponentMixIn
 	, ModelBackedTaskAwareComponentMixIn
+	, ModelBackedNamedMixIn
 {
 	private final ModelNode node = ModelNodeContext.getCurrentModelNode();
 	@Getter private final Property<String> productBundleIdentifier;

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/IosApplicationBundleInternal.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/IosApplicationBundleInternal.java
@@ -54,4 +54,9 @@ public class IosApplicationBundleInternal implements Binary, Buildable {
 	public Provider<FileSystemLocation> getApplicationBundleLocation() {
 		return bundleTask.flatMap(CreateIosApplicationBundleTask::getApplicationBundle);
 	}
+
+	@Override
+	public String getName() {
+		throw new UnsupportedOperationException();
+	}
 }

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/IosApplicationComponentModelRegistrationFactory.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/IosApplicationComponentModelRegistrationFactory.java
@@ -263,6 +263,7 @@ public final class IosApplicationComponentModelRegistrationFactory {
 					.withComponent(path.child("executable"))
 					.withComponent(IsBinary.tag())
 					.withComponent(executableIdentifier)
+					.withComponent(new FullyQualifiedName(BinaryNamer.INSTANCE.determineName(executableIdentifier)))
 					.withComponent(createdUsing(of(ExecutableBinaryInternal.class), () -> {
 						return project.getExtensions().getByType(BinaryRepository.class).get(executableIdentifier);
 					}))
@@ -274,6 +275,7 @@ public final class IosApplicationComponentModelRegistrationFactory {
 					.withComponent(path.child("applicationBundle"))
 					.withComponent(IsBinary.tag())
 					.withComponent(applicationBundleIdentifier)
+					.withComponent(new FullyQualifiedName(BinaryNamer.INSTANCE.determineName(applicationBundleIdentifier)))
 					.withComponent(createdUsing(of(IosApplicationBundleInternal.class), () -> {
 						return project.getExtensions().getByType(BinaryRepository.class).get(applicationBundleIdentifier);
 					}))
@@ -285,6 +287,7 @@ public final class IosApplicationComponentModelRegistrationFactory {
 					.withComponent(path.child("signedApplicationBundle"))
 					.withComponent(IsBinary.tag())
 					.withComponent(signedApplicationBundleIdentifier)
+					.withComponent(new FullyQualifiedName(BinaryNamer.INSTANCE.determineName(signedApplicationBundleIdentifier)))
 					.withComponent(createdUsing(of(SignedIosApplicationBundleInternal.class), () -> {
 						return project.getExtensions().getByType(BinaryRepository.class).get(signedApplicationBundleIdentifier);
 					}))

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/IosApplicationComponentModelRegistrationFactory.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/IosApplicationComponentModelRegistrationFactory.java
@@ -106,6 +106,7 @@ public final class IosApplicationComponentModelRegistrationFactory {
 				}
 			}))
 			.withComponent(IsComponent.tag())
+			.withComponent(new FullyQualifiedName(ComponentNamer.INSTANCE.determineName(identifier)))
 			.withComponent(createdUsing(of(DefaultIosApplicationComponent.class), () -> create(identifier.getName().get(), project)))
 			.action(ModelActionWithInputs.of(ModelComponentReference.of(ModelPath.class), ModelComponentReference.of(ModelState.class), new ModelActionWithInputs.A2<ModelPath, ModelState>() {
 				private boolean alreadyExecuted = false;

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/IosApplicationComponentModelRegistrationFactory.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/IosApplicationComponentModelRegistrationFactory.java
@@ -206,6 +206,7 @@ public final class IosApplicationComponentModelRegistrationFactory {
 		})
 			.withComponent(identifier)
 			.withComponent(IsVariant.tag())
+			.withComponent(new FullyQualifiedName(VariantNamer.INSTANCE.determineName(identifier)))
 			.action(self().apply(once(ModelActionWithInputs.of(ModelComponentReference.of(ModelPath.class), (entity, path) -> {
 				entity.addComponent(new ModelBackedNativeIncomingDependencies(path, project.getObjects(), project.getProviders(), project.getExtensions().getByType(ModelLookup.class)));
 			}))))

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/SignedIosApplicationBundleInternal.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/SignedIosApplicationBundleInternal.java
@@ -55,4 +55,9 @@ public class SignedIosApplicationBundleInternal implements SignedIosApplicationB
 	public Provider<FileSystemLocation> getApplicationBundleLocation() {
 		return bundleTask.flatMap(SignIosApplicationBundleTask::getSignedApplicationBundle);
 	}
+
+	@Override
+	public String getName() {
+		throw new UnsupportedOperationException();
+	}
 }

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/ObjectiveCIosApplicationPlugin.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/ObjectiveCIosApplicationPlugin.java
@@ -138,6 +138,7 @@ public class ObjectiveCIosApplicationPlugin implements Plugin<Project> {
 		, ModelBackedBinaryAwareComponentMixIn
 		, ModelBackedTaskAwareComponentMixIn
 		, ModelBackedHasBaseNameMixIn
+		, ModelBackedNamedMixIn
 	{
 		@Override
 		public ObjectiveCSourceSet getObjectiveCSources() {

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/SwiftIosApplicationPlugin.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/SwiftIosApplicationPlugin.java
@@ -93,6 +93,7 @@ public class SwiftIosApplicationPlugin implements Plugin<Project> {
 		, ModelBackedBinaryAwareComponentMixIn
 		, ModelBackedTaskAwareComponentMixIn
 		, ModelBackedHasBaseNameMixIn
+		, ModelBackedNamedMixIn
 	{
 		@Override
 		public SwiftSourceSet getSwiftSources() {

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/DefaultJvmJarBinary.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/DefaultJvmJarBinary.java
@@ -28,4 +28,9 @@ public class DefaultJvmJarBinary extends AbstractJarBinary implements JvmJarBina
 	public DefaultJvmJarBinary(TaskProvider<Jar> jarTask) {
 		super(jarTask);
 	}
+
+	@Override
+	public String getName() {
+		throw new UnsupportedOperationException();
+	}
 }

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniJarBinaryRegistrationFactory.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniJarBinaryRegistrationFactory.java
@@ -18,6 +18,7 @@ package dev.nokee.platform.jni.internal;
 import dev.nokee.model.internal.core.*;
 import dev.nokee.platform.base.internal.BinaryIdentifier;
 import dev.nokee.platform.base.internal.IsBinary;
+import dev.nokee.platform.base.internal.ModelBackedNamedMixIn;
 import dev.nokee.platform.base.internal.VariantIdentifier;
 import dev.nokee.platform.jni.JniJarBinary;
 import dev.nokee.utils.TaskDependencyUtils;
@@ -54,7 +55,7 @@ public final class JniJarBinaryRegistrationFactory {
 			.build();
 	}
 
-	public static class ModelBackedJniJarBinary implements JniJarBinary, ModelNodeAware, HasPublicType {
+	public static class ModelBackedJniJarBinary implements JniJarBinary, ModelNodeAware, HasPublicType, ModelBackedNamedMixIn {
 		private final ModelNode node = ModelNodeContext.getCurrentModelNode();
 
 		@Override

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryComponentInternal.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryComponentInternal.java
@@ -60,6 +60,7 @@ public class JniLibraryComponentInternal extends BaseComponent<JniLibraryInterna
 	, DependencyAwareComponent<JavaNativeInterfaceLibraryComponentDependencies>
 	, ModelBackedSourceAwareComponentMixIn<JavaNativeInterfaceLibrarySources>
 	, ModelBackedBinaryAwareComponentMixIn
+	, ModelBackedNamedMixIn
 {
 	@Getter private final GroupId groupId;
 	@Getter private final SetProperty<TargetMachine> targetMachines;

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryInternal.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryInternal.java
@@ -94,6 +94,11 @@ public class JniLibraryInternal extends BaseVariant implements JniLibrary, Varia
 		getDevelopmentBinary().convention(providers.provider(this::getJar));
 	}
 
+	@Override
+	public String getName() {
+		return VariantNamer.INSTANCE.determineName(getIdentifier());
+	}
+
 	public ResolvableComponentDependencies getResolvableDependencies() {
 		return resolvableDependencies;
 	}

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JvmJarBinaryRegistrationFactory.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JvmJarBinaryRegistrationFactory.java
@@ -18,6 +18,7 @@ package dev.nokee.platform.jni.internal;
 import dev.nokee.model.internal.core.*;
 import dev.nokee.platform.base.internal.BinaryIdentifier;
 import dev.nokee.platform.base.internal.IsBinary;
+import dev.nokee.platform.base.internal.ModelBackedNamedMixIn;
 import dev.nokee.platform.jni.JvmJarBinary;
 import dev.nokee.utils.TaskDependencyUtils;
 import org.gradle.api.Buildable;
@@ -54,7 +55,7 @@ public final class JvmJarBinaryRegistrationFactory {
 			.build();
 	}
 
-	public static class ModelBackedJvmJarBinary implements JvmJarBinary, Buildable, ModelNodeAware, HasPublicType {
+	public static class ModelBackedJvmJarBinary implements JvmJarBinary, Buildable, ModelNodeAware, HasPublicType, ModelBackedNamedMixIn {
 		private final ModelNode node = ModelNodeContext.getCurrentModelNode();
 
 		@Override

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/plugins/JniLibraryPlugin.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/plugins/JniLibraryPlugin.java
@@ -619,6 +619,7 @@ public class JniLibraryPlugin implements Plugin<Project> {
 		, ModelBackedVariantAwareComponentMixIn<JniLibrary>
 		, ModelBackedSourceAwareComponentMixIn<JavaNativeInterfaceLibrarySources>
 		, ModelBackedBinaryAwareComponentMixIn
+		, ModelBackedNamedMixIn
 	{
 	}
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeBinary.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/BaseNativeBinary.java
@@ -35,6 +35,7 @@ import dev.nokee.language.swift.tasks.internal.SwiftCompileTask;
 import dev.nokee.platform.base.Binary;
 import dev.nokee.platform.base.TaskView;
 import dev.nokee.platform.base.internal.BinaryIdentifier;
+import dev.nokee.platform.base.internal.BinaryNamer;
 import dev.nokee.platform.base.internal.tasks.TaskViewFactory;
 import dev.nokee.platform.nativebase.NativeBinary;
 import dev.nokee.platform.nativebase.SharedLibraryBinary;
@@ -114,6 +115,11 @@ public abstract class BaseNativeBinary implements Binary, NativeBinary, HasHeade
 			task.getModules().from(dependencies.getSwiftModules());
 			task.getCompilerArgs().addAll(getProviders().provider(() -> dependencies.getFrameworkSearchPaths().getFiles().stream().flatMap(this::toFrameworkSearchPathFlags).collect(Collectors.toList())));
 		});
+	}
+
+	@Override
+	public String getName() {
+		return BinaryNamer.INSTANCE.determineName(identifier);
 	}
 
 	public Provider<Set<FileSystemLocation>> getHeaderSearchPaths() {

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationComponent.java
@@ -18,9 +18,7 @@ package dev.nokee.platform.nativebase.internal;
 import dev.nokee.model.KnownDomainObject;
 import dev.nokee.model.internal.DomainObjectEventPublisher;
 import dev.nokee.model.internal.core.*;
-import dev.nokee.model.internal.registry.ModelNodeBackedKnownDomainObject;
 import dev.nokee.model.internal.state.ModelState;
-import dev.nokee.model.internal.type.ModelType;
 import dev.nokee.platform.base.*;
 import dev.nokee.platform.base.internal.*;
 import dev.nokee.platform.base.internal.tasks.TaskRegistry;
@@ -44,7 +42,6 @@ import org.gradle.util.ConfigureUtil;
 import javax.inject.Inject;
 
 import static dev.nokee.model.internal.core.ModelActions.once;
-import static dev.nokee.model.internal.core.ModelComponentType.projectionOf;
 import static dev.nokee.model.internal.core.ModelNodeUtils.applyTo;
 import static dev.nokee.model.internal.core.ModelNodes.stateAtLeast;
 import static dev.nokee.model.internal.core.NodePredicate.allDirectDescendants;
@@ -56,6 +53,7 @@ public class DefaultNativeApplicationComponent extends BaseNativeComponent<Defau
 	, ModelBackedBinaryAwareComponentMixIn
 	, ModelBackedTaskAwareComponentMixIn
 	, ModelBackedHasDevelopmentVariantMixIn<DefaultNativeApplicationVariant>
+	, ModelBackedNamedMixIn
 {
 	private final TaskRegistry taskRegistry;
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationVariant.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationVariant.java
@@ -40,6 +40,7 @@ public class DefaultNativeApplicationVariant extends BaseNativeVariant implement
 	, ModelBackedDependencyAwareComponentMixIn<NativeApplicationComponentDependencies>
 	, ModelBackedBinaryAwareComponentMixIn
 	, ModelBackedTaskAwareComponentMixIn
+	, ModelBackedNamedMixIn
 {
 	private final ModelNode node = ModelNodeContext.getCurrentModelNode();
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryComponent.java
@@ -18,9 +18,7 @@ package dev.nokee.platform.nativebase.internal;
 import dev.nokee.model.KnownDomainObject;
 import dev.nokee.model.internal.DomainObjectEventPublisher;
 import dev.nokee.model.internal.core.*;
-import dev.nokee.model.internal.registry.ModelNodeBackedKnownDomainObject;
 import dev.nokee.model.internal.state.ModelState;
-import dev.nokee.model.internal.type.ModelType;
 import dev.nokee.platform.base.*;
 import dev.nokee.platform.base.internal.*;
 import dev.nokee.platform.base.internal.tasks.TaskRegistry;
@@ -44,7 +42,6 @@ import org.gradle.util.ConfigureUtil;
 import javax.inject.Inject;
 
 import static dev.nokee.model.internal.core.ModelActions.once;
-import static dev.nokee.model.internal.core.ModelComponentType.projectionOf;
 import static dev.nokee.model.internal.core.ModelNodeUtils.applyTo;
 import static dev.nokee.model.internal.core.ModelNodes.stateAtLeast;
 import static dev.nokee.model.internal.core.NodePredicate.allDirectDescendants;
@@ -56,6 +53,7 @@ public class DefaultNativeLibraryComponent extends BaseNativeComponent<DefaultNa
 	, ModelBackedBinaryAwareComponentMixIn
 	, ModelBackedTaskAwareComponentMixIn
 	, ModelBackedHasDevelopmentVariantMixIn<DefaultNativeLibraryVariant>
+	, ModelBackedNamedMixIn
 {
 	private final TaskRegistry taskRegistry;
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryVariant.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryVariant.java
@@ -40,6 +40,7 @@ public class DefaultNativeLibraryVariant extends BaseNativeVariant implements Na
 	, ModelBackedDependencyAwareComponentMixIn<NativeLibraryComponentDependencies>
 	, ModelBackedBinaryAwareComponentMixIn
 	, ModelBackedTaskAwareComponentMixIn
+	, ModelBackedNamedMixIn
 {
 	private final ModelNode node = ModelNodeContext.getCurrentModelNode();
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/NativeApplicationComponentModelRegistrationFactory.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/NativeApplicationComponentModelRegistrationFactory.java
@@ -82,6 +82,7 @@ public final class NativeApplicationComponentModelRegistrationFactory {
 			.withComponent(createdUsing(of(componentType), () -> project.getObjects().newInstance(implementationComponentType)))
 			.withComponent(identifier)
 			.withComponent(IsComponent.tag())
+			.withComponent(new FullyQualifiedName(ComponentNamer.INSTANCE.determineName(identifier)))
 			// TODO: Should configure FileCollection on CApplication
 			//   and link FileCollection to source sets
 			.action(ModelActionWithInputs.of(ModelComponentReference.of(ModelPath.class), ModelComponentReference.ofProjection(LanguageSourceSet.class).asDomainObject(), ModelComponentReference.of(ModelState.IsAtLeastRealized.class), (entity, path, sourceSet, ignored) -> {

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/NativeLibraryComponentModelRegistrationFactory.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/NativeLibraryComponentModelRegistrationFactory.java
@@ -95,6 +95,7 @@ public final class NativeLibraryComponentModelRegistrationFactory {
 			.withComponent(createdUsing(of(componentType), () -> project.getObjects().newInstance(implementationComponentType)))
 			.withComponent(identifier)
 			.withComponent(IsComponent.tag())
+			.withComponent(new FullyQualifiedName(ComponentNamer.INSTANCE.determineName(identifier)))
 			// TODO: Should configure FileCollection on CApplication
 			//   and link FileCollection to source sets
 			.action(ModelActionWithInputs.of(ModelComponentReference.of(ModelPath.class), ModelComponentReference.ofProjection(LanguageSourceSet.class).asDomainObject(), ModelComponentReference.of(ModelState.IsAtLeastRealized.class), (entity, path, sourceSet, ignored) -> {

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/SharedLibraryBinaryRegistrationFactory.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/SharedLibraryBinaryRegistrationFactory.java
@@ -19,8 +19,7 @@ import dev.nokee.language.base.tasks.SourceCompile;
 import dev.nokee.model.internal.core.*;
 import dev.nokee.model.internal.type.ModelType;
 import dev.nokee.platform.base.TaskView;
-import dev.nokee.platform.base.internal.BinaryIdentifier;
-import dev.nokee.platform.base.internal.IsBinary;
+import dev.nokee.platform.base.internal.*;
 import dev.nokee.platform.nativebase.SharedLibraryBinary;
 import dev.nokee.platform.nativebase.tasks.LinkSharedLibrary;
 import dev.nokee.platform.nativebase.tasks.internal.LinkSharedLibraryTask;
@@ -54,6 +53,7 @@ public final class SharedLibraryBinaryRegistrationFactory {
 			.withComponent(identifier)
 			.withComponent(toPath(identifier))
 			.withComponent(IsBinary.tag())
+			.withComponent(new FullyQualifiedName(BinaryNamer.INSTANCE.determineName(identifier)))
 			.withComponent(createdUsing(ModelType.of(SharedLibraryBinary.class), ModelBackedSharedLibraryBinary::new))
 			.action(new AttachLinkLibrariesToLinkTaskRule(identifier))
 			.action(linkTaskRegistrationActionFactory.create(identifier, LinkSharedLibrary.class, LinkSharedLibraryTask.class))
@@ -67,7 +67,7 @@ public final class SharedLibraryBinaryRegistrationFactory {
 			.build();
 	}
 
-	private static final class ModelBackedSharedLibraryBinary implements SharedLibraryBinary, HasPublicType, ModelNodeAware {
+	private static final class ModelBackedSharedLibraryBinary implements SharedLibraryBinary, HasPublicType, ModelNodeAware, ModelBackedNamedMixIn {
 		private final ModelNode node = ModelNodeContext.getCurrentModelNode();
 		private final NativeBinaryBuildable isBuildable = new NativeBinaryBuildable(this);
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeApplicationPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeApplicationPlugin.java
@@ -214,6 +214,7 @@ public class NativeApplicationPlugin implements Plugin<Project> {
 		, ModelBackedTargetMachineAwareComponentMixIn
 		, ModelBackedTargetBuildTypeAwareComponentMixIn
 		, ModelBackedHasBaseNameMixIn
+		, ModelBackedNamedMixIn
 	{
 	}
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeApplicationPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeApplicationPlugin.java
@@ -133,6 +133,7 @@ public class NativeApplicationPlugin implements Plugin<Project> {
 					.withComponent(path.child("executable"))
 					.withComponent(IsBinary.tag())
 					.withComponent(binaryIdentifier)
+					.withComponent(new FullyQualifiedName(BinaryNamer.INSTANCE.determineName(binaryIdentifier)))
 					.withComponent(createdUsing(of(ExecutableBinaryInternal.class), () -> {
 						ModelStates.realize(entity);
 						return project.getExtensions().getByType(BinaryRepository.class).get(binaryIdentifier);

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeApplicationPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeApplicationPlugin.java
@@ -123,6 +123,7 @@ public class NativeApplicationPlugin implements Plugin<Project> {
 			})
 			.withComponent(IsVariant.tag())
 			.withComponent(identifier)
+			.withComponent(new FullyQualifiedName(VariantNamer.INSTANCE.determineName(identifier)))
 			.action(self().apply(once(ModelActionWithInputs.of(ModelComponentReference.of(ModelPath.class), (entity, path) -> {
 				entity.addComponent(new ModelBackedNativeIncomingDependencies(path, project.getObjects(), project.getProviders(), project.getExtensions().getByType(ModelLookup.class)));
 			}))))

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeLibraryPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeLibraryPlugin.java
@@ -139,6 +139,7 @@ public class NativeLibraryPlugin implements Plugin<Project> {
 		})
 			.withComponent(IsVariant.tag())
 			.withComponent(identifier)
+			.withComponent(new FullyQualifiedName(VariantNamer.INSTANCE.determineName(identifier)))
 			.action(self().apply(once(ModelActionWithInputs.of(ModelComponentReference.of(ModelPath.class), (entity, path) -> {
 				entity.addComponent(new ModelBackedNativeIncomingDependencies(path, project.getObjects(), project.getProviders(), project.getExtensions().getByType(ModelLookup.class)));
 			}))))

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeLibraryPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeLibraryPlugin.java
@@ -124,6 +124,7 @@ public class NativeLibraryPlugin implements Plugin<Project> {
 		, ModelBackedTargetBuildTypeAwareComponentMixIn
 		, ModelBackedTargetLinkageAwareComponentMixIn
 		, ModelBackedHasBaseNameMixIn
+		, ModelBackedNamedMixIn
 	{
 	}
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeLibraryPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeLibraryPlugin.java
@@ -154,6 +154,7 @@ public class NativeLibraryPlugin implements Plugin<Project> {
 						.withComponent(path.child("sharedLibrary"))
 						.withComponent(IsBinary.tag())
 						.withComponent(binaryIdentifier)
+						.withComponent(new FullyQualifiedName(BinaryNamer.INSTANCE.determineName(binaryIdentifier)))
 						.withComponent(createdUsing(of(SharedLibraryBinaryInternal.class), () -> {
 							ModelStates.realize(entity);
 							return project.getExtensions().getByType(BinaryRepository.class).get(binaryIdentifier);
@@ -167,6 +168,7 @@ public class NativeLibraryPlugin implements Plugin<Project> {
 						.withComponent(path.child("staticLibrary"))
 						.withComponent(IsBinary.tag())
 						.withComponent(binaryIdentifier)
+						.withComponent(new FullyQualifiedName(BinaryNamer.INSTANCE.determineName(binaryIdentifier)))
 						.withComponent(createdUsing(of(StaticLibraryBinaryInternal.class), () -> {
 							ModelStates.realize(entity);
 							return project.getExtensions().getByType(BinaryRepository.class).get(binaryIdentifier);

--- a/subprojects/platform-objective-c/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCApplicationPlugin.java
+++ b/subprojects/platform-objective-c/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCApplicationPlugin.java
@@ -111,6 +111,7 @@ public class ObjectiveCApplicationPlugin implements Plugin<Project> {
 		, ModelBackedTargetMachineAwareComponentMixIn
 		, ModelBackedTargetBuildTypeAwareComponentMixIn
 		, ModelBackedHasBaseNameMixIn
+		, ModelBackedNamedMixIn
 	{
 		@Override
 		public ObjectiveCSourceSet getObjectiveCSources() {

--- a/subprojects/platform-objective-c/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCLibraryPlugin.java
+++ b/subprojects/platform-objective-c/src/main/java/dev/nokee/platform/objectivec/internal/plugins/ObjectiveCLibraryPlugin.java
@@ -116,6 +116,7 @@ public class ObjectiveCLibraryPlugin implements Plugin<Project> {
 		, ModelBackedTargetBuildTypeAwareComponentMixIn
 		, ModelBackedTargetLinkageAwareComponentMixIn
 		, ModelBackedHasBaseNameMixIn
+		, ModelBackedNamedMixIn
 	{
 		@Override
 		public ObjectiveCSourceSet getObjectiveCSources() {

--- a/subprojects/platform-objective-cpp/src/main/java/dev/nokee/platform/objectivecpp/internal/plugins/ObjectiveCppApplicationPlugin.java
+++ b/subprojects/platform-objective-cpp/src/main/java/dev/nokee/platform/objectivecpp/internal/plugins/ObjectiveCppApplicationPlugin.java
@@ -113,6 +113,7 @@ public class ObjectiveCppApplicationPlugin implements Plugin<Project> {
 		, ModelBackedTargetMachineAwareComponentMixIn
 		, ModelBackedTargetBuildTypeAwareComponentMixIn
 		, ModelBackedHasBaseNameMixIn
+		, ModelBackedNamedMixIn
 	{
 		@Override
 		public ObjectiveCppSourceSet getObjectiveCppSources() {

--- a/subprojects/platform-objective-cpp/src/main/java/dev/nokee/platform/objectivecpp/internal/plugins/ObjectiveCppLibraryPlugin.java
+++ b/subprojects/platform-objective-cpp/src/main/java/dev/nokee/platform/objectivecpp/internal/plugins/ObjectiveCppLibraryPlugin.java
@@ -117,6 +117,7 @@ public class ObjectiveCppLibraryPlugin implements Plugin<Project> {
 		, ModelBackedTargetBuildTypeAwareComponentMixIn
 		, ModelBackedTargetLinkageAwareComponentMixIn
 		, ModelBackedHasBaseNameMixIn
+		, ModelBackedNamedMixIn
 	{
 		@Override
 		public ObjectiveCppSourceSet getObjectiveCppSources() {

--- a/subprojects/platform-swift/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftApplicationPlugin.java
+++ b/subprojects/platform-swift/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftApplicationPlugin.java
@@ -97,6 +97,7 @@ public class SwiftApplicationPlugin implements Plugin<Project> {
 		, ModelBackedTargetMachineAwareComponentMixIn
 		, ModelBackedTargetBuildTypeAwareComponentMixIn
 		, ModelBackedHasBaseNameMixIn
+		, ModelBackedNamedMixIn
 	{
 		@Override
 		public SwiftSourceSet getSwiftSources() {

--- a/subprojects/platform-swift/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftLibraryPlugin.java
+++ b/subprojects/platform-swift/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftLibraryPlugin.java
@@ -99,6 +99,7 @@ public class SwiftLibraryPlugin implements Plugin<Project> {
 		, ModelBackedTargetBuildTypeAwareComponentMixIn
 		, ModelBackedTargetLinkageAwareComponentMixIn
 		, ModelBackedHasBaseNameMixIn
+		, ModelBackedNamedMixIn
 	{
 		@Override
 		public SwiftSourceSet getSwiftSources() {

--- a/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteComponent.java
+++ b/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteComponent.java
@@ -98,6 +98,7 @@ public class DefaultNativeTestSuiteComponent extends BaseNativeComponent<Default
 	, ModelBackedSourceAwareComponentMixIn<ComponentSources>
 	, ModelBackedVariantAwareComponentMixIn<DefaultNativeTestSuiteVariant>
 	, ModelBackedHasDevelopmentVariantMixIn<DefaultNativeTestSuiteVariant>
+	, ModelBackedNamedMixIn
 {
 	private final ObjectFactory objects;
 	private final ProviderFactory providers;

--- a/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteVariant.java
+++ b/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteVariant.java
@@ -43,6 +43,7 @@ public class DefaultNativeTestSuiteVariant extends BaseNativeVariant implements 
 	, ModelBackedDependencyAwareComponentMixIn<NativeComponentDependencies>
 	, ModelBackedBinaryAwareComponentMixIn
 	, ModelBackedSourceAwareComponentMixIn
+	, ModelBackedNamedMixIn
 {
 	private final ModelNode node = ModelNodeContext.getCurrentModelNode();
 

--- a/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/plugins/NativeUnitTestingPlugin.java
+++ b/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/plugins/NativeUnitTestingPlugin.java
@@ -110,6 +110,7 @@ public class NativeUnitTestingPlugin implements Plugin<Project> {
 			.withComponent(IsTestComponent.tag())
 			.withComponent(IsComponent.tag())
 			.withComponent(identifier)
+			.withComponent(new FullyQualifiedName(ComponentNamer.INSTANCE.determineName(identifier)))
 			.action(ModelActionWithInputs.of(ModelComponentReference.of(ModelPath.class), ModelComponentReference.ofProjection(LanguageSourceSet.class).asDomainObject(), ModelComponentReference.of(ModelState.IsAtLeastRealized.class), (entity, path, sourceSet, ignored) -> {
 				if (entityPath.isDescendant(path)) {
 					withConventionOf(maven(identifier.getName())).accept(sourceSet);

--- a/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/plugins/NativeUnitTestingPlugin.java
+++ b/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/plugins/NativeUnitTestingPlugin.java
@@ -190,6 +190,7 @@ public class NativeUnitTestingPlugin implements Plugin<Project> {
 		})
 			.withComponent(IsVariant.tag())
 			.withComponent(identifier)
+			.withComponent(new FullyQualifiedName(VariantNamer.INSTANCE.determineName(identifier)))
 			.action(self().apply(once(ModelActionWithInputs.of(ModelComponentReference.of(ModelPath.class), (entity, path) -> {
 				entity.addComponent(new ModelBackedNativeIncomingDependencies(path, project.getObjects(), project.getProviders(), project.getExtensions().getByType(ModelLookup.class)));
 			}))))

--- a/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/plugins/NativeUnitTestingPlugin.java
+++ b/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/plugins/NativeUnitTestingPlugin.java
@@ -201,6 +201,7 @@ public class NativeUnitTestingPlugin implements Plugin<Project> {
 					.withComponent(path.child("executable"))
 					.withComponent(IsBinary.tag())
 					.withComponent(binaryIdentifier)
+					.withComponent(new FullyQualifiedName(BinaryNamer.INSTANCE.determineName(binaryIdentifier)))
 					.withComponent(createdUsing(of(ExecutableBinaryInternal.class), () -> binaryRepository.get(binaryIdentifier)))
 					.build());
 				project.getExtensions().getByType(BinaryConfigurer.class)

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultUiTestXCTestTestSuiteComponent.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultUiTestXCTestTestSuiteComponent.java
@@ -62,6 +62,7 @@ public final class DefaultUiTestXCTestTestSuiteComponent extends BaseXCTestTestS
 	, ModelBackedVariantAwareComponentMixIn<DefaultXCTestTestSuiteVariant>
 	, ModelBackedBinaryAwareComponentMixIn
 	, ModelBackedTaskAwareComponentMixIn
+	, ModelBackedNamedMixIn
 {
 	private final ProviderFactory providers;
 	private final TaskRegistry taskRegistry;

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultUnitTestXCTestTestSuiteComponent.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultUnitTestXCTestTestSuiteComponent.java
@@ -58,6 +58,7 @@ public final class DefaultUnitTestXCTestTestSuiteComponent extends BaseXCTestTes
 	, ModelBackedVariantAwareComponentMixIn<DefaultXCTestTestSuiteVariant>
 	, ModelBackedBinaryAwareComponentMixIn
 	, ModelBackedTaskAwareComponentMixIn
+	, ModelBackedNamedMixIn
 {
 	private final ProviderFactory providers;
 	private final TaskRegistry taskRegistry;

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultXCTestTestSuiteVariant.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/DefaultXCTestTestSuiteVariant.java
@@ -41,6 +41,7 @@ public class DefaultXCTestTestSuiteVariant extends BaseNativeVariant implements 
 	, ModelBackedDependencyAwareComponentMixIn<NativeComponentDependencies>
 	, ModelBackedBinaryAwareComponentMixIn
 	, ModelBackedTaskAwareComponentMixIn
+	, ModelBackedNamedMixIn
 {
 	private final ModelNode node = ModelNodeContext.getCurrentModelNode();
 

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/IosXCTestBundle.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/IosXCTestBundle.java
@@ -39,4 +39,9 @@ public final class IosXCTestBundle implements Binary, HasOutputFile {
 		return createTask.flatMap(task ->
 			task.getProject().getObjects().fileProperty().fileProvider(task.getXCTestBundle().map(it -> it.getAsFile())));
 	}
+
+	@Override
+	public String getName() {
+		throw new UnsupportedOperationException();
+	}
 }

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/plugins/ObjectiveCXCTestTestSuitePlugin.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/plugins/ObjectiveCXCTestTestSuitePlugin.java
@@ -242,6 +242,7 @@ public class ObjectiveCXCTestTestSuitePlugin implements Plugin<Project> {
 							.withComponent(path.child(variantIdentifier.getUnambiguousName()).child("unitTestXCTestBundle"))
 							.withComponent(IsBinary.tag())
 							.withComponent(binaryIdentifierXCTestBundle)
+							.withComponent(new FullyQualifiedName(BinaryNamer.INSTANCE.determineName(binaryIdentifierXCTestBundle)))
 							.withComponent(createdUsing(of(IosXCTestBundle.class), () -> binaryRepository.get(binaryIdentifierXCTestBundle)))
 							.build());
 						binaryConfigurer.configure(binaryIdentifierXCTestBundle, binary -> ModelStates.realize(ModelNodes.of(xcTestBundleEntity)));
@@ -251,6 +252,7 @@ public class ObjectiveCXCTestTestSuitePlugin implements Plugin<Project> {
 							.withComponent(path.child(variantIdentifier.getUnambiguousName()).child("signedApplicationBundle"))
 							.withComponent(IsBinary.tag())
 							.withComponent(binaryIdentifierApplicationBundle)
+							.withComponent(new FullyQualifiedName(BinaryNamer.INSTANCE.determineName(binaryIdentifierApplicationBundle)))
 							.withComponent(createdUsing(of(SignedIosApplicationBundleInternal.class), () -> binaryRepository.get(binaryIdentifierApplicationBundle)))
 							.build());
 						binaryConfigurer.configure(binaryIdentifierApplicationBundle, binary -> ModelStates.realize(ModelNodes.of(applicationBundleEntity)));
@@ -376,6 +378,7 @@ public class ObjectiveCXCTestTestSuitePlugin implements Plugin<Project> {
 							.withComponent(path.child(variantIdentifier.getUnambiguousName()).child("unitTestXCTestBundle"))
 							.withComponent(IsBinary.tag())
 							.withComponent(binaryIdentifierApplicationBundle)
+							.withComponent(new FullyQualifiedName(BinaryNamer.INSTANCE.determineName(binaryIdentifierApplicationBundle)))
 							.withComponent(createdUsing(of(IosApplicationBundleInternal.class), () -> binaryRepository.get(binaryIdentifierApplicationBundle)))
 							.build());
 						binaryConfigurer.configure(binaryIdentifierApplicationBundle, binary -> ModelStates.realize(ModelNodes.of(launcherApplicationBundleEntity)));
@@ -385,6 +388,7 @@ public class ObjectiveCXCTestTestSuitePlugin implements Plugin<Project> {
 							.withComponent(path.child(variantIdentifier.getUnambiguousName()).child("signedLauncherApplicationBundle"))
 							.withComponent(IsBinary.tag())
 							.withComponent(binaryIdentifierSignedApplicationBundle)
+							.withComponent(new FullyQualifiedName(BinaryNamer.INSTANCE.determineName(binaryIdentifierSignedApplicationBundle)))
 							.withComponent(createdUsing(of(SignedIosApplicationBundleInternal.class), () -> binaryRepository.get(binaryIdentifierSignedApplicationBundle)))
 							.build());
 						binaryConfigurer.configure(binaryIdentifierSignedApplicationBundle, binary -> ModelStates.realize(ModelNodes.of(signedLauncherApplicationBundleEntity)));

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/plugins/ObjectiveCXCTestTestSuitePlugin.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/plugins/ObjectiveCXCTestTestSuitePlugin.java
@@ -417,6 +417,7 @@ public class ObjectiveCXCTestTestSuitePlugin implements Plugin<Project> {
 		})
 			.withComponent(identifier)
 			.withComponent(IsVariant.tag())
+			.withComponent(new FullyQualifiedName(VariantNamer.INSTANCE.determineName(identifier)))
 			.action(self().apply(once(ModelActionWithInputs.of(ModelComponentReference.of(ModelPath.class), (entity, path) -> {
 				entity.addComponent(new ModelBackedNativeIncomingDependencies(path, project.getObjects(), project.getProviders(), project.getExtensions().getByType(ModelLookup.class)));
 			}))))

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/plugins/ObjectiveCXCTestTestSuitePlugin.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/plugins/ObjectiveCXCTestTestSuitePlugin.java
@@ -143,6 +143,7 @@ public class ObjectiveCXCTestTestSuitePlugin implements Plugin<Project> {
 			}))
 			.withComponent(IsComponent.tag())
 			.withComponent(IsTestComponent.tag())
+			.withComponent(new FullyQualifiedName(ComponentNamer.INSTANCE.determineName(identifier)))
 			.action(ModelActionWithInputs.of(ModelComponentReference.of(ModelPath.class), ModelComponentReference.ofProjection(LanguageSourceSet.class).asDomainObject(), ModelComponentReference.of(ModelState.IsAtLeastRealized.class), (entity, path, sourceSet, ignored) -> {
 				if (entityPath.isDescendant(path)) {
 					withConventionOf(maven(identifier.getName())).accept(sourceSet);
@@ -278,6 +279,7 @@ public class ObjectiveCXCTestTestSuitePlugin implements Plugin<Project> {
 			.withComponent(identifier)
 			.withComponent(IsComponent.tag())
 			.withComponent(IsTestComponent.tag())
+			.withComponent(new FullyQualifiedName(ComponentNamer.INSTANCE.determineName(identifier)))
 			.withComponent(createdUsing(of(DefaultUiTestXCTestTestSuiteComponent.class), () -> {
 				return newUiTestFactory(project).create(identifier);
 			}))


### PR DESCRIPTION
This PR essentially implements `Named` interface for all domain objects. We say essentially as everything this is in place but  require additional refactoring which will naturally come when we finish migrating everything to the universal model.

Fixes https://github.com/nokeedev/gradle-native/issues/456