### PR TITLE
Includes Gradle annotation to ensure forward compatibility with v7.4

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -20,6 +20,10 @@ include 'coreGradle'
 project(':coreGradle').projectDir = file('subprojects/core-gradle')
 project(':coreGradle').buildFileName = 'core-gradle.gradle'
 
+include 'gradleAnnotation'
+project(':gradleAnnotation').projectDir = file('subprojects/gradle-annotation')
+project(':gradleAnnotation').buildFileName = 'gradle-annotation.gradle'
+
 include 'coreModel'
 project(':coreModel').projectDir = file('subprojects/core-model')
 project(':coreModel').buildFileName = 'core-model.gradle'

--- a/subprojects/gradle-annotation/gradle-annotation.gradle
+++ b/subprojects/gradle-annotation/gradle-annotation.gradle
@@ -1,0 +1,5 @@
+plugins {
+	id 'java-library'
+}
+
+description = 'Includes annotation from future Gradle distribution to ensure forward compatibility. Please only use `compileOnly` dependencies to this project'

--- a/subprojects/gradle-annotation/src/main/java/org/gradle/api/tasks/IgnoreEmptyDirectories.java
+++ b/subprojects/gradle-annotation/src/main/java/org/gradle/api/tasks/IgnoreEmptyDirectories.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.tasks;
+
+import java.lang.annotation.*;
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.FIELD})
+public @interface IgnoreEmptyDirectories {
+}

--- a/subprojects/language-base/language-base.gradle
+++ b/subprojects/language-base/language-base.gradle
@@ -5,6 +5,7 @@ plugins {
 }
 
 dependencies {
+	compileOnly project(':gradleAnnotation')
 	api project(':coreModel')
 	implementation project(':coreUtils')
 	implementation project(':coreScript')

--- a/subprojects/language-base/src/main/java/dev/nokee/language/base/tasks/SourceCompile.java
+++ b/subprojects/language-base/src/main/java/dev/nokee/language/base/tasks/SourceCompile.java
@@ -59,6 +59,7 @@ public interface SourceCompile extends Task, HasDestinationDirectory {
 	 */
 	@InputFiles
 	@SkipWhenEmpty
+	@IgnoreEmptyDirectories
 	@PathSensitive(PathSensitivity.RELATIVE)
 	ConfigurableFileCollection getSource();
 }

--- a/subprojects/platform-ios/platform-ios.gradle
+++ b/subprojects/platform-ios/platform-ios.gradle
@@ -4,6 +4,7 @@ plugins {
 }
 
 dependencies {
+	compileOnly project(':gradleAnnotation')
 	implementation project(':coreUtils')
 	implementation project(':coreModel')
 	implementation project(':languageObjectiveC')

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/tasks/internal/AssetCatalogCompileTask.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/tasks/internal/AssetCatalogCompileTask.java
@@ -40,6 +40,7 @@ public class AssetCatalogCompileTask extends DefaultTask {
 	}
 
 	@SkipWhenEmpty
+	@IgnoreEmptyDirectories
 	@InputDirectory
 	public RegularFileProperty getSource() {
 		return source;

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/tasks/internal/CreateIosApplicationBundleTask.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/tasks/internal/CreateIosApplicationBundleTask.java
@@ -61,6 +61,7 @@ public class CreateIosApplicationBundleTask extends DefaultTask {
 	}
 
 	@SkipWhenEmpty
+	@IgnoreEmptyDirectories
 	@InputFiles
 	@PathSensitive(PathSensitivity.RELATIVE)
 	protected FileTree getInputFiles() {

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/tasks/internal/ProcessPropertyListTask.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/tasks/internal/ProcessPropertyListTask.java
@@ -38,6 +38,7 @@ public class ProcessPropertyListTask extends DefaultTask {
 
 	@Optional
 	@SkipWhenEmpty // TODO: Test no source
+	@IgnoreEmptyDirectories
 	@InputFiles
 	public ConfigurableFileCollection getSources() {
 		return sources;

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/tasks/internal/SignIosApplicationBundleTask.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/tasks/internal/SignIosApplicationBundleTask.java
@@ -35,6 +35,7 @@ public class SignIosApplicationBundleTask extends DefaultTask {
 	private final ObjectFactory objects;
 
 	@SkipWhenEmpty
+	@IgnoreEmptyDirectories
 	@InputDirectory
 	public Property<FileSystemLocation> getUnsignedApplicationBundle() {
 		return unsignedApplicationBundle;

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/tasks/internal/StoryboardLinkTask.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/tasks/internal/StoryboardLinkTask.java
@@ -50,6 +50,7 @@ public class StoryboardLinkTask extends DefaultTask {
 
 	// TODO: This may need to be richer so we keep the context path
 	@SkipWhenEmpty
+	@IgnoreEmptyDirectories
 	@InputFiles
 	protected List<File> getInputFiles() {
 		return getSources().getFiles().stream().flatMap(it -> {


### PR DESCRIPTION
The latest Gradle nightly force the inclusion of the `IgnoreEmptyDirectories`. To ensure forward compatibility, we created a shim for the annotation so we can compile it in.