### PR TITLE
Fold CI checks into single run per OS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,47 +37,6 @@ jobs:
     windows:
         needs: assemble
         runs-on: windows-latest
-        strategy:
-            fail-fast: false
-            matrix:
-                checkTask: [
-                    ':buildAdapterCmake:check',
-                    ':coreExec:check',
-                    ':coreGradle:check',
-                    ':coreModel:check',
-                    ':coreScript:check',
-                    ':coreUtils:check',
-                    ':docs:exemplarKit:check',
-                    ':gradleApi:check',
-                    ':ideBase:check',
-                    ':ideVisualStudio:check',
-                    ':ideXcode:check',
-                    ':internalSmokeTest:check',
-                    ':internalTesting:check',
-                    ':languageBase:check',
-                    ':languageC:check',
-                    ':languageCpp:check',
-                    ':languageNative:check',
-                    ':languageObjectiveC:check',
-                    ':languageObjectiveCpp:check',
-                    ':languageSwift:check',
-                    ':platformBase:check',
-                    ':platformC:check',
-                    ':platformCpp:check',
-                    ':platformObjectiveC:check',
-                    ':platformObjectiveCpp:check',
-                    ':platformSwift:check',
-                    ':platformIos:check',
-                    ':platformJni:check',
-                    ':platformNative:check',
-                    ':publishingCore:check',
-                    ':runtimeBase:check',
-                    ':runtimeDarwin:check',
-                    ':runtimeNative:check',
-                    ':runtimeWindows:check',
-                    ':testingBase:check',
-                    ':testingNative:check',
-                    ':testingXctest:check']
         steps:
             -   uses: actions/checkout@v2
             -   uses: actions/setup-java@v1
@@ -87,54 +46,13 @@ jobs:
                 id: gradle
                 uses: eskatos/gradle-command-action@v1
                 with:
-                    arguments: ${{ matrix.checkTask }} --scan --continue --no-daemon "-PnokeeBuildCacheUsername=${{ secrets.GRADLE_CACHE_USERNAME }}" "-PnokeeBuildCachePassword=${{ secrets.GRADLE_CACHE_PASSWORD }}"
+                    arguments: check -x :docs:check --scan --continue --no-daemon "-PnokeeBuildCacheUsername=${{ secrets.GRADLE_CACHE_USERNAME }}" "-PnokeeBuildCachePassword=${{ secrets.GRADLE_CACHE_PASSWORD }}"
                     wrapper-cache-enabled: true
                     dependencies-cache-enabled: true
 
     macos:
         needs: assemble
         runs-on: macos-latest
-        strategy:
-            fail-fast: false
-            matrix:
-                checkTask: [
-                    ':buildAdapterCmake:check',
-                    ':coreExec:check',
-                    ':coreGradle:check',
-                    ':coreModel:check',
-                    ':coreScript:check',
-                    ':coreUtils:check',
-                    ':docs:exemplarKit:check',
-                    ':gradleApi:check',
-                    ':ideBase:check',
-                    ':ideVisualStudio:check',
-                    ':ideXcode:check',
-                    ':internalSmokeTest:check',
-                    ':internalTesting:check',
-                    ':languageBase:check',
-                    ':languageC:check',
-                    ':languageCpp:check',
-                    ':languageNative:check',
-                    ':languageObjectiveC:check',
-                    ':languageObjectiveCpp:check',
-                    ':languageSwift:check',
-                    ':platformBase:check',
-                    ':platformC:check',
-                    ':platformCpp:check',
-                    ':platformObjectiveC:check',
-                    ':platformObjectiveCpp:check',
-                    ':platformSwift:check',
-                    ':platformIos:check',
-                    ':platformJni:check',
-                    ':platformNative:check',
-                    ':publishingCore:check',
-                    ':runtimeBase:check',
-                    ':runtimeDarwin:check',
-                    ':runtimeNative:check',
-                    ':runtimeWindows:check',
-                    ':testingBase:check',
-                    ':testingNative:check',
-                    ':testingXctest:check']
         steps:
             -   uses: actions/checkout@v2
             -   uses: actions/setup-java@v1
@@ -144,54 +62,13 @@ jobs:
                 id: gradle
                 uses: eskatos/gradle-command-action@v1
                 with:
-                    arguments: ${{ matrix.checkTask }} --scan --continue --no-daemon "-PnokeeBuildCacheUsername=${{ secrets.GRADLE_CACHE_USERNAME }}" "-PnokeeBuildCachePassword=${{ secrets.GRADLE_CACHE_PASSWORD }}"
+                    arguments: check -x :docs:check --scan --continue --no-daemon "-PnokeeBuildCacheUsername=${{ secrets.GRADLE_CACHE_USERNAME }}" "-PnokeeBuildCachePassword=${{ secrets.GRADLE_CACHE_PASSWORD }}"
                     wrapper-cache-enabled: true
                     dependencies-cache-enabled: true
 
     linux:
         needs: assemble
         runs-on: ubuntu-latest
-        strategy:
-            fail-fast: false
-            matrix:
-                checkTask: [
-                    ':buildAdapterCmake:check',
-                    ':coreExec:check',
-                    ':coreGradle:check',
-                    ':coreModel:check',
-                    ':coreScript:check',
-                    ':coreUtils:check',
-                    ':docs:exemplarKit:check',
-                    ':gradleApi:check',
-                    ':ideBase:check',
-                    ':ideVisualStudio:check',
-                    ':ideXcode:check',
-                    ':internalSmokeTest:check',
-                    ':internalTesting:check',
-                    ':languageBase:check',
-                    ':languageC:check',
-                    ':languageCpp:check',
-                    ':languageNative:check',
-                    ':languageObjectiveC:check',
-                    ':languageObjectiveCpp:check',
-                    ':languageSwift:check',
-                    ':platformBase:check',
-                    ':platformC:check',
-                    ':platformCpp:check',
-                    ':platformObjectiveC:check',
-                    ':platformObjectiveCpp:check',
-                    ':platformSwift:check',
-                    ':platformIos:check',
-                    ':platformJni:check',
-                    ':platformNative:check',
-                    ':publishingCore:check',
-                    ':runtimeBase:check',
-                    ':runtimeDarwin:check',
-                    ':runtimeNative:check',
-                    ':runtimeWindows:check',
-                    ':testingBase:check',
-                    ':testingNative:check',
-                    ':testingXctest:check']
         steps:
             -   uses: actions/checkout@v2
             -   uses: actions/setup-java@v1
@@ -203,7 +80,7 @@ jobs:
                 id: gradle
                 uses: eskatos/gradle-command-action@v1
                 with:
-                    arguments: ${{ matrix.checkTask }} --scan --continue --no-daemon "-PnokeeBuildCacheUsername=${{ secrets.GRADLE_CACHE_USERNAME }}" "-PnokeeBuildCachePassword=${{ secrets.GRADLE_CACHE_PASSWORD }}"
+                    arguments: check -x :docs:check --scan --continue --no-daemon "-PnokeeBuildCacheUsername=${{ secrets.GRADLE_CACHE_USERNAME }}" "-PnokeeBuildCachePassword=${{ secrets.GRADLE_CACHE_PASSWORD }}"
                     wrapper-cache-enabled: true
                     dependencies-cache-enabled: true
     check-baked-documentation:


### PR DESCRIPTION
The leading idea for this experiment is how GitHub dispatch jobs which
seems to have a pretty heavy backoff period when sending lots of jobs.
In our case, we split our tests into 37 different jobs times 3. I don't
think GitHub likes that. It leads to long delay before the job starts
which then takes at most 15 min to runs. Let's try to see if minimizing
start up delay out weights the duration of a full check.