### PR TITLE
Introduce mixin capability on ModelElement

### DIFF
--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/BaseNamedDomainObjectViewProjection.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/BaseNamedDomainObjectViewProjection.java
@@ -36,16 +36,18 @@ import static dev.nokee.model.internal.core.NodePredicate.self;
 
 public class BaseNamedDomainObjectViewProjection implements AbstractModelNodeBackedNamedDomainObjectView.Projection {
 	private final ObjectFactory objectFactory;
+	private final ModelElementFactory elementFactory;
 	private final ModelNode node = getCurrentModelNode();
 
 	@Inject
 	public BaseNamedDomainObjectViewProjection(ObjectFactory objectFactory) {
 		this.objectFactory = objectFactory;
+		this.elementFactory = new ModelElementFactory();
 	}
 
 	@Override
 	public <T> DomainObjectProvider<T> get(String name, ModelType<T> type) {
-		return DefaultModelObject.of(type, checkType(name, type).apply(ModelNodeUtils.getDescendant(node, name)));
+		return elementFactory.createObject(checkType(name, type).apply(ModelNodeUtils.getDescendant(node, name)), type);
 	}
 
 	@Override

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/BaseNamedDomainObjectViewProjection.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/BaseNamedDomainObjectViewProjection.java
@@ -42,7 +42,7 @@ public class BaseNamedDomainObjectViewProjection implements AbstractModelNodeBac
 	@Inject
 	public BaseNamedDomainObjectViewProjection(ObjectFactory objectFactory) {
 		this.objectFactory = objectFactory;
-		this.elementFactory = new ModelElementFactory();
+		this.elementFactory = new ModelElementFactory(objectFactory::newInstance);
 	}
 
 	@Override

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/DefaultModelObject.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/DefaultModelObject.java
@@ -41,10 +41,11 @@ public final class DefaultModelObject<T> implements DomainObjectProvider<T>, Pro
 	private final ConfigurableStrategy configurableStrategy;
 	private final ModelCastableStrategy castableStrategy;
 	private final ModelPropertyLookupStrategy propertyLookup;
+	private final ModelMixInStrategy mixInStrategy;
 	private final Supplier<? extends T> valueSupplier;
 	private final Supplier<ModelNode> entitySupplier;
 
-	public DefaultModelObject(NamedStrategy namedStrategy, Supplier<DomainObjectIdentifier> identifierSupplier, ModelType<T> type, ConfigurableProviderConvertibleStrategy providerConvertibleStrategy, ConfigurableStrategy configurableStrategy, ModelCastableStrategy castableStrategy, ModelPropertyLookupStrategy propertyLookup, Supplier<? extends T> valueSupplier, Supplier<ModelNode> entitySupplier) {
+	public DefaultModelObject(NamedStrategy namedStrategy, Supplier<DomainObjectIdentifier> identifierSupplier, ModelType<T> type, ConfigurableProviderConvertibleStrategy providerConvertibleStrategy, ConfigurableStrategy configurableStrategy, ModelCastableStrategy castableStrategy, ModelPropertyLookupStrategy propertyLookup, ModelMixInStrategy mixInStrategy, Supplier<? extends T> valueSupplier, Supplier<ModelNode> entitySupplier) {
 		this.namedStrategy = Objects.requireNonNull(namedStrategy);
 		this.identifierSupplier = Objects.requireNonNull(identifierSupplier);
 		this.type = Objects.requireNonNull(type);
@@ -52,6 +53,7 @@ public final class DefaultModelObject<T> implements DomainObjectProvider<T>, Pro
 		this.configurableStrategy = Objects.requireNonNull(configurableStrategy);
 		this.castableStrategy = Objects.requireNonNull(castableStrategy);
 		this.propertyLookup = Objects.requireNonNull(propertyLookup);
+		this.mixInStrategy = Objects.requireNonNull(mixInStrategy);
 		this.valueSupplier = Objects.requireNonNull(valueSupplier);
 		this.entitySupplier = Objects.requireNonNull(entitySupplier);
 	}
@@ -132,6 +134,12 @@ public final class DefaultModelObject<T> implements DomainObjectProvider<T>, Pro
 		Objects.requireNonNull(action);
 		configurableStrategy.configure(type, action);
 		return this;
+	}
+
+	@Override
+	public <S> DomainObjectProvider<S> mixin(ModelType<S> type) {
+		Objects.requireNonNull(type);
+		return mixInStrategy.mixin(type);
 	}
 
 	@Override

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/DefaultModelObject.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/DefaultModelObject.java
@@ -15,21 +15,14 @@
  */
 package dev.nokee.model.internal;
 
-import com.google.common.base.Preconditions;
-import dev.nokee.gradle.NamedDomainObjectProviderFactory;
-import dev.nokee.gradle.NamedDomainObjectProviderSpec;
 import dev.nokee.internal.provider.ProviderConvertibleInternal;
 import dev.nokee.model.DomainObjectIdentifier;
 import dev.nokee.model.DomainObjectProvider;
 import dev.nokee.model.internal.core.*;
-import dev.nokee.model.internal.state.ModelState;
-import dev.nokee.model.internal.state.ModelStates;
 import dev.nokee.model.internal.type.ModelType;
 import dev.nokee.utils.ClosureWrappedConfigureAction;
-import dev.nokee.utils.ProviderUtils;
 import groovy.lang.Closure;
 import lombok.EqualsAndHashCode;
-import lombok.val;
 import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Transformer;
@@ -37,12 +30,6 @@ import org.gradle.api.provider.Provider;
 
 import java.util.Objects;
 import java.util.function.Supplier;
-
-import static dev.nokee.model.internal.core.ModelActions.executeUsingProjection;
-import static dev.nokee.model.internal.core.ModelActions.once;
-import static dev.nokee.model.internal.core.ModelComponentType.projectionOf;
-import static dev.nokee.model.internal.core.ModelNodes.stateAtLeast;
-import static dev.nokee.model.internal.core.NodePredicate.self;
 
 // TODO: implementing ModelNodeAware is simply for legacy reason, it needs to be removed.
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
@@ -67,95 +54,6 @@ public final class DefaultModelObject<T> implements DomainObjectProvider<T>, Pro
 		this.propertyLookup = Objects.requireNonNull(propertyLookup);
 		this.valueSupplier = Objects.requireNonNull(valueSupplier);
 		this.entitySupplier = Objects.requireNonNull(entitySupplier);
-	}
-
-	public static <T> DefaultModelObject<T> of(ModelType<T> type, ModelNode entity) {
-		// TODO: Align exception with the one in ModelNode#get(ModelType). It's throwing an illegal state exception...
-		Preconditions.checkArgument(ModelNodeUtils.canBeViewedAs(entity, type), "node '%s' cannot be viewed as %s", entity, type);
-		@SuppressWarnings("unchecked")
-		val fullType = (ModelType<T>) entity.getComponents().filter(ModelProjection.class::isInstance).map(ModelProjection.class::cast).filter(it -> it.canBeViewedAs(type)).map(ModelProjection::getType).findFirst().orElseThrow(RuntimeException::new);
-		val namedStrategy = new NamedStrategy() {
-			@Override
-			public String getAsString() {
-				return entity.getComponent(ElementNameComponent.class).get();
-			}
-		};
-		val castableStrategy = new ModelBackedModelCastableStrategy(entity);
-		val configurableStrategy = new ConfigurableStrategy() {
-			@Override
-			public <S> void configure(ModelType<S> type, Action<? super S> action) {
-				if (!ModelNodeUtils.canBeViewedAs(entity, type)) {
-					throw new RuntimeException("...");
-				}
-				assert fullType.equals(type);
-				val o = entity.getComponents().filter(it -> it instanceof ModelProjection).map(ModelProjection.class::cast).filter(it -> it.canBeViewedAs(ModelType.of(NamedDomainObjectProvider.class))).findFirst().map(it -> it.get(ModelType.of(NamedDomainObjectProvider.class)));
-				if (o.isPresent() && ((Boolean) ProviderUtils.getType(o.get()).map(it -> it.equals(type.getConcreteType())).orElse(Boolean.FALSE))) {
-					o.get().configure(action);
-					return;
-				}
-				if (entity.hasComponent(projectionOf(NamedDomainObjectProvider.class))) {
-					val provider = entity.getComponent(projectionOf(NamedDomainObjectProvider.class)).get(ModelType.of(NamedDomainObjectProvider.class));
-					val ttype = ProviderUtils.getType(provider);
-					if (ttype.isPresent() && type.getConcreteType().isAssignableFrom((Class<?>) ttype.get())) {
-						provider.configure(action);
-					} else {
-						ModelNodeUtils.applyTo(entity, self(stateAtLeast(ModelState.Realized)).apply(once(executeUsingProjection(type, action))));
-					}
-				} else {
-					ModelNodeUtils.applyTo(entity, self(stateAtLeast(ModelState.Realized)).apply(once(executeUsingProjection(type, action))));
-				}
-			}
-		};
-		val propertyLookup = new ModelBackedModelPropertyLookupStrategy(entity);
-
-		val valueSupplier = new Supplier<T>() {
-			@Override
-			public T get() {
-				// TODO: We should prevent realizing the provider before a certain gate is achieved (maybe not registered)
-				if (type.isSubtypeOf(Provider.class)) {
-					return ModelNodeUtils.get(entity, type);
-				}
-				return ModelNodeUtils.get(ModelStates.realize(entity), type);
-			}
-		};
-		val provider = ProviderUtils.supplied(valueSupplier::get);
-		val p = provider;
-		val factory = new NamedDomainObjectProviderFactory();
-		val providerStrategy = new ConfigurableProviderConvertibleStrategy() {
-			@Override
-			public <S> NamedDomainObjectProvider<S> asProvider(ModelType<S> t) {
-				assert fullType.equals(t);
-				if (entity.hasComponent(projectionOf(NamedDomainObjectProvider.class))) {
-					val provider = entity.getComponent(projectionOf(NamedDomainObjectProvider.class)).get(ModelType.of(NamedDomainObjectProvider.class));
-					val ttype = ProviderUtils.getType(provider);
-					if (ttype.isPresent() && type.getConcreteType().isAssignableFrom((Class<?>) ttype.get())) {
-						return provider;
-					} else {
-						return factory.create(NamedDomainObjectProviderSpec.builder().named(() -> entity.getComponent(FullyQualifiedNameComponent.class).get()).delegateTo(p).typedAs(t.getConcreteType()).configureUsing(action -> configurableStrategy.configure(t, action)).build());
-					}
-				} else {
-					return factory.create(NamedDomainObjectProviderSpec.builder().named(() -> entity.getComponent(FullyQualifiedNameComponent.class).get()).delegateTo(p).typedAs(t.getConcreteType()).configureUsing(action -> configurableStrategy.configure(t, action)).build());
-				}
-			}
-		};
-		val identifierSupplier = new IdentifierSupplier(entity, fullType);
-		return new DefaultModelObject<>(namedStrategy, identifierSupplier, fullType, providerStrategy, configurableStrategy, castableStrategy, propertyLookup, valueSupplier, () -> entity);
-	}
-
-	@EqualsAndHashCode
-	private static final class IdentifierSupplier implements Supplier<DomainObjectIdentifier> {
-		private final ModelNode entity;
-		private final ModelType<?> type;
-
-		private IdentifierSupplier(ModelNode entity, ModelType<?> type) {
-			this.entity = entity;
-			this.type = type;
-		}
-
-		@Override
-		public DomainObjectIdentifier get() {
-			return entity.findComponent(DomainObjectIdentifier.class).orElseGet(() -> ModelIdentifier.of(entity.getComponent(ModelPath.class), type));
-		}
 	}
 
 	@Override

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/ModelElementFactory.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/ModelElementFactory.java
@@ -80,7 +80,7 @@ public final class ModelElementFactory {
 		val mixInStrategy = new ModelMixInStrategy() {
 			@Override
 			public <S> DomainObjectProvider<S> mixin(ModelType<S> type) {
-				if (castableTypes(entity).anyMatch(type::equals)) {
+				if (castableTypes(entity).anyMatch(type::isSupertypeOf)) {
 					throw new RuntimeException();
 				}
 				entity.addComponent(createdUsing(type, () -> instantiator.newInstance(type.getConcreteType())));
@@ -138,7 +138,7 @@ public final class ModelElementFactory {
 		val mixInStrategy = new ModelMixInStrategy() {
 			@Override
 			public <S> DomainObjectProvider<S> mixin(ModelType<S> type) {
-				if (castableTypes(entity).anyMatch(type::equals)) {
+				if (castableTypes(entity).anyMatch(type::isSupertypeOf)) {
 					throw new RuntimeException();
 				}
 				entity.addComponent(createdUsing(type, () -> instantiator.newInstance(type.getConcreteType())));

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/ModelElementFactory.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/ModelElementFactory.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal;
+
+import com.google.common.base.Preconditions;
+import dev.nokee.gradle.NamedDomainObjectProviderFactory;
+import dev.nokee.gradle.NamedDomainObjectProviderSpec;
+import dev.nokee.model.DomainObjectIdentifier;
+import dev.nokee.model.DomainObjectProvider;
+import dev.nokee.model.internal.core.*;
+import dev.nokee.model.internal.state.ModelState;
+import dev.nokee.model.internal.state.ModelStates;
+import dev.nokee.model.internal.type.ModelType;
+import dev.nokee.utils.ProviderUtils;
+import lombok.EqualsAndHashCode;
+import lombok.val;
+import org.gradle.api.Action;
+import org.gradle.api.NamedDomainObjectProvider;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import static dev.nokee.model.internal.core.ModelActions.executeUsingProjection;
+import static dev.nokee.model.internal.core.ModelActions.once;
+import static dev.nokee.model.internal.core.ModelComponentType.projectionOf;
+import static dev.nokee.model.internal.core.ModelNodes.stateAtLeast;
+import static dev.nokee.model.internal.core.NodePredicate.self;
+
+public final class ModelElementFactory {
+	public ModelElement createElement(ModelNode entity) {
+		Objects.requireNonNull(entity);
+		val namedStrategy = new NamedStrategy() {
+			@Override
+			public String getAsString() {
+				return entity.getComponent(ElementNameComponent.class).get();
+			}
+		};
+		val castableStrategy = new ModelBackedModelCastableStrategy(entity, this);
+		val configurableStrategy = new ConfigurableStrategy() {
+			@Override
+			public <S> void configure(ModelType<S> type, Action<? super S> action) {
+				assert type != null;
+				assert action != null;
+				if (!ModelNodeUtils.canBeViewedAs(entity, type)) {
+					throw new RuntimeException("...");
+				}
+				if (type.isSubtypeOf(Property.class)) {
+					action.execute(castableStrategy.castTo(type).get());
+				} else {
+					castableStrategy.castTo(type).configure(action);
+				}
+			}
+		};
+		val propertyLookup = new ModelBackedModelPropertyLookupStrategy(entity);
+		return new DefaultModelElement(
+			namedStrategy,
+			configurableStrategy,
+			castableStrategy,
+			propertyLookup,
+			() -> entity
+		);
+	}
+
+	public <T> DomainObjectProvider<T> createObject(ModelNode entity, ModelType<T> type) {
+		// TODO: Align exception with the one in ModelNode#get(ModelType). It's throwing an illegal state exception...
+		Preconditions.checkArgument(ModelNodeUtils.canBeViewedAs(entity, type), "node '%s' cannot be viewed as %s", entity, type);
+		@SuppressWarnings("unchecked")
+		val fullType = (ModelType<T>) entity.getComponents().filter(ModelProjection.class::isInstance).map(ModelProjection.class::cast).filter(it -> it.canBeViewedAs(type)).map(ModelProjection::getType).findFirst().orElseThrow(RuntimeException::new);
+		val namedStrategy = new NamedStrategy() {
+			@Override
+			public String getAsString() {
+				return entity.getComponent(ElementNameComponent.class).get();
+			}
+		};
+		val castableStrategy = new ModelBackedModelCastableStrategy(entity, this);
+		val configurableStrategy = new ConfigurableStrategy() {
+			@Override
+			public <S> void configure(ModelType<S> type, Action<? super S> action) {
+				if (!ModelNodeUtils.canBeViewedAs(entity, type)) {
+					throw new RuntimeException("...");
+				}
+				assert fullType.equals(type);
+				val o = entity.getComponents().filter(it -> it instanceof ModelProjection).map(ModelProjection.class::cast).filter(it -> it.canBeViewedAs(ModelType.of(NamedDomainObjectProvider.class))).findFirst().map(it -> it.get(ModelType.of(NamedDomainObjectProvider.class)));
+				if (o.isPresent() && ((Boolean) ProviderUtils.getType(o.get()).map(it -> it.equals(type.getConcreteType())).orElse(Boolean.FALSE))) {
+					o.get().configure(action);
+					return;
+				}
+				if (entity.hasComponent(projectionOf(NamedDomainObjectProvider.class))) {
+					val provider = entity.getComponent(projectionOf(NamedDomainObjectProvider.class)).get(ModelType.of(NamedDomainObjectProvider.class));
+					val ttype = ProviderUtils.getType(provider);
+					if (ttype.isPresent() && type.getConcreteType().isAssignableFrom((Class<?>) ttype.get())) {
+						provider.configure(action);
+					} else {
+						ModelNodeUtils.applyTo(entity, self(stateAtLeast(ModelState.Realized)).apply(once(executeUsingProjection(type, action))));
+					}
+				} else {
+					ModelNodeUtils.applyTo(entity, self(stateAtLeast(ModelState.Realized)).apply(once(executeUsingProjection(type, action))));
+				}
+			}
+		};
+		val propertyLookup = new ModelBackedModelPropertyLookupStrategy(entity);
+
+		val valueSupplier = new Supplier<T>() {
+			@Override
+			public T get() {
+				// TODO: We should prevent realizing the provider before a certain gate is achieved (maybe not registered)
+				if (type.isSubtypeOf(Provider.class)) {
+					return ModelNodeUtils.get(entity, type);
+				}
+				return ModelNodeUtils.get(ModelStates.realize(entity), type);
+			}
+		};
+		val provider = ProviderUtils.supplied(valueSupplier::get);
+		val p = provider;
+		val factory = new NamedDomainObjectProviderFactory();
+		val providerStrategy = new ConfigurableProviderConvertibleStrategy() {
+			@Override
+			public <S> NamedDomainObjectProvider<S> asProvider(ModelType<S> t) {
+				assert fullType.equals(t);
+				if (entity.hasComponent(projectionOf(NamedDomainObjectProvider.class))) {
+					val provider = entity.getComponent(projectionOf(NamedDomainObjectProvider.class)).get(ModelType.of(NamedDomainObjectProvider.class));
+					val ttype = ProviderUtils.getType(provider);
+					if (ttype.isPresent() && type.getConcreteType().isAssignableFrom((Class<?>) ttype.get())) {
+						return provider;
+					} else {
+						return factory.create(NamedDomainObjectProviderSpec.builder().named(() -> entity.getComponent(FullyQualifiedNameComponent.class).get()).delegateTo(p).typedAs(t.getConcreteType()).configureUsing(action -> configurableStrategy.configure(t, action)).build());
+					}
+				} else {
+					return factory.create(NamedDomainObjectProviderSpec.builder().named(() -> entity.getComponent(FullyQualifiedNameComponent.class).get()).delegateTo(p).typedAs(t.getConcreteType()).configureUsing(action -> configurableStrategy.configure(t, action)).build());
+				}
+			}
+		};
+		val identifierSupplier = new IdentifierSupplier(entity, fullType);
+		return new DefaultModelObject<>(namedStrategy, identifierSupplier, fullType, providerStrategy, configurableStrategy, castableStrategy, propertyLookup, valueSupplier, () -> entity);
+	}
+
+	@EqualsAndHashCode
+	private static final class IdentifierSupplier implements Supplier<DomainObjectIdentifier> {
+		private final ModelNode entity;
+		private final ModelType<?> type;
+
+		private IdentifierSupplier(ModelNode entity, ModelType<?> type) {
+			this.entity = entity;
+			this.type = type;
+		}
+
+		@Override
+		public DomainObjectIdentifier get() {
+			return entity.findComponent(DomainObjectIdentifier.class).orElseGet(() -> ModelIdentifier.of(entity.getComponent(ModelPath.class), type));
+		}
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/DefaultModelElement.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/DefaultModelElement.java
@@ -30,17 +30,19 @@ public final class DefaultModelElement implements ModelElement, ModelNodeAware {
 	private final ConfigurableStrategy configurableStrategy;
 	private final ModelCastableStrategy castableStrategy;
 	private final ModelPropertyLookupStrategy propertyLookup;
+	private final ModelMixInStrategy mixInStrategy;
 	private final Supplier<ModelNode> entitySupplier;
 
-	public DefaultModelElement(NamedStrategy namedStrategy, ConfigurableStrategy configurableStrategy, ModelCastableStrategy castableStrategy, ModelPropertyLookupStrategy propertyLookup) {
-		this(namedStrategy, configurableStrategy, castableStrategy, propertyLookup, () -> { throw new UnsupportedOperationException(); });
+	public DefaultModelElement(NamedStrategy namedStrategy, ConfigurableStrategy configurableStrategy, ModelCastableStrategy castableStrategy, ModelPropertyLookupStrategy propertyLookup, ModelMixInStrategy mixInStrategy) {
+		this(namedStrategy, configurableStrategy, castableStrategy, propertyLookup, mixInStrategy, () -> { throw new UnsupportedOperationException(); });
 	}
 
-	public DefaultModelElement(NamedStrategy namedStrategy, ConfigurableStrategy configurableStrategy, ModelCastableStrategy castableStrategy, ModelPropertyLookupStrategy propertyLookup, Supplier<ModelNode> entitySupplier) {
+	public DefaultModelElement(NamedStrategy namedStrategy, ConfigurableStrategy configurableStrategy, ModelCastableStrategy castableStrategy, ModelPropertyLookupStrategy propertyLookup, ModelMixInStrategy mixInStrategy, Supplier<ModelNode> entitySupplier) {
 		this.namedStrategy = Objects.requireNonNull(namedStrategy);
 		this.configurableStrategy = Objects.requireNonNull(configurableStrategy);
 		this.castableStrategy = Objects.requireNonNull(castableStrategy);
 		this.propertyLookup = Objects.requireNonNull(propertyLookup);
+		this.mixInStrategy = Objects.requireNonNull(mixInStrategy);
 		this.entitySupplier = Objects.requireNonNull(entitySupplier);
 	}
 
@@ -72,6 +74,12 @@ public final class DefaultModelElement implements ModelElement, ModelNodeAware {
 		Objects.requireNonNull(action);
 		configurableStrategy.configure(type, action);
 		return this;
+	}
+
+	@Override
+	public <S> DomainObjectProvider<S> mixin(ModelType<S> type) {
+		Objects.requireNonNull(type);
+		return mixInStrategy.mixin(type);
 	}
 
 	@Override

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/DefaultModelElement.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/DefaultModelElement.java
@@ -19,9 +19,7 @@ import dev.nokee.model.DomainObjectProvider;
 import dev.nokee.model.internal.ConfigurableStrategy;
 import dev.nokee.model.internal.NamedStrategy;
 import dev.nokee.model.internal.type.ModelType;
-import lombok.val;
 import org.gradle.api.Action;
-import org.gradle.api.provider.Property;
 
 import java.util.Objects;
 import java.util.function.Supplier;
@@ -38,46 +36,12 @@ public final class DefaultModelElement implements ModelElement, ModelNodeAware {
 		this(namedStrategy, configurableStrategy, castableStrategy, propertyLookup, () -> { throw new UnsupportedOperationException(); });
 	}
 
-	private DefaultModelElement(NamedStrategy namedStrategy, ConfigurableStrategy configurableStrategy, ModelCastableStrategy castableStrategy, ModelPropertyLookupStrategy propertyLookup, Supplier<ModelNode> entitySupplier) {
+	public DefaultModelElement(NamedStrategy namedStrategy, ConfigurableStrategy configurableStrategy, ModelCastableStrategy castableStrategy, ModelPropertyLookupStrategy propertyLookup, Supplier<ModelNode> entitySupplier) {
 		this.namedStrategy = Objects.requireNonNull(namedStrategy);
 		this.configurableStrategy = Objects.requireNonNull(configurableStrategy);
 		this.castableStrategy = Objects.requireNonNull(castableStrategy);
 		this.propertyLookup = Objects.requireNonNull(propertyLookup);
 		this.entitySupplier = Objects.requireNonNull(entitySupplier);
-	}
-
-	public static DefaultModelElement of(ModelNode entity) {
-		Objects.requireNonNull(entity);
-		val namedStrategy = new NamedStrategy() {
-			@Override
-			public String getAsString() {
-				return entity.getComponent(ElementNameComponent.class).get();
-			}
-		};
-		val castableStrategy = new ModelBackedModelCastableStrategy(entity);
-		val configurableStrategy = new ConfigurableStrategy() {
-			@Override
-			public <S> void configure(ModelType<S> type, Action<? super S> action) {
-				assert type != null;
-				assert action != null;
-				if (!ModelNodeUtils.canBeViewedAs(entity, type)) {
-					throw new RuntimeException("...");
-				}
-				if (type.isSubtypeOf(Property.class)) {
-					action.execute(castableStrategy.castTo(type).get());
-				} else {
-					castableStrategy.castTo(type).configure(action);
-				}
-			}
-		};
-		val propertyLookup = new ModelBackedModelPropertyLookupStrategy(entity);
-		return new DefaultModelElement(
-			namedStrategy,
-			configurableStrategy,
-			castableStrategy,
-			propertyLookup,
-			() -> entity
-		);
 	}
 
 	@Override

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelBackedModelCastableStrategy.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelBackedModelCastableStrategy.java
@@ -18,6 +18,7 @@ package dev.nokee.model.internal.core;
 import com.google.common.collect.Streams;
 import dev.nokee.model.DomainObjectProvider;
 import dev.nokee.model.internal.DefaultModelObject;
+import dev.nokee.model.internal.ModelElementFactory;
 import dev.nokee.model.internal.type.ModelType;
 
 import java.util.Optional;
@@ -28,15 +29,17 @@ import static java.util.stream.Collectors.toList;
 
 public final class ModelBackedModelCastableStrategy implements ModelCastableStrategy {
 	private final ModelNode entity;
+	private final ModelElementFactory elementFactory;
 
-	public ModelBackedModelCastableStrategy(ModelNode entity) {
+	public ModelBackedModelCastableStrategy(ModelNode entity, ModelElementFactory elementFactory) {
 		this.entity = entity;
+		this.elementFactory = elementFactory;
 	}
 
 	@Override
 	public <S> DomainObjectProvider<S> castTo(ModelType<S> type) {
 		assert type != null;
-		return DefaultModelObject.of(tryFind(type).orElseThrow(() -> castException(displayName(entity), type, castableTypes(entity).collect(toList()))), entity);
+		return elementFactory.createObject(entity, tryFind(type).orElseThrow(() -> castException(displayName(entity), type, castableTypes(entity).collect(toList()))));
 	}
 
 	@SuppressWarnings("unchecked")

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelMixInStrategy.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelMixInStrategy.java
@@ -17,28 +17,7 @@ package dev.nokee.model.internal.core;
 
 import dev.nokee.model.DomainObjectProvider;
 import dev.nokee.model.internal.type.ModelType;
-import org.gradle.api.Action;
-import org.gradle.api.Named;
 
-import java.lang.reflect.Type;
-
-public interface ModelElement extends Named {
-	default <S> DomainObjectProvider<S> as(Class<S> type) {
-		return as(ModelType.of(type));
-	}
-	<S> DomainObjectProvider<S> as(ModelType<S> type);
-
-	default boolean instanceOf(Type type) {
-		return instanceOf(ModelType.of(type));
-	}
-	boolean instanceOf(ModelType<?> type);
-
-	ModelElement property(String name);
-
-	<S> ModelElement configure(ModelType<S> type, Action<? super S> action);
-	default <S> ModelElement configure(Class<S> type, Action<? super S> action) {
-		return configure(ModelType.of(type), action);
-	}
-
+public interface ModelMixInStrategy {
 	<S> DomainObjectProvider<S> mixin(ModelType<S> type);
 }

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelProperties.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelProperties.java
@@ -15,6 +15,7 @@
  */
 package dev.nokee.model.internal.core;
 
+import dev.nokee.model.internal.ModelElementFactory;
 import lombok.val;
 
 import java.util.Optional;
@@ -24,11 +25,11 @@ public final class ModelProperties {
 	private ModelProperties() {}
 
 	public static ModelElement getProperty(Object self, String name) {
-		return ModelNodes.of(self).getComponent(ModelComponentType.componentOf(DescendantNodes.class)).getDirectDescendants().stream().filter(it -> it.hasComponent(IsModelProperty.class)).filter(it -> it.getComponent(ModelPath.class).getName().equals(name)).findFirst().map(DefaultModelElement::of).orElseThrow(() -> new IllegalArgumentException("No property of name '" + name + "'"));
+		return ModelNodes.of(self).getComponent(ModelComponentType.componentOf(DescendantNodes.class)).getDirectDescendants().stream().filter(it -> it.hasComponent(IsModelProperty.class)).filter(it -> it.getComponent(ModelPath.class).getName().equals(name)).findFirst().map(ModelProperties::newElement).orElseThrow(() -> new IllegalArgumentException("No property of name '" + name + "'"));
 	}
 
 	public static Optional<ModelElement> findProperty(Object self, String name) {
-		return ModelNodes.of(self).getComponent(ModelComponentType.componentOf(DescendantNodes.class)).getDirectDescendants().stream().filter(it -> it.hasComponent(IsModelProperty.class)).filter(it -> it.getComponent(ModelPath.class).getName().equals(name)).findFirst().map(DefaultModelElement::of);
+		return ModelNodes.of(self).getComponent(ModelComponentType.componentOf(DescendantNodes.class)).getDirectDescendants().stream().filter(it -> it.hasComponent(IsModelProperty.class)).filter(it -> it.getComponent(ModelPath.class).getName().equals(name)).findFirst().map(ModelProperties::newElement);
 	}
 
 	public static boolean hasProperty(Object self, String name) {
@@ -37,6 +38,10 @@ public final class ModelProperties {
 
 	public static Stream<ModelElement> getProperties(Object self) {
 		val result = ModelNodes.of(self).getComponent(ModelComponentType.componentOf(DescendantNodes.class)).getDirectDescendants();
-		return result.stream().filter(it -> it.hasComponent(ModelComponentType.componentOf(IsModelProperty.class))).map(DefaultModelElement::of);
+		return result.stream().filter(it -> it.hasComponent(ModelComponentType.componentOf(IsModelProperty.class))).map(ModelProperties::newElement);
+	}
+
+	private static ModelElement newElement(ModelNode entity) {
+		return entity.getComponent(ModelElementFactory.class).createElement(entity);
 	}
 }

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/registry/DefaultModelRegistry.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/registry/DefaultModelRegistry.java
@@ -39,7 +39,7 @@ public final class DefaultModelRegistry implements ModelRegistry, ModelConfigure
 
 	public DefaultModelRegistry(Instantiator instantiator) {
 		this.instantiator = instantiator;
-		this.elementFactory = new ModelElementFactory();
+		this.elementFactory = new ModelElementFactory(instantiator);
 		this.bindingService = new BindManagedProjectionService(instantiator);
 		configurations.add(ModelActionWithInputs.of(ModelComponentReference.of(ModelPath.class), ModelComponentReference.of(ModelState.class), (node, path, state) -> {
 			if (state.equals(ModelState.Created)) {

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/type/ModelType.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/type/ModelType.java
@@ -68,6 +68,14 @@ public final class ModelType<T> {
 		return this.type.isSubtypeOf(type.type);
 	}
 
+	public boolean isSupertypeOf(Type type) {
+		return this.type.isSupertypeOf(type);
+	}
+
+	public boolean isSupertypeOf(ModelType<?> type) {
+		return this.type.isSupertypeOf(type.type);
+	}
+
 	public boolean isParameterized() {
 		return this.type.getType() instanceof ParameterizedType;
 	}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelObjectBackedByModelEntityIntegrationTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelObjectBackedByModelEntityIntegrationTest.java
@@ -45,7 +45,8 @@ class DefaultModelObjectBackedByModelEntityIntegrationTest implements ModelObjec
 	private static final MyType myTypeInstance = Mockito.mock(MyType.class);
 	private final ModelConfigurer modelConfigurer = Mockito.mock(ModelConfigurer.class);
 	private final ModelNode node = newEntity(modelConfigurer);
-	private final DefaultModelObject<MyType> subject = DefaultModelObject.of(of(MyType.class), node);
+	private final ModelElementFactory factory = new ModelElementFactory();
+	private final DomainObjectProvider<MyType> subject = factory.createObject(node, of(MyType.class));
 
 	private static ModelNode newEntity(ModelConfigurer modelConfigurer) {
 		val entity = node("qibe", ModelProjections.createdUsing(of(MyType.class), () -> myTypeInstance), builder -> builder.withConfigurer(modelConfigurer));
@@ -100,19 +101,19 @@ class DefaultModelObjectBackedByModelEntityIntegrationTest implements ModelObjec
 
 	@Test
 	void throwExceptionWhenCreatingKnownObjectWithWrongProjectionType() {
-		val ex = assertThrows(IllegalArgumentException.class, () -> DefaultModelObject.of(of(WrongType.class), node));
+		val ex = assertThrows(IllegalArgumentException.class, () -> factory.createObject(node, of(WrongType.class)));
 		assertThat(ex.getMessage(),
 			equalTo("node 'qibe' cannot be viewed as interface dev.nokee.model.internal.DefaultModelObjectBackedByModelEntityIntegrationTest$WrongType"));
 	}
 
 	@Test
 	void throwsNullPointerExceptionWhenProjectionTypeIsNull() {
-		assertThrows(NullPointerException.class, () -> DefaultModelObject.of(null, node));
+		assertThrows(NullPointerException.class, () -> factory.createObject(node, null));
 	}
 
 	@Test
 	void throwsNullPointerExceptionWhenEntityIsNull() {
-		assertThrows(NullPointerException.class, () -> DefaultModelObject.of(of(Object.class), null));
+		assertThrows(NullPointerException.class, () -> factory.createObject(null, of(Object.class)));
 	}
 
 	@Test

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelObjectBackedByModelEntityIntegrationTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelObjectBackedByModelEntityIntegrationTest.java
@@ -146,12 +146,6 @@ class DefaultModelObjectBackedByModelEntityIntegrationTest implements ModelObjec
 		verify(modelConfigurer).configure(any());
 	}
 
-	@Test
-	void mixinTypeBecomesKnownToTheModelObject() {
-		subject.mixin(of(MyOtherTypeMixIn.class));
-		assertTrue(subject.instanceOf(of(MyOtherTypeMixIn.class)));
-	}
-
 	@Nested
 	class MixedInModelElementTest implements ModelObjectTester<MyOtherTypeMixIn> {
 		private final DomainObjectProvider<MyOtherTypeMixIn> subject = DefaultModelObjectBackedByModelEntityIntegrationTest.this.subject.mixin(of(MyOtherTypeMixIn.class));

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/DefaultModelElementBackedByModelEntityIntegrationTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/DefaultModelElementBackedByModelEntityIntegrationTest.java
@@ -17,6 +17,7 @@ package dev.nokee.model.internal.core;
 
 import dev.nokee.model.DomainObjectIdentifier;
 import dev.nokee.model.DomainObjectProvider;
+import dev.nokee.model.internal.ModelElementFactory;
 import dev.nokee.model.internal.ModelObjectTester;
 import dev.nokee.model.internal.registry.ModelConfigurer;
 import dev.nokee.model.internal.type.ModelType;
@@ -36,7 +37,8 @@ class DefaultModelElementBackedByModelEntityIntegrationTest implements ModelElem
 	private static final MyType myTypeInstance = Mockito.mock(MyType.class);
 	private final ModelConfigurer modelConfigurer = Mockito.mock(ModelConfigurer.class);
 	private final ModelNode entity = newEntity(modelConfigurer);
-	private final DefaultModelElement subject = DefaultModelElement.of(entity);
+	private final ModelElementFactory factory = new ModelElementFactory();
+	private final ModelElement subject = factory.createElement(entity);
 
 	static ModelNode newEntity(ModelConfigurer modelConfigurer) {
 		val entity = node("foru", ModelProjections.createdUsing(of(MyType.class), () -> myTypeInstance), builder -> builder.withConfigurer(modelConfigurer));
@@ -58,7 +60,7 @@ class DefaultModelElementBackedByModelEntityIntegrationTest implements ModelElem
 
 	@Test
 	void throwsExceptionIfEntityIsNull() {
-		assertThrows(NullPointerException.class, () -> DefaultModelElement.of(null));
+		assertThrows(NullPointerException.class, () -> factory.createElement(null));
 	}
 
 	@Test

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/DefaultModelElementBackedByModelEntityIntegrationTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/DefaultModelElementBackedByModelEntityIntegrationTest.java
@@ -86,12 +86,6 @@ class DefaultModelElementBackedByModelEntityIntegrationTest implements ModelElem
 		assertEquals("Could not cast entity 'foru.tare' to WrongType. Available instances: MyType.", ex.getMessage());
 	}
 
-	@Test
-	void mixinTypeBecomesKnownToTheModelElement() {
-		subject.mixin(of(MyOtherTypeMixIn.class));
-		assertTrue(subject.instanceOf(of(MyOtherTypeMixIn.class)));
-	}
-
 	@Nested
 	class MixedInModelElementTest implements ModelObjectTester<MyOtherTypeMixIn> {
 		private final DomainObjectProvider<MyOtherTypeMixIn> subject = DefaultModelElementBackedByModelEntityIntegrationTest.this.subject.mixin(of(MyOtherTypeMixIn.class));

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/ModelElementTester.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/ModelElementTester.java
@@ -92,6 +92,13 @@ public interface ModelElementTester {
 		assertThrows(RuntimeException.class, () -> subject().mixin(aKnownType()));
 	}
 
+	@Test
+	default void throwsExceptionWhenMixInSuperTypeOfKnownType() {
+		assertDoesNotThrow(() -> subject().mixin(of(MixInChildType.class)));
+		assertThrows(RuntimeException.class, () -> subject().mixin(of(MixInType.class)));
+	}
+
 	interface WrongType {}
 	interface MixInType {}
+	interface MixInChildType extends MixInType {}
 }

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/ModelElementTester.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/ModelElementTester.java
@@ -81,5 +81,12 @@ public interface ModelElementTester {
 		assertThat("mention castable types", ex.getMessage(), allOf(containsString("Available instances: "), containsString(aKnownType().getConcreteType().getSimpleName())));
 	}
 
+	@Test
+	default void mixinTypeBecomesKnownToTheModelElement() {
+		subject().mixin(of(MixInType.class));
+		assertTrue(subject().instanceOf(of(MixInType.class)));
+	}
+
 	interface WrongType {}
+	interface MixInType {}
 }

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/ModelElementTester.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/ModelElementTester.java
@@ -82,9 +82,14 @@ public interface ModelElementTester {
 	}
 
 	@Test
-	default void mixinTypeBecomesKnownToTheModelElement() {
+	default void mixinTypeBecomesKnown() {
 		subject().mixin(of(MixInType.class));
 		assertTrue(subject().instanceOf(of(MixInType.class)));
+	}
+
+	@Test
+	default void throwsExceptionWhenMixInKnownType() {
+		assertThrows(RuntimeException.class, () -> subject().mixin(aKnownType()));
 	}
 
 	interface WrongType {}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/ModelTestUtils.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/ModelTestUtils.java
@@ -43,7 +43,7 @@ public final class ModelTestUtils {
 	private static final Consumer<ModelNode.Builder> DO_NOTHING = builder -> {};
 	private static final String DEFAULT_NODE_NAME = "test";
 	private static final ModelNode ROOT = rootNode();
-	private static final ModelElementFactory FACTORY = new ModelElementFactory();
+	private static final ModelElementFactory FACTORY = new ModelElementFactory(objectFactory()::newInstance);
 	private ModelTestUtils() {}
 
 	public static ModelProjection projectionOf(Class<?> projectionType) {

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/ModelTestUtils.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/ModelTestUtils.java
@@ -17,6 +17,7 @@ package dev.nokee.model.internal.core;
 
 import com.google.common.collect.ImmutableList;
 import dev.nokee.model.DomainObjectProvider;
+import dev.nokee.model.internal.ModelElementFactory;
 import dev.nokee.model.internal.registry.ModelConfigurer;
 import dev.nokee.model.internal.registry.ModelLookup;
 import dev.nokee.model.internal.registry.ModelRegistry;
@@ -42,6 +43,7 @@ public final class ModelTestUtils {
 	private static final Consumer<ModelNode.Builder> DO_NOTHING = builder -> {};
 	private static final String DEFAULT_NODE_NAME = "test";
 	private static final ModelNode ROOT = rootNode();
+	private static final ModelElementFactory FACTORY = new ModelElementFactory();
 	private ModelTestUtils() {}
 
 	public static ModelProjection projectionOf(Class<?> projectionType) {
@@ -221,7 +223,7 @@ public final class ModelTestUtils {
 				val childNode = childNode(nodeProvider.getValue(), path.getName(), registration.getActions(), builder -> {});
 				registration.getComponents().forEach(childNode::addComponent);
 				children.put(path, childNode);
-				return DefaultModelElement.of(childNode);
+				return FACTORY.createElement(childNode);
 			}
 
 			private Stream<ModelPath> findModelPath(Object component) {

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/type/ModelTypeTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/type/ModelTypeTest.java
@@ -67,29 +67,5 @@ public class ModelTypeTest {
 		);
 	}
 
-	@Test
-	void canCheckSubtypeCompatibilityJavaType() {
-		val myType = of(MyType.class);
-		assertAll(
-			() -> assertTrue(myType.isSubtypeOf(myType.getRawType()), "same instance should be subtype"),
-			() -> assertTrue(of(MyType.class).isSubtypeOf(MyType.class), "same type should be subtype"),
-			() -> assertTrue(of(MyType.class).isSubtypeOf(Object.class), "all types are subtype of Object"),
-			() -> assertFalse(of(Object.class).isSubtypeOf(MyType.class), "Object is not subtype of any other type"),
-			() -> assertFalse(of(MyType.class).isSubtypeOf(String.class), "unrelated types should not be subtype")
-		);
-	}
-
-	@Test
-	void canCheckSubtypeCompatibilityUsingModelType() {
-		val myType = of(MyType.class);
-		assertAll(
-			() -> assertTrue(myType.isSubtypeOf(of(myType.getRawType())), "same instance should be subtype"),
-			() -> assertTrue(of(MyType.class).isSubtypeOf(of(MyType.class)), "same type should be subtype"),
-			() -> assertTrue(of(MyType.class).isSubtypeOf((Object.class)), "all types are subtype of Object"),
-			() -> assertFalse(of(Object.class).isSubtypeOf((MyType.class)), "Object is not subtype of any other type"),
-			() -> assertFalse(of(MyType.class).isSubtypeOf((String.class)), "unrelated types should not be subtype")
-		);
-	}
-
 	interface MyType {}
 }

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/type/ModelType_IsSubtypeOfTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/type/ModelType_IsSubtypeOfTest.java
@@ -20,30 +20,50 @@ import org.junit.jupiter.api.Test;
 
 import static dev.nokee.model.internal.type.ModelType.of;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class ModelType_IsSubtypeOfTest {
 	@Test
-	void canCheckSubtypeCompatibilityJavaType() {
+	void sameTypeInstanceIsSubtypeOfItself() {
 		val myType = of(MyType.class);
 		assertAll(
-			() -> assertTrue(myType.isSubtypeOf(myType.getRawType()), "same instance should be subtype"),
-			() -> assertTrue(of(MyType.class).isSubtypeOf(MyType.class), "same type should be subtype"),
-			() -> assertTrue(of(MyType.class).isSubtypeOf(Object.class), "all types are subtype of Object"),
-			() -> assertFalse(of(Object.class).isSubtypeOf(MyType.class), "Object is not subtype of any other type"),
-			() -> assertFalse(of(MyType.class).isSubtypeOf(String.class), "unrelated types should not be subtype")
+			() -> assertTrue(myType.isSubtypeOf(myType.getRawType())),
+			() -> assertTrue(myType.isSubtypeOf(myType.getType())),
+			() -> assertTrue(myType.isSubtypeOf(myType))
 		);
 	}
 
 	@Test
-	void canCheckSubtypeCompatibilityUsingModelType() {
-		val myType = of(MyType.class);
+	void sameTypeIsSubtypeOfItself() {
 		assertAll(
-			() -> assertTrue(myType.isSubtypeOf(of(myType.getRawType())), "same instance should be subtype"),
-			() -> assertTrue(of(MyType.class).isSubtypeOf(of(MyType.class)), "same type should be subtype"),
-			() -> assertTrue(of(MyType.class).isSubtypeOf((Object.class)), "all types are subtype of Object"),
-			() -> assertFalse(of(Object.class).isSubtypeOf((MyType.class)), "Object is not subtype of any other type"),
-			() -> assertFalse(of(MyType.class).isSubtypeOf((String.class)), "unrelated types should not be subtype")
+			() -> assertTrue(of(MyType.class).isSubtypeOf(MyType.class)),
+			() -> assertTrue(of(MyType.class).isSubtypeOf(of(MyType.class)))
+		);
+	}
+
+	@Test
+	void allTypesAreSubtypeOfObject() {
+		assertAll(
+			() -> assertTrue(of(MyType.class).isSubtypeOf(Object.class)),
+			() -> assertTrue(of(MyType.class).isSubtypeOf(of(Object.class))),
+			() -> assertTrue(of(String.class).isSubtypeOf(Object.class))
+		);
+	}
+
+	@Test
+	void objectIsNotSubtypeOfAnyTypes() {
+		assertAll(
+			() -> assertFalse(of(Object.class).isSubtypeOf(MyType.class)),
+			() -> assertFalse(of(Object.class).isSubtypeOf(of(MyType.class))),
+			() -> assertFalse(of(Object.class).isSubtypeOf(String.class))
+		);
+	}
+
+	@Test
+	void unrelatedTypesAreNotSubtype() {
+		assertAll(
+			() -> assertFalse(of(MyType.class).isSubtypeOf(String.class)),
+			() -> assertFalse(of(MyType.class).isSubtypeOf(of(String.class))),
+			() -> assertFalse(of(String.class).isSubtypeOf(Number.class))
 		);
 	}
 

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/type/ModelType_IsSubtypeOfTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/type/ModelType_IsSubtypeOfTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.type;
+
+import lombok.val;
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.model.internal.type.ModelType.of;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class ModelType_IsSubtypeOfTest {
+	@Test
+	void canCheckSubtypeCompatibilityJavaType() {
+		val myType = of(MyType.class);
+		assertAll(
+			() -> assertTrue(myType.isSubtypeOf(myType.getRawType()), "same instance should be subtype"),
+			() -> assertTrue(of(MyType.class).isSubtypeOf(MyType.class), "same type should be subtype"),
+			() -> assertTrue(of(MyType.class).isSubtypeOf(Object.class), "all types are subtype of Object"),
+			() -> assertFalse(of(Object.class).isSubtypeOf(MyType.class), "Object is not subtype of any other type"),
+			() -> assertFalse(of(MyType.class).isSubtypeOf(String.class), "unrelated types should not be subtype")
+		);
+	}
+
+	@Test
+	void canCheckSubtypeCompatibilityUsingModelType() {
+		val myType = of(MyType.class);
+		assertAll(
+			() -> assertTrue(myType.isSubtypeOf(of(myType.getRawType())), "same instance should be subtype"),
+			() -> assertTrue(of(MyType.class).isSubtypeOf(of(MyType.class)), "same type should be subtype"),
+			() -> assertTrue(of(MyType.class).isSubtypeOf((Object.class)), "all types are subtype of Object"),
+			() -> assertFalse(of(Object.class).isSubtypeOf((MyType.class)), "Object is not subtype of any other type"),
+			() -> assertFalse(of(MyType.class).isSubtypeOf((String.class)), "unrelated types should not be subtype")
+		);
+	}
+
+	private interface MyType {}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/type/ModelType_IsSupertypeOfTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/type/ModelType_IsSupertypeOfTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.type;
+
+import lombok.val;
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.model.internal.type.ModelType.of;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ModelType_IsSupertypeOfTest {
+	@Test
+	void sameTypeInstanceIsSupertypeOfItself() {
+		val myType = of(MyType.class);
+		assertAll(
+			() -> assertTrue(myType.isSupertypeOf(myType.getRawType())),
+			() -> assertTrue(myType.isSupertypeOf(myType.getType())),
+			() -> assertTrue(myType.isSupertypeOf(myType))
+		);
+	}
+
+	@Test
+	void sameTypeIsSupertypeOfItself() {
+		assertAll(
+			() -> assertTrue(of(MyType.class).isSupertypeOf(MyType.class)),
+			() -> assertTrue(of(MyType.class).isSupertypeOf(of(MyType.class)))
+		);
+	}
+
+	@Test
+	void objectIsSupertypeOfAllTypes() {
+		assertAll(
+			() -> assertTrue(of(Object.class).isSupertypeOf(MyType.class)),
+			() -> assertTrue(of(Object.class).isSupertypeOf(of(MyType.class))),
+			() -> assertTrue(of(Object.class).isSupertypeOf(String.class))
+		);
+	}
+
+	@Test
+	void allTypesAreNotSupertypeOfObject() {
+		assertAll(
+			() -> assertFalse(of(MyType.class).isSupertypeOf(Object.class)),
+			() -> assertFalse(of(MyType.class).isSupertypeOf(of(Object.class))),
+			() -> assertFalse(of(String.class).isSupertypeOf(Object.class))
+		);
+	}
+
+	@Test
+	void unrelatedTypesAreNotSupertype() {
+		assertAll(
+			() -> assertFalse(of(MyType.class).isSupertypeOf(String.class)),
+			() -> assertFalse(of(MyType.class).isSupertypeOf(of(String.class))),
+			() -> assertFalse(of(String.class).isSupertypeOf(Number.class))
+		);
+	}
+
+	private interface MyType {}
+}


### PR DESCRIPTION
This PR allows basic mixin capabilities at the second layer of the universal model. The basic construct for now is any interfaces that are trivially instantiable by the `ObjectFactory` (no arguments required) can be used as a mixin. We may restrict this later or allow more flexibility.

The aim is to support scenarios like the following:
```
whenElementDiscovered(HasCSources) {
    it.newProperty("cSources", ConfigurableFileCollection)
}
whenElementDiscovered(NativeComponent) {
    if (!it.instanceOf(HasCSources)) {
        it.mixin(HasCSources)
    }
}
```