### PR TITLE
Introduce APIs to access child elements from `ModelElement` and `ModelObject`

### DIFF
--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/DefaultModelObject.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/DefaultModelObject.java
@@ -131,6 +131,12 @@ public final class DefaultModelObject<T> implements DomainObjectProvider<T>, Pro
 	}
 
 	@Override
+	public ModelElement element(String name) {
+		Objects.requireNonNull(name);
+		return elementLookup.get(name);
+	}
+
+	@Override
 	public <S> DomainObjectProvider<S> element(String name, Class<S> type) {
 		Objects.requireNonNull(name);
 		Objects.requireNonNull(type);

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/DefaultModelObject.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/DefaultModelObject.java
@@ -41,11 +41,12 @@ public final class DefaultModelObject<T> implements DomainObjectProvider<T>, Pro
 	private final ConfigurableStrategy configurableStrategy;
 	private final ModelCastableStrategy castableStrategy;
 	private final ModelPropertyLookupStrategy propertyLookup;
+	private final ModelElementLookupStrategy elementLookup;
 	private final ModelMixInStrategy mixInStrategy;
 	private final Supplier<? extends T> valueSupplier;
 	private final Supplier<ModelNode> entitySupplier;
 
-	public DefaultModelObject(NamedStrategy namedStrategy, Supplier<DomainObjectIdentifier> identifierSupplier, ModelType<T> type, ConfigurableProviderConvertibleStrategy providerConvertibleStrategy, ConfigurableStrategy configurableStrategy, ModelCastableStrategy castableStrategy, ModelPropertyLookupStrategy propertyLookup, ModelMixInStrategy mixInStrategy, Supplier<? extends T> valueSupplier, Supplier<ModelNode> entitySupplier) {
+	public DefaultModelObject(NamedStrategy namedStrategy, Supplier<DomainObjectIdentifier> identifierSupplier, ModelType<T> type, ConfigurableProviderConvertibleStrategy providerConvertibleStrategy, ConfigurableStrategy configurableStrategy, ModelCastableStrategy castableStrategy, ModelPropertyLookupStrategy propertyLookup, ModelElementLookupStrategy elementLookup, ModelMixInStrategy mixInStrategy, Supplier<? extends T> valueSupplier, Supplier<ModelNode> entitySupplier) {
 		this.namedStrategy = Objects.requireNonNull(namedStrategy);
 		this.identifierSupplier = Objects.requireNonNull(identifierSupplier);
 		this.type = Objects.requireNonNull(type);
@@ -53,6 +54,7 @@ public final class DefaultModelObject<T> implements DomainObjectProvider<T>, Pro
 		this.configurableStrategy = Objects.requireNonNull(configurableStrategy);
 		this.castableStrategy = Objects.requireNonNull(castableStrategy);
 		this.propertyLookup = Objects.requireNonNull(propertyLookup);
+		this.elementLookup = Objects.requireNonNull(elementLookup);
 		this.mixInStrategy = Objects.requireNonNull(mixInStrategy);
 		this.valueSupplier = Objects.requireNonNull(valueSupplier);
 		this.entitySupplier = Objects.requireNonNull(entitySupplier);
@@ -126,6 +128,20 @@ public final class DefaultModelObject<T> implements DomainObjectProvider<T>, Pro
 	public ModelElement property(String name) {
 		Objects.requireNonNull(name);
 		return propertyLookup.get(name);
+	}
+
+	@Override
+	public <S> DomainObjectProvider<S> element(String name, Class<S> type) {
+		Objects.requireNonNull(name);
+		Objects.requireNonNull(type);
+		return elementLookup.get(name, ModelType.of(type));
+	}
+
+	@Override
+	public <S> DomainObjectProvider<S> element(String name, ModelType<S> type) {
+		Objects.requireNonNull(name);
+		Objects.requireNonNull(type);
+		return elementLookup.get(name, type);
 	}
 
 	@Override

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/ModelElementFactory.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/ModelElementFactory.java
@@ -40,7 +40,6 @@ import java.util.stream.Stream;
 import static dev.nokee.model.internal.core.ModelActions.executeUsingProjection;
 import static dev.nokee.model.internal.core.ModelActions.once;
 import static dev.nokee.model.internal.core.ModelComponentType.projectionOf;
-import static dev.nokee.model.internal.core.ModelNodeUtils.getProjections;
 import static dev.nokee.model.internal.core.ModelNodes.stateAtLeast;
 import static dev.nokee.model.internal.core.ModelProjections.createdUsing;
 import static dev.nokee.model.internal.core.NodePredicate.self;
@@ -77,6 +76,7 @@ public final class ModelElementFactory {
 			}
 		};
 		val propertyLookup = new ModelBackedModelPropertyLookupStrategy(entity);
+		val elementLookup = new ModelBackedModelElementLookupStrategy(entity, this);
 		val mixInStrategy = new ModelMixInStrategy() {
 			@Override
 			public <S> DomainObjectProvider<S> mixin(ModelType<S> type) {
@@ -92,6 +92,7 @@ public final class ModelElementFactory {
 			configurableStrategy,
 			castableStrategy,
 			propertyLookup,
+			elementLookup,
 			mixInStrategy,
 			() -> entity
 		);
@@ -135,6 +136,7 @@ public final class ModelElementFactory {
 			}
 		};
 		val propertyLookup = new ModelBackedModelPropertyLookupStrategy(entity);
+		val elementLookup = new ModelBackedModelElementLookupStrategy(entity, this);
 		val mixInStrategy = new ModelMixInStrategy() {
 			@Override
 			public <S> DomainObjectProvider<S> mixin(ModelType<S> type) {
@@ -177,7 +179,7 @@ public final class ModelElementFactory {
 			}
 		};
 		val identifierSupplier = new IdentifierSupplier(entity, fullType);
-		return new DefaultModelObject<>(namedStrategy, identifierSupplier, fullType, providerStrategy, configurableStrategy, castableStrategy, propertyLookup, mixInStrategy, valueSupplier, () -> entity);
+		return new DefaultModelObject<>(namedStrategy, identifierSupplier, fullType, providerStrategy, configurableStrategy, castableStrategy, propertyLookup, elementLookup, mixInStrategy, valueSupplier, () -> entity);
 	}
 
 	@EqualsAndHashCode

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/DefaultModelElement.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/DefaultModelElement.java
@@ -17,6 +17,7 @@ package dev.nokee.model.internal.core;
 
 import dev.nokee.model.DomainObjectProvider;
 import dev.nokee.model.internal.ConfigurableStrategy;
+import dev.nokee.model.internal.ModelElementFactory;
 import dev.nokee.model.internal.NamedStrategy;
 import dev.nokee.model.internal.type.ModelType;
 import org.gradle.api.Action;
@@ -30,18 +31,20 @@ public final class DefaultModelElement implements ModelElement, ModelNodeAware {
 	private final ConfigurableStrategy configurableStrategy;
 	private final ModelCastableStrategy castableStrategy;
 	private final ModelPropertyLookupStrategy propertyLookup;
+	private final ModelElementLookupStrategy elementLookup;
 	private final ModelMixInStrategy mixInStrategy;
 	private final Supplier<ModelNode> entitySupplier;
 
-	public DefaultModelElement(NamedStrategy namedStrategy, ConfigurableStrategy configurableStrategy, ModelCastableStrategy castableStrategy, ModelPropertyLookupStrategy propertyLookup, ModelMixInStrategy mixInStrategy) {
-		this(namedStrategy, configurableStrategy, castableStrategy, propertyLookup, mixInStrategy, () -> { throw new UnsupportedOperationException(); });
+	public DefaultModelElement(NamedStrategy namedStrategy, ConfigurableStrategy configurableStrategy, ModelCastableStrategy castableStrategy, ModelPropertyLookupStrategy propertyLookup, ModelElementLookupStrategy elementLookup, ModelMixInStrategy mixInStrategy) {
+		this(namedStrategy, configurableStrategy, castableStrategy, propertyLookup, elementLookup, mixInStrategy, () -> { throw new UnsupportedOperationException(); });
 	}
 
-	public DefaultModelElement(NamedStrategy namedStrategy, ConfigurableStrategy configurableStrategy, ModelCastableStrategy castableStrategy, ModelPropertyLookupStrategy propertyLookup, ModelMixInStrategy mixInStrategy, Supplier<ModelNode> entitySupplier) {
+	public DefaultModelElement(NamedStrategy namedStrategy, ConfigurableStrategy configurableStrategy, ModelCastableStrategy castableStrategy, ModelPropertyLookupStrategy propertyLookup, ModelElementLookupStrategy elementLookup, ModelMixInStrategy mixInStrategy, Supplier<ModelNode> entitySupplier) {
 		this.namedStrategy = Objects.requireNonNull(namedStrategy);
 		this.configurableStrategy = Objects.requireNonNull(configurableStrategy);
 		this.castableStrategy = Objects.requireNonNull(castableStrategy);
 		this.propertyLookup = Objects.requireNonNull(propertyLookup);
+		this.elementLookup = Objects.requireNonNull(elementLookup);
 		this.mixInStrategy = Objects.requireNonNull(mixInStrategy);
 		this.entitySupplier = Objects.requireNonNull(entitySupplier);
 	}
@@ -66,6 +69,20 @@ public final class DefaultModelElement implements ModelElement, ModelNodeAware {
 	public ModelElement property(String name) {
 		Objects.requireNonNull(name);
 		return propertyLookup.get(name);
+	}
+
+	@Override
+	public <S> DomainObjectProvider<S> element(String name, Class<S> type) {
+		Objects.requireNonNull(name);
+		Objects.requireNonNull(type);
+		return elementLookup.get(name, ModelType.of(type));
+	}
+
+	@Override
+	public <S> DomainObjectProvider<S> element(String name, ModelType<S> type) {
+		Objects.requireNonNull(name);
+		Objects.requireNonNull(type);
+		return elementLookup.get(name, type);
 	}
 
 	@Override

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/DefaultModelElement.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/DefaultModelElement.java
@@ -72,6 +72,12 @@ public final class DefaultModelElement implements ModelElement, ModelNodeAware {
 	}
 
 	@Override
+	public ModelElement element(String name) {
+		Objects.requireNonNull(name);
+		return elementLookup.get(name);
+	}
+
+	@Override
 	public <S> DomainObjectProvider<S> element(String name, Class<S> type) {
 		Objects.requireNonNull(name);
 		Objects.requireNonNull(type);

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelBackedModelElementLookupStrategy.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelBackedModelElementLookupStrategy.java
@@ -30,6 +30,12 @@ public final class ModelBackedModelElementLookupStrategy implements ModelElement
 	}
 
 	@Override
+	public ModelElement get(String name) {
+		assert name != null;
+		return elementFactory.createElement(ModelNodeUtils.getDirectDescendants(entity).stream().filter(it -> it.getComponent(ElementNameComponent.class).get().equals(name)).collect(MoreCollectors.onlyElement()));
+	}
+
+	@Override
 	public <S> DomainObjectProvider<S> get(String name, ModelType<S> type) {
 		assert name != null;
 		assert type != null;

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelBackedModelElementLookupStrategy.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelBackedModelElementLookupStrategy.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.core;
+
+import com.google.common.collect.MoreCollectors;
+import dev.nokee.model.DomainObjectProvider;
+import dev.nokee.model.internal.ModelElementFactory;
+import dev.nokee.model.internal.type.ModelType;
+
+public final class ModelBackedModelElementLookupStrategy implements ModelElementLookupStrategy {
+	private final ModelNode entity;
+	private final ModelElementFactory elementFactory;
+
+	public ModelBackedModelElementLookupStrategy(ModelNode entity, ModelElementFactory elementFactory) {
+		this.entity = entity;
+		this.elementFactory = elementFactory;
+	}
+
+	@Override
+	public <S> DomainObjectProvider<S> get(String name, ModelType<S> type) {
+		assert name != null;
+		assert type != null;
+		return elementFactory.createObject(ModelNodeUtils.getDirectDescendants(entity).stream().filter(it -> it.getComponent(ElementNameComponent.class).get().equals(name) && ModelNodeUtils.canBeViewedAs(it, type)).collect(MoreCollectors.onlyElement()), type);
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelElement.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelElement.java
@@ -35,6 +35,9 @@ public interface ModelElement extends Named {
 
 	ModelElement property(String name);
 
+	<S> DomainObjectProvider<S> element(String name, Class<S> type);
+	<S> DomainObjectProvider<S> element(String name, ModelType<S> type);
+
 	<S> ModelElement configure(ModelType<S> type, Action<? super S> action);
 	default <S> ModelElement configure(Class<S> type, Action<? super S> action) {
 		return configure(ModelType.of(type), action);

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelElement.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelElement.java
@@ -35,6 +35,7 @@ public interface ModelElement extends Named {
 
 	ModelElement property(String name);
 
+	ModelElement element(String name);
 	<S> DomainObjectProvider<S> element(String name, Class<S> type);
 	<S> DomainObjectProvider<S> element(String name, ModelType<S> type);
 

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelElementLookupStrategy.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelElementLookupStrategy.java
@@ -19,5 +19,6 @@ import dev.nokee.model.DomainObjectProvider;
 import dev.nokee.model.internal.type.ModelType;
 
 public interface ModelElementLookupStrategy {
+	ModelElement get(String name);
 	<T> DomainObjectProvider<T> get(String name, ModelType<T> type);
 }

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelElementLookupStrategy.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelElementLookupStrategy.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.core;
+
+import dev.nokee.model.DomainObjectProvider;
+import dev.nokee.model.internal.type.ModelType;
+
+public interface ModelElementLookupStrategy {
+	<T> DomainObjectProvider<T> get(String name, ModelType<T> type);
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelObjectElementQueryIntegrationTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelObjectElementQueryIntegrationTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.mock;
 class DefaultModelObjectElementQueryIntegrationTest extends AbstractPluginTest {
 	private final DomainObjectIdentifier i0 = mock(DomainObjectIdentifier.class);
 	private final DomainObjectIdentifier i1 = mock(DomainObjectIdentifier.class);
+	private final DomainObjectIdentifier i2 = mock(DomainObjectIdentifier.class);
 	private DomainObjectProvider<Object> object;
 
 	@BeforeEach
@@ -46,8 +47,8 @@ class DefaultModelObjectElementQueryIntegrationTest extends AbstractPluginTest {
 		object = registry.register(builder().withComponent(path("a")).withComponent(ofInstance(new Object())).build()).as(Object.class);
 		registry.register(builder().withComponent(path("a.b")).withComponent(i0).withComponent(ofInstance("peda")).build());
 		registry.register(builder().withComponent(path("a.b")).withComponent(i1).withComponent(createdUsing(of(MyType.class), () -> objectFactory().newInstance(MyType.class))).build());
+		registry.register(builder().withComponent(path("a.c")).withComponent(i2).withComponent(ofInstance(Boolean.TRUE)).build());
 	}
-
 
 	@Nested
 	class FirstElementTest {
@@ -90,6 +91,26 @@ class DefaultModelObjectElementQueryIntegrationTest extends AbstractPluginTest {
 	}
 
 	@Nested
+	class ThirdElementTest {
+		private DomainObjectProvider<Boolean> subject;
+
+		@BeforeEach
+		void createSubject() {
+			subject = object.element("c").as(Boolean.class);
+		}
+
+		@Test
+		void returnsThirdElementType() {
+			assertEquals(Boolean.class, subject.getType());
+		}
+
+		@Test
+		void returnsThirdElementIdentifier() {
+			assertEquals(i2, subject.getIdentifier());
+		}
+	}
+
+	@Nested
 	class MultipleElementWithSameTypeTest {
 		@BeforeEach
 		void createConflictingElement() {
@@ -105,6 +126,16 @@ class DefaultModelObjectElementQueryIntegrationTest extends AbstractPluginTest {
 		@Test
 		void doesNotThrowExceptionIfOnlyOneElementHaveTheSpecifiedType() {
 			assertDoesNotThrow(() -> object.element("b", MyType.class));
+		}
+
+		@Test
+		void throwsExceptionIfMultipleElementHaveTheSameName() {
+			assertThrows(RuntimeException.class, () -> object.element("b"));
+		}
+
+		@Test
+		void doesNotThrowExceptionIfOnlyOneElementHaveTheSpecifiedName() {
+			assertDoesNotThrow(() -> object.element("c"));
 		}
 	}
 

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelObjectElementQueryIntegrationTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelObjectElementQueryIntegrationTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal;
+
+import dev.nokee.internal.testing.AbstractPluginTest;
+import dev.nokee.internal.testing.PluginRequirement;
+import dev.nokee.model.DomainObjectIdentifier;
+import dev.nokee.model.DomainObjectProvider;
+import dev.nokee.model.internal.registry.ModelRegistry;
+import lombok.val;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
+import static dev.nokee.model.internal.core.ModelPath.path;
+import static dev.nokee.model.internal.core.ModelProjections.createdUsing;
+import static dev.nokee.model.internal.core.ModelProjections.ofInstance;
+import static dev.nokee.model.internal.core.ModelRegistration.builder;
+import static dev.nokee.model.internal.type.ModelType.of;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+@PluginRequirement.Require(id = "dev.nokee.model-base")
+class DefaultModelObjectElementQueryIntegrationTest extends AbstractPluginTest {
+	private final DomainObjectIdentifier i0 = mock(DomainObjectIdentifier.class);
+	private final DomainObjectIdentifier i1 = mock(DomainObjectIdentifier.class);
+	private DomainObjectProvider<Object> object;
+
+	@BeforeEach
+	void createObject() {
+		val registry = project.getExtensions().getByType(ModelRegistry.class);
+		object = registry.register(builder().withComponent(path("a")).withComponent(ofInstance(new Object())).build()).as(Object.class);
+		registry.register(builder().withComponent(path("a.b")).withComponent(i0).withComponent(ofInstance("peda")).build());
+		registry.register(builder().withComponent(path("a.b")).withComponent(i1).withComponent(createdUsing(of(MyType.class), () -> objectFactory().newInstance(MyType.class))).build());
+	}
+
+
+	@Nested
+	class FirstElementTest {
+		private DomainObjectProvider<String> subject;
+
+		@BeforeEach
+		void createSubject() {
+			subject = object.element("b", String.class);
+		}
+
+		@Test
+		void returnsFirstElementType() {
+			assertEquals(String.class, subject.getType());
+		}
+
+		@Test
+		void returnsFirstElementIdentifier() {
+			assertEquals(i0, subject.getIdentifier());
+		}
+	}
+
+	@Nested
+	class SecondElementTest {
+		private DomainObjectProvider<MyType> subject;
+
+		@BeforeEach
+		void createSubject() {
+			subject = object.element("b", MyType.class);
+		}
+
+		@Test
+		void returnsSecondElementType() {
+			assertEquals(MyType.class, subject.getType());
+		}
+
+		@Test
+		void returnsSecondElementIdentifier() {
+			assertEquals(i1, subject.getIdentifier());
+		}
+	}
+
+	@Nested
+	class MultipleElementWithSameTypeTest {
+		@BeforeEach
+		void createConflictingElement() {
+			val registry = project.getExtensions().getByType(ModelRegistry.class);
+			registry.register(builder().withComponent(path("a.b")).withComponent(mock(DomainObjectIdentifier.class)).withComponent(ofInstance("vequ")).build());
+		}
+
+		@Test
+		void throwsExceptionIfMultipleElementHaveTheSameType() {
+			assertThrows(RuntimeException.class, () -> object.element("b", String.class));
+		}
+
+		@Test
+		void doesNotThrowExceptionIfOnlyOneElementHaveTheSpecifiedType() {
+			assertDoesNotThrow(() -> object.element("b", MyType.class));
+		}
+	}
+
+	interface MyType {}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelObjectTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelObjectTest.java
@@ -45,10 +45,11 @@ class DefaultModelObjectTest {
 	private final ConfigurableStrategy configurableStrategy = mock(ConfigurableStrategy.class);
 	private final ModelCastableStrategy castableStrategy = mock(ModelCastableStrategy.class);
 	private final ModelPropertyLookupStrategy propertyLookupStrategy = mock(ModelPropertyLookupStrategy.class);
+	private final ModelElementLookupStrategy elementLookupStrategy = mock(ModelElementLookupStrategy.class);
 	private final ModelMixInStrategy mixInStrategy = mock(ModelMixInStrategy.class);
 	@SuppressWarnings("unchecked") private final Supplier<MyType> valueSupplier = mock(Supplier.class);
 	@SuppressWarnings("unchecked") private final Supplier<ModelNode> entitySupplier = mock(Supplier.class);
-	private final DefaultModelObject<MyType> subject = new DefaultModelObject<>(namedStrategy, identifierSupplier, of(MyType.class), providerConvertibleStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, mixInStrategy, valueSupplier, entitySupplier);
+	private final DefaultModelObject<MyType> subject = new DefaultModelObject<>(namedStrategy, identifierSupplier, of(MyType.class), providerConvertibleStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, elementLookupStrategy, mixInStrategy, valueSupplier, entitySupplier);
 
 	@Test
 	@SuppressWarnings("UnstableApiUsage")
@@ -167,7 +168,7 @@ class DefaultModelObjectTest {
 		val result = mock(ModelElement.class);
 		when(propertyLookupStrategy.get(any())).thenReturn(result);
 
-		assertEquals(result, subject.property("dumo"));
+		assertSame(result, subject.property("dumo"));
 		verify(propertyLookupStrategy).get("dumo");
 	}
 
@@ -175,6 +176,24 @@ class DefaultModelObjectTest {
 	void forwardsConfigureUsingModelTypeAndActionToStrategy() {
 		assertSame(subject, subject.configure(of(MyType.class), doSomething()));
 		verify(configurableStrategy).configure(of(MyType.class), doSomething());
+	}
+
+	@Test
+	void forwardsElementUsingClassQueryToStrategy() {
+		val result = mock(DomainObjectProvider.class);
+		when(elementLookupStrategy.get(any(), any())).thenReturn(result);
+
+		assertSame(result, subject.element("guha", MyType.class));
+		verify(elementLookupStrategy).get("guha", of(MyType.class));
+	}
+
+	@Test
+	void forwardsElementUsingModelTypeQueryToStrategy() {
+		val result = mock(DomainObjectProvider.class);
+		when(elementLookupStrategy.get(any(), any())).thenReturn(result);
+
+		assertSame(result, subject.element("poji", of(MyType.class)));
+		verify(elementLookupStrategy).get("poji", of(MyType.class));
 	}
 	//endregion
 
@@ -208,19 +227,20 @@ class DefaultModelObjectTest {
 		val identifier = mock(DomainObjectIdentifier.class);
 		new EqualsTester()
 			.addEqualityGroup(
-				new DefaultModelObject<>(namedStrategy, ofInstance(identifier), of(MyType.class), providerConvertibleStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, mixInStrategy, valueSupplier, entitySupplier),
-				new DefaultModelObject<>(mock(NamedStrategy.class), ofInstance(identifier), of(MyType.class), providerConvertibleStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, mixInStrategy, valueSupplier, entitySupplier),
-				new DefaultModelObject<>(namedStrategy, ofInstance(identifier), of(MyType.class), mock(ConfigurableProviderConvertibleStrategy.class), configurableStrategy, castableStrategy, propertyLookupStrategy, mixInStrategy, valueSupplier, entitySupplier),
-				new DefaultModelObject<>(namedStrategy, ofInstance(identifier), of(MyType.class), providerConvertibleStrategy, mock(ConfigurableStrategy.class), castableStrategy, propertyLookupStrategy, mixInStrategy, valueSupplier, entitySupplier),
-				new DefaultModelObject<>(namedStrategy, ofInstance(identifier), of(MyType.class), providerConvertibleStrategy, configurableStrategy, mock(ModelCastableStrategy.class), propertyLookupStrategy, mixInStrategy, valueSupplier, entitySupplier),
-				new DefaultModelObject<>(namedStrategy, ofInstance(identifier), of(MyType.class), providerConvertibleStrategy, configurableStrategy, castableStrategy, mock(ModelPropertyLookupStrategy.class), mixInStrategy, valueSupplier, entitySupplier),
-				new DefaultModelObject<>(namedStrategy, ofInstance(identifier), of(MyType.class), providerConvertibleStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, mock(ModelMixInStrategy.class), valueSupplier, entitySupplier),
-				new DefaultModelObject<>(namedStrategy, ofInstance(identifier), of(MyType.class), providerConvertibleStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, mixInStrategy, mock(Supplier.class), entitySupplier),
-				new DefaultModelObject<>(namedStrategy, ofInstance(identifier), of(MyType.class), providerConvertibleStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, mixInStrategy, valueSupplier, mock(Supplier.class))
+				new DefaultModelObject<>(namedStrategy, ofInstance(identifier), of(MyType.class), providerConvertibleStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, elementLookupStrategy, mixInStrategy, valueSupplier, entitySupplier),
+				new DefaultModelObject<>(mock(NamedStrategy.class), ofInstance(identifier), of(MyType.class), providerConvertibleStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, elementLookupStrategy, mixInStrategy, valueSupplier, entitySupplier),
+				new DefaultModelObject<>(namedStrategy, ofInstance(identifier), of(MyType.class), mock(ConfigurableProviderConvertibleStrategy.class), configurableStrategy, castableStrategy, propertyLookupStrategy, elementLookupStrategy, mixInStrategy, valueSupplier, entitySupplier),
+				new DefaultModelObject<>(namedStrategy, ofInstance(identifier), of(MyType.class), providerConvertibleStrategy, mock(ConfigurableStrategy.class), castableStrategy, propertyLookupStrategy, elementLookupStrategy, mixInStrategy, valueSupplier, entitySupplier),
+				new DefaultModelObject<>(namedStrategy, ofInstance(identifier), of(MyType.class), providerConvertibleStrategy, configurableStrategy, mock(ModelCastableStrategy.class), propertyLookupStrategy, elementLookupStrategy, mixInStrategy, valueSupplier, entitySupplier),
+				new DefaultModelObject<>(namedStrategy, ofInstance(identifier), of(MyType.class), providerConvertibleStrategy, configurableStrategy, castableStrategy, mock(ModelPropertyLookupStrategy.class), elementLookupStrategy, mixInStrategy, valueSupplier, entitySupplier),
+				new DefaultModelObject<>(namedStrategy, ofInstance(identifier), of(MyType.class), providerConvertibleStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, mock(ModelElementLookupStrategy.class), mixInStrategy, valueSupplier, entitySupplier),
+				new DefaultModelObject<>(namedStrategy, ofInstance(identifier), of(MyType.class), providerConvertibleStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, elementLookupStrategy, mock(ModelMixInStrategy.class), valueSupplier, entitySupplier),
+				new DefaultModelObject<>(namedStrategy, ofInstance(identifier), of(MyType.class), providerConvertibleStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, elementLookupStrategy, mixInStrategy, mock(Supplier.class), entitySupplier),
+				new DefaultModelObject<>(namedStrategy, ofInstance(identifier), of(MyType.class), providerConvertibleStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, elementLookupStrategy, mixInStrategy, valueSupplier, mock(Supplier.class))
 			)
-			.addEqualityGroup(new DefaultModelObject<>(namedStrategy, ofInstance(identifier), of(Object.class), providerConvertibleStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, mixInStrategy, valueSupplier, entitySupplier))
-			.addEqualityGroup(new DefaultModelObject<>(namedStrategy, ofInstance(mock(DomainObjectIdentifier.class)), of(MyType.class), providerConvertibleStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, mixInStrategy, valueSupplier, entitySupplier))
-			.addEqualityGroup(new DefaultModelObject<>(namedStrategy, ofInstance(mock(DomainObjectIdentifier.class)), of(Object.class), providerConvertibleStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, mixInStrategy, valueSupplier, entitySupplier))
+			.addEqualityGroup(new DefaultModelObject<>(namedStrategy, ofInstance(identifier), of(Object.class), providerConvertibleStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, elementLookupStrategy, mixInStrategy, valueSupplier, entitySupplier))
+			.addEqualityGroup(new DefaultModelObject<>(namedStrategy, ofInstance(mock(DomainObjectIdentifier.class)), of(MyType.class), providerConvertibleStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, elementLookupStrategy, mixInStrategy, valueSupplier, entitySupplier))
+			.addEqualityGroup(new DefaultModelObject<>(namedStrategy, ofInstance(mock(DomainObjectIdentifier.class)), of(Object.class), providerConvertibleStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, elementLookupStrategy, mixInStrategy, valueSupplier, entitySupplier))
 			.testEquals();
 	}
 

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelObjectTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelObjectTest.java
@@ -179,6 +179,15 @@ class DefaultModelObjectTest {
 	}
 
 	@Test
+	void forwardsElementUsingNameOnlyQueryToStrategy() {
+		val result = mock(ModelElement.class);
+		when(elementLookupStrategy.get(any())).thenReturn(result);
+
+		assertSame(result, subject.element("hiji"));
+		verify(elementLookupStrategy).get("hiji");
+	}
+
+	@Test
 	void forwardsElementUsingClassQueryToStrategy() {
 		val result = mock(DomainObjectProvider.class);
 		when(elementLookupStrategy.get(any(), any())).thenReturn(result);

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/DefaultModelElementElementQueryIntegrationTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/DefaultModelElementElementQueryIntegrationTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.core;
+
+import dev.nokee.internal.testing.AbstractPluginTest;
+import dev.nokee.internal.testing.PluginRequirement;
+import dev.nokee.model.DomainObjectIdentifier;
+import dev.nokee.model.DomainObjectProvider;
+import dev.nokee.model.internal.registry.ModelRegistry;
+import lombok.val;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
+import static dev.nokee.model.internal.core.ModelPath.path;
+import static dev.nokee.model.internal.core.ModelProjections.createdUsing;
+import static dev.nokee.model.internal.core.ModelProjections.ofInstance;
+import static dev.nokee.model.internal.core.ModelRegistration.builder;
+import static dev.nokee.model.internal.type.ModelType.of;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+@PluginRequirement.Require(id = "dev.nokee.model-base")
+class DefaultModelElementElementQueryIntegrationTest extends AbstractPluginTest {
+	private final DomainObjectIdentifier i0 = mock(DomainObjectIdentifier.class);
+	private final DomainObjectIdentifier i1 = mock(DomainObjectIdentifier.class);
+	private ModelElement element;
+
+	@BeforeEach
+	void createObject() {
+		val registry = project.getExtensions().getByType(ModelRegistry.class);
+		element = registry.register(builder().withComponent(path("a")).withComponent(ofInstance(new Object())).build());
+		registry.register(builder().withComponent(path("a.b")).withComponent(i0).withComponent(createdUsing(of(MyType.class), () -> objectFactory().newInstance(MyType.class))).build());
+		registry.register(builder().withComponent(path("a.b")).withComponent(i1).withComponent(ofInstance("dalo")).build());
+	}
+
+
+	@Nested
+	class FirstElementTest {
+		private DomainObjectProvider<MyType> subject;
+
+		@BeforeEach
+		void createSubject() {
+			subject = element.element("b", MyType.class);
+		}
+
+		@Test
+		void returnsFirstElementType() {
+			assertEquals(MyType.class, subject.getType());
+		}
+
+		@Test
+		void returnsFirstElementIdentifier() {
+			assertEquals(i0, subject.getIdentifier());
+		}
+	}
+
+	@Nested
+	class SecondElementTest {
+		private DomainObjectProvider<String> subject;
+
+		@BeforeEach
+		void createSubject() {
+			subject = element.element("b", String.class);
+		}
+
+		@Test
+		void returnsSecondElementType() {
+			assertEquals(String.class, subject.getType());
+		}
+
+		@Test
+		void returnsSecondElementIdentifier() {
+			assertEquals(i1, subject.getIdentifier());
+		}
+	}
+
+	@Nested
+	class MultipleElementWithSameTypeTest {
+		@BeforeEach
+		void createConflictingElement() {
+			val registry = project.getExtensions().getByType(ModelRegistry.class);
+			registry.register(builder().withComponent(path("a.b")).withComponent(mock(DomainObjectIdentifier.class)).withComponent(ofInstance("cere")).build());
+		}
+
+		@Test
+		void throwsExceptionIfMultipleElementHaveTheSameType() {
+			assertThrows(RuntimeException.class, () -> element.element("b", String.class));
+		}
+
+		@Test
+		void doesNotThrowExceptionIfOnlyOneElementHaveTheSpecifiedType() {
+			assertDoesNotThrow(() -> element.element("b", MyType.class));
+		}
+	}
+
+	interface MyType {}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/DefaultModelElementElementQueryIntegrationTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/DefaultModelElementElementQueryIntegrationTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.mock;
 class DefaultModelElementElementQueryIntegrationTest extends AbstractPluginTest {
 	private final DomainObjectIdentifier i0 = mock(DomainObjectIdentifier.class);
 	private final DomainObjectIdentifier i1 = mock(DomainObjectIdentifier.class);
+	private final DomainObjectIdentifier i2 = mock(DomainObjectIdentifier.class);
 	private ModelElement element;
 
 	@BeforeEach
@@ -46,8 +47,8 @@ class DefaultModelElementElementQueryIntegrationTest extends AbstractPluginTest 
 		element = registry.register(builder().withComponent(path("a")).withComponent(ofInstance(new Object())).build());
 		registry.register(builder().withComponent(path("a.b")).withComponent(i0).withComponent(createdUsing(of(MyType.class), () -> objectFactory().newInstance(MyType.class))).build());
 		registry.register(builder().withComponent(path("a.b")).withComponent(i1).withComponent(ofInstance("dalo")).build());
+		registry.register(builder().withComponent(path("a.c")).withComponent(i2).withComponent(ofInstance(Boolean.TRUE)).build());
 	}
-
 
 	@Nested
 	class FirstElementTest {
@@ -90,6 +91,26 @@ class DefaultModelElementElementQueryIntegrationTest extends AbstractPluginTest 
 	}
 
 	@Nested
+	class ThirdElementTest {
+		private DomainObjectProvider<Boolean> subject;
+
+		@BeforeEach
+		void createSubject() {
+			subject = element.element("c").as(Boolean.class);
+		}
+
+		@Test
+		void returnsThirdElementType() {
+			assertEquals(Boolean.class, subject.getType());
+		}
+
+		@Test
+		void returnsThirdElementIdentifier() {
+			assertEquals(i2, subject.getIdentifier());
+		}
+	}
+
+	@Nested
 	class MultipleElementWithSameTypeTest {
 		@BeforeEach
 		void createConflictingElement() {
@@ -105,6 +126,16 @@ class DefaultModelElementElementQueryIntegrationTest extends AbstractPluginTest 
 		@Test
 		void doesNotThrowExceptionIfOnlyOneElementHaveTheSpecifiedType() {
 			assertDoesNotThrow(() -> element.element("b", MyType.class));
+		}
+
+		@Test
+		void throwsExceptionIfMultipleElementHaveTheSameName() {
+			assertThrows(RuntimeException.class, () -> element.element("b"));
+		}
+
+		@Test
+		void doesNotThrowExceptionIfOnlyOneElementHaveTheSpecifiedName() {
+			assertDoesNotThrow(() -> element.element("c"));
 		}
 	}
 

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/DefaultModelElementTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/DefaultModelElementTest.java
@@ -116,6 +116,14 @@ class DefaultModelElementTest {
 		assertEquals("Use ModelElement#as(ModelType) instead.", ex.getMessage());
 	}
 
+	@Test
+	void forwardsElementUsingNameOnlyQueryToStrategy() {
+		val result = mock(ModelElement.class);
+		when(elementLookupStrategy.get(any())).thenReturn(result);
+
+		assertSame(result, subject.element("wosa"));
+		verify(elementLookupStrategy).get("wosa");
+	}
 
 	@Test
 	void forwardsElementUsingClassQueryToStrategy() {

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/DefaultModelElementTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/DefaultModelElementTest.java
@@ -35,8 +35,9 @@ class DefaultModelElementTest {
 	private final ConfigurableStrategy configurableStrategy = Mockito.mock(ConfigurableStrategy.class);
 	private final ModelCastableStrategy castableStrategy = Mockito.mock(ModelCastableStrategy.class);
 	private final ModelPropertyLookupStrategy propertyLookupStrategy = Mockito.mock(ModelPropertyLookupStrategy.class);
+	private final ModelElementLookupStrategy elementLookupStrategy = Mockito.mock(ModelElementLookupStrategy.class);
 	private final ModelMixInStrategy mixInStrategy = Mockito.mock(ModelMixInStrategy.class);
-	private final DefaultModelElement subject = new DefaultModelElement(namedStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, mixInStrategy);
+	private final DefaultModelElement subject = new DefaultModelElement(namedStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, elementLookupStrategy, mixInStrategy);
 
 	@Test
 	@SuppressWarnings("UnstableApiUsage")
@@ -113,6 +114,25 @@ class DefaultModelElementTest {
 	void throwsExceptionWhenCastingUsingGroovyTypeCastOperator() {
 		val ex = assertThrows(UnsupportedOperationException.class, () -> subject.asType(MyType.class));
 		assertEquals("Use ModelElement#as(ModelType) instead.", ex.getMessage());
+	}
+
+
+	@Test
+	void forwardsElementUsingClassQueryToStrategy() {
+		val result = mock(DomainObjectProvider.class);
+		when(elementLookupStrategy.get(any(), any())).thenReturn(result);
+
+		assertSame(result, subject.element("qufu", MyType.class));
+		verify(elementLookupStrategy).get("qufu", of(MyType.class));
+	}
+
+	@Test
+	void forwardsElementUsingModelTypeQueryToStrategy() {
+		val result = mock(DomainObjectProvider.class);
+		when(elementLookupStrategy.get(any(), any())).thenReturn(result);
+
+		assertSame(result, subject.element("tise", of(MyType.class)));
+		verify(elementLookupStrategy).get("tise", of(MyType.class));
 	}
 
 	public interface MyType {}


### PR DESCRIPTION
The API serves as a convenience to access child elements as well as an alternative to the domain object projections. For example, given a hypothetical `LanguageSourceSet` projection:

```
interface LanguageSourceSet {
    ConfigurableSourceSet getSource()
    TaskProvider<SourceCompile> getCompileTask()
}
```

The underlying model may look more like the following:
```
LanguageSourceSetModel {
    ModelProperty<Set<File>> getSource();
    ModelObject<SourceCompile> getCompile();
}
```

The model getter reflects the name of the `ModelElement` vs the projection property name as shown in the projection. Note the `source` property has a mixin for `ConfigurableSourceSet` projection which means the following code is valid:
```
ModelObject<ConfigurableSourceSet> potato = getSource().as(ConfigurableSourceSet)
```

In the absence of a clearly defined model class, we can access each child element as follow:

```
ModelElement/ModelObject<LanguageSourceSet> sourceSet = <...>
sourceSet.element('source', ConfigurableSourceSet) // returns ModelObject<ConfigurableSourceSet>
sourceSet.element('compile') // returns ModelElement for the entity of the source compile
sourceSet.element('compile').as(SourceCompile) // returns ModelObject<SourceCompile>
sourceSet.element('compileTask') // throws exception as the element is named 'compile' not 'compileTask', the latter is the projection property name
sourceSet.property('source') // returns ModelProperty<?> which underneath refers to ModelProperty<Set<File>> as property has only one "settable" type but may have multiple projection (mixin)
sourceSet.property('source').asProperty(ConfigurableFileCollection) // returns ConfigurableFileCollection that represent the ModelProperty, it's not a projection but a _conversion_
sourceSet.property('compile') // throws exception as the 'compile' element is not a property but an element
sourceSet.element('compile', SourceCompile).asProvider() // returns NamedDomainObjectProvider<SourceCompile>
```

Later, we will probably want the ability to create child property and elements. Something along the line:
```
sourceSet.newElement('compileClasspath', ResolvableDependencyBucketSpec)
```

Note the `ModelElement`, `ModelObject`, `ModelProperty` may be perceived as god objects, however, we have to see them as aggregators that nicely fit between the ECS system and the Gradle DSL. They also try to rely as much as possible on the mixin capability while adding some improved state hooks (over the `Provider` API).