### PR TITLE
Introduce model property draft

### DIFF
--- a/subprojects/core-model/src/main/java/dev/nokee/model/DomainObjectProvider.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/DomainObjectProvider.java
@@ -20,32 +20,30 @@ import dev.nokee.model.internal.type.ModelType;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
-import org.gradle.api.NamedDomainObjectProvider;
-import org.gradle.api.Transformer;
-import org.gradle.api.provider.Provider;
 import org.gradle.util.ConfigureUtil;
 
 import static java.util.Objects.requireNonNull;
 
 public interface DomainObjectProvider<T> extends KnownDomainObject<T>, ModelElement {
-	DomainObjectIdentifier getIdentifier();
-
-	Class<T> getType();
-
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
 	DomainObjectProvider<T> configure(Action<? super T> action);
 
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
 	default DomainObjectProvider<T> configure(@DelegatesTo(type = "T", strategy = Closure.DELEGATE_FIRST) @SuppressWarnings("rawtypes") Closure closure) {
 		return configure(ConfigureUtil.configureUsing(requireNonNull(closure)));
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	<S> DomainObjectProvider<T> configure(ModelType<S> type, Action<? super S> action);
 
 	T get();
-
-	<S> Provider<S> map(Transformer<? extends S, ? super T> transformer);
-
-	<S> Provider<S> flatMap(Transformer<? extends Provider<? extends S>, ? super T> transformer);
-
-	NamedDomainObjectProvider<T> asProvider();
 }

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/ModelBackedGradlePropertyConvertibleStrategy.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/ModelBackedGradlePropertyConvertibleStrategy.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal;
+
+import dev.nokee.model.internal.core.GradlePropertyComponent;
+import dev.nokee.model.internal.core.ModelNode;
+import dev.nokee.model.internal.type.GradlePropertyTypes;
+import dev.nokee.model.internal.type.ModelType;
+import lombok.val;
+import org.gradle.api.provider.HasConfigurableValue;
+
+public final class ModelBackedGradlePropertyConvertibleStrategy implements PropertyConvertibleStrategy {
+	private final ModelNode entity;
+
+	public ModelBackedGradlePropertyConvertibleStrategy(ModelNode entity) {
+		this.entity = entity;
+	}
+
+	@Override
+	@SuppressWarnings({"unchecked", "UnstableApiUsage"})
+	public <P extends HasConfigurableValue> P asProperty(ModelType<P> propertyType) {
+		val result = entity.getComponent(GradlePropertyComponent.class).get();
+		if (GradlePropertyTypes.of(result).isSubtypeOf(propertyType)) {
+			return (P) result;
+		} else {
+			throw new RuntimeException();
+		}
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/PropertyConvertibleStrategy.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/PropertyConvertibleStrategy.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal;
+
+import dev.nokee.model.internal.type.ModelType;
+import org.gradle.api.provider.HasConfigurableValue;
+
+@SuppressWarnings("UnstableApiUsage")
+public interface PropertyConvertibleStrategy {
+	<P extends HasConfigurableValue> P asProperty(ModelType<P> propertyType);
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/DefaultModelProperty.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/DefaultModelProperty.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.core;
+
+import dev.nokee.model.DomainObjectIdentifier;
+import dev.nokee.model.DomainObjectProvider;
+import dev.nokee.model.internal.ConfigurableProviderConvertibleStrategy;
+import dev.nokee.model.internal.ConfigurableStrategy;
+import dev.nokee.model.internal.NamedStrategy;
+import dev.nokee.model.internal.PropertyConvertibleStrategy;
+import dev.nokee.model.internal.type.ModelType;
+import dev.nokee.utils.ClosureWrappedConfigureAction;
+import groovy.lang.Closure;
+import lombok.EqualsAndHashCode;
+import org.gradle.api.Action;
+import org.gradle.api.NamedDomainObjectProvider;
+import org.gradle.api.Transformer;
+import org.gradle.api.provider.HasConfigurableValue;
+import org.gradle.api.provider.Provider;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+// TODO: Remove ModelNodeAware implementation
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public final class DefaultModelProperty<T> implements ModelProperty<T>, ModelNodeAware {
+	private final NamedStrategy namedStrategy;
+	private final Supplier<DomainObjectIdentifier> identifierSupplier;
+	private final ModelType<T> type;
+	private final ConfigurableProviderConvertibleStrategy providerConvertibleStrategy;
+	private final PropertyConvertibleStrategy propertyConvertibleStrategy;
+	private final ConfigurableStrategy configurableStrategy;
+	private final ModelCastableStrategy castableStrategy;
+	private final ModelPropertyLookupStrategy propertyLookupStrategy;
+	private final ModelElementLookupStrategy elementLookupStrategy;
+	private final ModelMixInStrategy mixInStrategy;
+	private final Supplier<? extends T> valueSupplier;
+	private final Supplier<ModelNode> entitySupplier;
+
+	public DefaultModelProperty(NamedStrategy namedStrategy, Supplier<DomainObjectIdentifier> identifierSupplier, ModelType<T> type, ConfigurableProviderConvertibleStrategy providerConvertibleStrategy, PropertyConvertibleStrategy propertyConvertibleStrategy, ConfigurableStrategy configurableStrategy, ModelCastableStrategy castableStrategy, ModelPropertyLookupStrategy propertyLookupStrategy, ModelElementLookupStrategy elementLookupStrategy, ModelMixInStrategy mixInStrategy, Supplier<? extends T> valueSupplier, Supplier<ModelNode> entitySupplier) {
+		this.namedStrategy = Objects.requireNonNull(namedStrategy);
+		this.identifierSupplier = Objects.requireNonNull(identifierSupplier);
+		this.type = Objects.requireNonNull(type);
+		this.providerConvertibleStrategy = Objects.requireNonNull(providerConvertibleStrategy);
+		this.propertyConvertibleStrategy = Objects.requireNonNull(propertyConvertibleStrategy);
+		this.configurableStrategy = Objects.requireNonNull(configurableStrategy);
+		this.castableStrategy = Objects.requireNonNull(castableStrategy);
+		this.propertyLookupStrategy = Objects.requireNonNull(propertyLookupStrategy);
+		this.elementLookupStrategy = Objects.requireNonNull(elementLookupStrategy);
+		this.mixInStrategy = Objects.requireNonNull(mixInStrategy);
+		this.valueSupplier = Objects.requireNonNull(valueSupplier);
+		this.entitySupplier = Objects.requireNonNull(entitySupplier);
+	}
+
+	@Override
+	@EqualsAndHashCode.Include(replaces = "identifierSupplier")
+	public DomainObjectIdentifier getIdentifier() {
+		return identifierSupplier.get();
+	}
+
+	@Override
+	@EqualsAndHashCode.Include(replaces = "type")
+	public Class<T> getType() {
+		return type.getConcreteType();
+	}
+
+	@Override
+	public ModelProperty<T> configure(Action<? super T> action) {
+		Objects.requireNonNull(action);
+		configurableStrategy.configure(type, action);
+		return this;
+	}
+
+	@Override
+	public ModelProperty<T> configure(@SuppressWarnings("rawtypes") Closure closure) {
+		Objects.requireNonNull(closure);
+		configurableStrategy.configure(type, new ClosureWrappedConfigureAction<>(closure));
+		return this;
+	}
+
+	@Override
+	public T get() {
+		return valueSupplier.get();
+	}
+
+	@Override
+	public <S> Provider<S> map(Transformer<? extends S, ? super T> transformer) {
+		Objects.requireNonNull(transformer);
+		return asProvider().map(transformer);
+	}
+
+	@Override
+	public <S> Provider<S> flatMap(Transformer<? extends Provider<? extends S>, ? super T> transformer) {
+		Objects.requireNonNull(transformer);
+		return asProvider().flatMap(transformer);
+	}
+
+	@Override
+	public NamedDomainObjectProvider<T> asProvider() {
+		return providerConvertibleStrategy.asProvider(type);
+	}
+
+	@Override
+	public <S> DomainObjectProvider<S> as(ModelType<S> type) {
+		Objects.requireNonNull(type);
+		return castableStrategy.castTo(type);
+	}
+
+	public <S> S asType(Class<S> ignored) {
+		throw new UnsupportedOperationException("Use ModelProperty#as(ModelType) instead.");
+	}
+
+	@Override
+	public boolean instanceOf(ModelType<?> type) {
+		Objects.requireNonNull(type);
+		return castableStrategy.instanceOf(type);
+	}
+
+	@Override
+	public ModelElement property(String name) {
+		Objects.requireNonNull(name);
+		return propertyLookupStrategy.get(name);
+	}
+
+	@Override
+	public ModelElement element(String name) {
+		Objects.requireNonNull(name);
+		return elementLookupStrategy.get(name);
+	}
+
+	@Override
+	public <S> DomainObjectProvider<S> element(String name, Class<S> type) {
+		Objects.requireNonNull(name);
+		Objects.requireNonNull(type);
+		return elementLookupStrategy.get(name, ModelType.of(type));
+	}
+
+	@Override
+	public <S> DomainObjectProvider<S> element(String name, ModelType<S> type) {
+		Objects.requireNonNull(name);
+		Objects.requireNonNull(type);
+		return elementLookupStrategy.get(name, type);
+	}
+
+	@Override
+	public <S> ModelProperty<T> configure(ModelType<S> type, Action<? super S> action) {
+		Objects.requireNonNull(type);
+		Objects.requireNonNull(action);
+		configurableStrategy.configure(type, action);
+		return this;
+	}
+
+	@Override
+	public <S> DomainObjectProvider<S> mixin(ModelType<S> type) {
+		Objects.requireNonNull(type);
+		return mixInStrategy.mixin(type);
+	}
+
+	@Override
+	public <P extends HasConfigurableValue> P asProperty(ModelType<P> propertyType) {
+		Objects.requireNonNull(propertyType);
+		return propertyConvertibleStrategy.asProperty(propertyType);
+	}
+
+	@Override
+	public String getName() {
+		return namedStrategy.getAsString();
+	}
+
+	@Override
+	public ModelNode getNode() {
+		return entitySupplier.get();
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/GradlePropertyComponent.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/GradlePropertyComponent.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.core;
+
+import org.gradle.api.provider.HasConfigurableValue;
+
+@SuppressWarnings("UnstableApiUsage")
+public final class GradlePropertyComponent {
+	private final HasConfigurableValue property;
+
+	public GradlePropertyComponent(HasConfigurableValue property) {
+		this.property = property;
+	}
+
+	public HasConfigurableValue get() {
+		return property;
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelNode.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelNode.java
@@ -129,7 +129,7 @@ public final class ModelNode {
 
 	@Override
 	public String toString() {
-		return getComponent(ModelPath.class).toString();
+		return findComponent(ModelPath.class).map(Objects::toString).orElseGet(() -> "entity '" + id + "'");
 	}
 
 	/**

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelProperty.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelProperty.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.core;
+
+import dev.nokee.model.DomainObjectProvider;
+import dev.nokee.model.internal.type.ModelType;
+import groovy.lang.Closure;
+import org.gradle.api.Action;
+import org.gradle.api.provider.HasConfigurableValue;
+
+public interface ModelProperty<T> extends DomainObjectProvider<T> {
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	ModelProperty<T> configure(Action<? super T> action);
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	ModelProperty<T> configure(@SuppressWarnings("rawtypes") Closure closure);
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	<S> ModelProperty<T> configure(ModelType<S> type, Action<? super S> action);
+
+	/**
+	 * Returns a Gradle property representation of this {@literal ModelProperty}.
+	 *
+	 * @param propertyType  the Gradle property type, i.e. SetProperty, must not be null
+	 * @param <P>  the Gradle property type
+	 * @return a Gradle property representing this {@literal ModelProperty}, never null
+	 */
+	<P extends HasConfigurableValue> P asProperty(ModelType<P> propertyType);
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelPropertyTag.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelPropertyTag.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.core;
+
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode
+public final class ModelPropertyTag {
+	private static final ModelPropertyTag INSTANCE = new ModelPropertyTag();
+
+	public static ModelPropertyTag instance() {
+		return INSTANCE;
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelPropertyTypeComponent.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelPropertyTypeComponent.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.core;
+
+import dev.nokee.model.internal.type.ModelType;
+
+public final class ModelPropertyTypeComponent {
+	private final ModelType<?> type;
+
+	public ModelPropertyTypeComponent(ModelType<?> type) {
+		this.type = type;
+	}
+
+	public ModelType<?> get() {
+		return type;
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/type/GradlePropertyTypes.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/type/GradlePropertyTypes.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.type;
+
+import com.google.common.reflect.TypeParameter;
+import com.google.common.reflect.TypeToken;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.internal.provider.AbstractCollectionProperty;
+import org.gradle.api.internal.provider.DefaultMapProperty;
+import org.gradle.api.internal.provider.Providers;
+import org.gradle.api.provider.*;
+
+public final class GradlePropertyTypes {
+	@SuppressWarnings({"unchecked", "UnstableApiUsage"})
+	public static <T> ModelType<Property<T>> property(ModelType<T> type) {
+		return (ModelType<Property<T>>) ModelType.of(new TypeToken<Property<T>>() {}
+			.where(new TypeParameter<T>() {}, (TypeToken<T>) TypeToken.of(type.getType())).getType());
+	}
+
+	@SuppressWarnings({"unchecked", "UnstableApiUsage"})
+	public static <T> ModelType<SetProperty<T>> setProperty(ModelType<T> type) {
+		return (ModelType<SetProperty<T>>) ModelType.of(new TypeToken<SetProperty<T>>() {}
+			.where(new TypeParameter<T>() {}, (TypeToken<T>) TypeToken.of(type.getType())).getType());
+	}
+
+	@SuppressWarnings({"unchecked", "UnstableApiUsage"})
+	public static <T> ModelType<ListProperty<T>> listProperty(ModelType<T> type) {
+		return (ModelType<ListProperty<T>>) ModelType.of(new TypeToken<ListProperty<T>>() {}
+			.where(new TypeParameter<T>() {}, (TypeToken<T>) TypeToken.of(type.getType())).getType());
+	}
+
+	@SuppressWarnings({"unchecked", "UnstableApiUsage"})
+	public static <K, V> ModelType<MapProperty<K, V>> mapProperty(ModelType<K> keyType, ModelType<V> valueType) {
+		return (ModelType<MapProperty<K, V>>) ModelType.of(new TypeToken<MapProperty<K, V>>() {}
+			.where(new TypeParameter<K>() {}, (TypeToken<K>) TypeToken.of(keyType.getType()))
+			.where(new TypeParameter<V>() {}, (TypeToken<V>) TypeToken.of(valueType.getType()))
+			.getType());
+	}
+
+	@SuppressWarnings({"unchecked", "UnstableApiUsage", "rawtypes"})
+	public static <T extends HasConfigurableValue> ModelType<T> of(T instance) {
+		if (instance instanceof Property) {
+			return property(ModelType.of(Providers.internal((Property) instance).getType()));
+		} else if (instance instanceof SetProperty) {
+			return setProperty(ModelType.of(((AbstractCollectionProperty) instance).getElementType()));
+		} else if (instance instanceof ListProperty) {
+			return listProperty(ModelType.of(((AbstractCollectionProperty) instance).getElementType()));
+		} else if (instance instanceof MapProperty) {
+			return mapProperty(ModelType.of(((DefaultMapProperty) instance).getKeyType()), ModelType.of(((DefaultMapProperty) instance).getValueType()));
+		} else if (instance instanceof ConfigurableFileCollection) {
+			return (ModelType<T>) ModelType.of(ConfigurableFileCollection.class);
+		} else {
+			throw new UnsupportedOperationException();
+		}
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/type/ModelType.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/type/ModelType.java
@@ -128,7 +128,7 @@ public final class ModelType<T> {
 	 */
 	@SuppressWarnings("unchecked")
 	public static <T> ModelType<T> typeOf(T instance) {
-		return new ModelType<>(TypeToken.of((Class<T>) instance.getClass()));
+		return new ModelType<>(TypeToken.of((Class<T>) ModelTypeUtils.toUndecoratedType(instance.getClass())));
 	}
 
 	/**

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/type/ModelTypes.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/type/ModelTypes.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.type;
+
+import com.google.common.reflect.TypeParameter;
+import com.google.common.reflect.TypeToken;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public final class ModelTypes {
+	/**
+	 * Returns {@literal ModelType} for a {@literal Set} of the specified element type.
+	 *
+	 * @param elementType  the element type of the set, must not be null
+	 * @param <E>  the element type
+	 * @return a {@link ModelType} for a {@link Set} of the specified element type, never null
+	 */
+	@SuppressWarnings({"unchecked", "UnstableApiUsage"})
+	public static <E> ModelType<Set<E>> set(ModelType<E> elementType) {
+		return (ModelType<Set<E>>) ModelType.of(new TypeToken<Set<E>>() {}
+			.where(new TypeParameter<E>() {}, (TypeToken<E>) TypeToken.of(elementType.getType()))
+			.getType());
+	}
+
+	/**
+	 * Returns {@literal ModelType} for a {@literal List} of the specified element type.
+	 *
+	 * @param elementType  the element type of the list, must not be null
+	 * @param <E>  the element type
+	 * @return a {@link ModelType} for a {@link List} of the specified element type, never null
+	 */
+	@SuppressWarnings({"unchecked", "UnstableApiUsage"})
+	public static <E> ModelType<List<E>> list(ModelType<E> elementType) {
+		return (ModelType<List<E>>) ModelType.of(new TypeToken<List<E>>() {}
+			.where(new TypeParameter<E>() {}, (TypeToken<E>) TypeToken.of(elementType.getType()))
+			.getType());
+	}
+
+	/**
+	 * Returns {@literal ModelType} for a {@literal Map} of the specified key and value type.
+	 *
+	 * @param keyType  the key type of the map, must not be null
+	 * @param valueType  the value type of the map, must not be null
+	 * @param <K>  the key type
+	 * @param <V>  the value type
+	 * @return a {@link ModelType} for a {@link Map} of the specified key and value type, never null
+	 */
+	@SuppressWarnings({"unchecked", "UnstableApiUsage"})
+	public static <K, V> ModelType<Map<K, V>> map(ModelType<K> keyType, ModelType<V> valueType) {
+		return (ModelType<Map<K, V>>) ModelType.of(new TypeToken<Map<K, V>>() {}
+			.where(new TypeParameter<K>() {}, (TypeToken<K>) TypeToken.of(keyType.getType()))
+			.where(new TypeParameter<V>() {}, (TypeToken<V>) TypeToken.of(valueType.getType()))
+			.getType());
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyGradleConfigurableFileCollectionIntegrationTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyGradleConfigurableFileCollectionIntegrationTest.java
@@ -92,4 +92,15 @@ class DefaultModelPropertyGradleConfigurableFileCollectionIntegrationTest {
 		}
 		assertEquals(expectedState, ModelStates.getState(entity));
 	}
+
+	@Test
+	void hasModelPropertyTypeAsUntypedModelProperty() {
+		assertEquals(set(of(File.class)).getConcreteType(), factory.createProperty(node).getType());
+	}
+
+	@Test
+	void hasModelPropertyTypeAsModelElement() {
+		assertTrue(factory.createElement(node) instanceof ModelProperty);
+		assertEquals(set(of(File.class)).getConcreteType(), ((ModelProperty<?>) factory.createElement(node)).getType());
+	}
 }

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyGradleConfigurableFileCollectionIntegrationTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyGradleConfigurableFileCollectionIntegrationTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal;
+
+import com.google.common.collect.ImmutableSet;
+import dev.nokee.model.internal.core.*;
+import dev.nokee.model.internal.registry.ModelConfigurer;
+import dev.nokee.model.internal.state.ModelStates;
+import lombok.val;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.util.Set;
+
+import static dev.nokee.internal.testing.FileSystemMatchers.aFileNamed;
+import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
+import static dev.nokee.model.internal.core.ModelTestUtils.node;
+import static dev.nokee.model.internal.type.ModelType.of;
+import static dev.nokee.model.internal.type.ModelTypes.set;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.isA;
+import static org.junit.jupiter.api.Assertions.*;
+
+class DefaultModelPropertyGradleConfigurableFileCollectionIntegrationTest {
+	private final ModelConfigurer modelConfigurer = Mockito.mock(ModelConfigurer.class);
+	private final ModelNode node = newEntity(modelConfigurer);
+	private final ModelElementFactory factory = new ModelElementFactory(objectFactory()::newInstance);
+	private final ModelProperty<Set<File>> subject = factory.createProperty(node, set(of(File.class)));
+
+	private static ModelNode newEntity(ModelConfigurer modelConfigurer) {
+		val property = objectFactory().fileCollection();
+		val entity = node("jeja", builder -> builder.withConfigurer(modelConfigurer));
+		entity.addComponent(ModelPropertyTag.instance());
+		entity.addComponent(new GradlePropertyComponent(property));
+		entity.addComponent(ModelIdentifier.of("jeja", Object.class));
+		return entity;
+	}
+
+	@Test
+	void canConvertToListPropertyUsingConfigurableFileCollectionType() {
+		assertThat(assertDoesNotThrow(() -> subject.asProperty(of(ConfigurableFileCollection.class))), isA(ConfigurableFileCollection.class));
+	}
+
+	@ParameterizedTest(name = "throwsExceptionOnInvalidFileCollectionConversion [{argumentsWithNames}]")
+	@ValueSource(classes = {ListProperty.class, Property.class, SetProperty.class, MapProperty.class, RegularFileProperty.class, DirectoryProperty.class})
+	void throwsExceptionOnInvalidFileCollectionConversion(Class<? extends HasConfigurableValue> invalidPropertyType) {
+		assertThrows(RuntimeException.class, () -> subject.asProperty(of(invalidPropertyType)));
+	}
+
+	@ParameterizedTest(name = "doesNotRealizeModelPropertyOnGradleFileCollectionConversion [{argumentsWithNames}]")
+	@ValueSource(classes = {SetProperty.class, ListProperty.class, MapProperty.class, ConfigurableFileCollection.class, RegularFileProperty.class, DirectoryProperty.class, Property.class})
+	void doesNotRealizeModelPropertyOnGradleFileCollectionConversion(Class<? extends HasConfigurableValue> propertyType) {
+		assertDoesNotChangeEntityState(node, () -> subject.asProperty(of(propertyType)));
+	}
+
+	@Test
+	void canSetValueViaGradleFileCollection() {
+		val expectedValue = ImmutableSet.of("f0.txt", "f1.txt");
+		subject.asProperty(of(ConfigurableFileCollection.class)).setFrom(expectedValue);
+		assertThat(subject.get(), contains(aFileNamed("f0.txt"), aFileNamed("f1.txt")));
+	}
+
+	private static void assertDoesNotChangeEntityState(ModelNode entity, Executable executable) {
+		val expectedState = ModelStates.getState(entity);
+		try {
+			executable.execute();
+		} catch (Throwable ex) {
+			// ignore exception
+		}
+		assertEquals(expectedState, ModelStates.getState(entity));
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyGradleConfigurableFileCollectionIntegrationTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyGradleConfigurableFileCollectionIntegrationTest.java
@@ -54,6 +54,7 @@ class DefaultModelPropertyGradleConfigurableFileCollectionIntegrationTest {
 		val entity = node("jeja", builder -> builder.withConfigurer(modelConfigurer));
 		entity.addComponent(ModelPropertyTag.instance());
 		entity.addComponent(new GradlePropertyComponent(property));
+		entity.addComponent(new ModelPropertyTypeComponent(set(of(File.class))));
 		entity.addComponent(ModelIdentifier.of("jeja", Object.class));
 		return entity;
 	}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyGradleListPropertyIntegrationTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyGradleListPropertyIntegrationTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal;
+
+import com.google.common.collect.ImmutableList;
+import dev.nokee.model.internal.core.*;
+import dev.nokee.model.internal.registry.ModelConfigurer;
+import dev.nokee.model.internal.state.ModelStates;
+import lombok.val;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
+import static dev.nokee.model.internal.core.ModelTestUtils.node;
+import static dev.nokee.model.internal.type.GradlePropertyTypes.listProperty;
+import static dev.nokee.model.internal.type.ModelType.of;
+import static dev.nokee.model.internal.type.ModelTypes.list;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isA;
+import static org.junit.jupiter.api.Assertions.*;
+
+class DefaultModelPropertyGradleListPropertyIntegrationTest {
+	private final ModelConfigurer modelConfigurer = Mockito.mock(ModelConfigurer.class);
+	private final ModelNode node = newEntity(modelConfigurer);
+	private final ModelElementFactory factory = new ModelElementFactory(objectFactory()::newInstance);
+	private final ModelProperty<List<MyType>> subject = factory.createProperty(node, list(of(MyType.class)));
+
+	private static ModelNode newEntity(ModelConfigurer modelConfigurer) {
+		val property = objectFactory().listProperty(MyType.class);
+		val entity = node("jeja", builder -> builder.withConfigurer(modelConfigurer));
+		entity.addComponent(ModelPropertyTag.instance());
+		entity.addComponent(new GradlePropertyComponent(property));
+		entity.addComponent(ModelIdentifier.of("jeja", Object.class));
+		return entity;
+	}
+
+	@Test
+	void canConvertToListPropertyUsingRawListPropertyType() {
+		assertThat(assertDoesNotThrow(() -> subject.asProperty(of(ListProperty.class))), isA(ListProperty.class));
+	}
+
+	@Test
+	void canConvertToListPropertyUsingModelListPropertyType() {
+		assertThat(assertDoesNotThrow(() -> subject.asProperty(listProperty(of(MyType.class)))), isA(ListProperty.class));
+	}
+
+	@Test
+	void throwsExceptionListPropertyTypeOfObjectConversion() {
+		assertThrows(RuntimeException.class, () -> subject.asProperty(listProperty(of(Object.class))));
+	}
+
+	@ParameterizedTest(name = "throwsExceptionOnInvalidListPropertyConversion [{argumentsWithNames}]")
+	@ValueSource(classes = {Property.class, SetProperty.class, MapProperty.class, ConfigurableFileCollection.class, RegularFileProperty.class, DirectoryProperty.class})
+	void throwsExceptionOnInvalidListPropertyConversion(Class<? extends HasConfigurableValue> invalidPropertyType) {
+		assertThrows(RuntimeException.class, () -> subject.asProperty(of(invalidPropertyType)));
+	}
+
+	@ParameterizedTest(name = "doesNotRealizeModelPropertyOnGradleListPropertyConversion [{argumentsWithNames}]")
+	@ValueSource(classes = {SetProperty.class, ListProperty.class, MapProperty.class, ConfigurableFileCollection.class, RegularFileProperty.class, DirectoryProperty.class, Property.class})
+	void doesNotRealizeModelPropertyOnGradleListPropertyConversion(Class<? extends HasConfigurableValue> propertyType) {
+		assertDoesNotChangeEntityState(node, () -> subject.asProperty(of(propertyType)));
+	}
+
+	@Test
+	void canSetValueViaGradleListProperty() {
+		val expectedValue = ImmutableList.of(Mockito.mock(MyType.class));
+		subject.asProperty(listProperty(of(MyType.class))).set(expectedValue);
+		assertEquals(expectedValue, subject.get());
+	}
+
+	private static void assertDoesNotChangeEntityState(ModelNode entity, Executable executable) {
+		val expectedState = ModelStates.getState(entity);
+		try {
+			executable.execute();
+		} catch (Throwable ex) {
+			// ignore exception
+		}
+		assertEquals(expectedState, ModelStates.getState(entity));
+	}
+
+	interface MyType {}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyGradleListPropertyIntegrationTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyGradleListPropertyIntegrationTest.java
@@ -52,6 +52,7 @@ class DefaultModelPropertyGradleListPropertyIntegrationTest {
 		val entity = node("jeja", builder -> builder.withConfigurer(modelConfigurer));
 		entity.addComponent(ModelPropertyTag.instance());
 		entity.addComponent(new GradlePropertyComponent(property));
+		entity.addComponent(new ModelPropertyTypeComponent(list(of(MyType.class))));
 		entity.addComponent(ModelIdentifier.of("jeja", Object.class));
 		return entity;
 	}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyGradleListPropertyIntegrationTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyGradleListPropertyIntegrationTest.java
@@ -101,5 +101,16 @@ class DefaultModelPropertyGradleListPropertyIntegrationTest {
 		assertEquals(expectedState, ModelStates.getState(entity));
 	}
 
+	@Test
+	void hasModelPropertyTypeAsUntypedModelProperty() {
+		assertEquals(list(of(MyType.class)).getConcreteType(), factory.createProperty(node).getType());
+	}
+
+	@Test
+	void hasModelPropertyTypeAsModelElement() {
+		assertTrue(factory.createElement(node) instanceof ModelProperty);
+		assertEquals(list(of(MyType.class)).getConcreteType(), ((ModelProperty<?>) factory.createElement(node)).getType());
+	}
+
 	interface MyType {}
 }

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyGradleMapPropertyIntegrationTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyGradleMapPropertyIntegrationTest.java
@@ -101,5 +101,17 @@ class DefaultModelPropertyGradleMapPropertyIntegrationTest {
 		assertEquals(expectedState, ModelStates.getState(entity));
 	}
 
+	@Test
+	void hasModelPropertyTypeAsUntypedModelProperty() {
+		assertEquals(map(of(String.class), of(MyType.class)).getConcreteType(), factory.createProperty(node).getType());
+	}
+
+	@Test
+	void hasModelPropertyTypeAsModelElement() {
+		assertTrue(factory.createElement(node) instanceof ModelProperty);
+		assertEquals(map(of(String.class), of(MyType.class)).getConcreteType(), ((ModelProperty<?>) factory.createElement(node)).getType());
+	}
+
+
 	interface MyType {}
 }

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyGradleMapPropertyIntegrationTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyGradleMapPropertyIntegrationTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal;
+
+import com.google.common.collect.ImmutableMap;
+import dev.nokee.model.internal.core.*;
+import dev.nokee.model.internal.registry.ModelConfigurer;
+import dev.nokee.model.internal.state.ModelStates;
+import lombok.val;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
+
+import java.util.Map;
+
+import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
+import static dev.nokee.model.internal.core.ModelTestUtils.node;
+import static dev.nokee.model.internal.type.GradlePropertyTypes.mapProperty;
+import static dev.nokee.model.internal.type.ModelType.of;
+import static dev.nokee.model.internal.type.ModelTypes.map;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isA;
+import static org.junit.jupiter.api.Assertions.*;
+
+class DefaultModelPropertyGradleMapPropertyIntegrationTest {
+	private final ModelConfigurer modelConfigurer = Mockito.mock(ModelConfigurer.class);
+	private final ModelNode node = newEntity(modelConfigurer);
+	private final ModelElementFactory factory = new ModelElementFactory(objectFactory()::newInstance);
+	private final ModelProperty<Map<String, MyType>> subject = factory.createProperty(node, map(of(String.class), of(MyType.class)));
+
+	private static ModelNode newEntity(ModelConfigurer modelConfigurer) {
+		val property = objectFactory().mapProperty(String.class, MyType.class);
+		val entity = node("jeja", builder -> builder.withConfigurer(modelConfigurer));
+		entity.addComponent(ModelPropertyTag.instance());
+		entity.addComponent(new GradlePropertyComponent(property));
+		entity.addComponent(ModelIdentifier.of("jeja", Object.class));
+		return entity;
+	}
+
+	@Test
+	void canConvertToMapPropertyUsingRawMapPropertyType() {
+		assertThat(assertDoesNotThrow(() -> subject.asProperty(of(MapProperty.class))), isA(MapProperty.class));
+	}
+
+	@Test
+	void canConvertToMapPropertyUsingModelMapPropertyType() {
+		assertThat(assertDoesNotThrow(() -> subject.asProperty(mapProperty(of(String.class), of(MyType.class)))), isA(MapProperty.class));
+	}
+
+	@Test
+	void throwsExceptionMapPropertyTypeOfObjectConversion() {
+		assertThrows(RuntimeException.class, () -> subject.asProperty(mapProperty(of(Object.class), of(Object.class))));
+	}
+
+	@ParameterizedTest(name = "throwsExceptionOnInvalidMapPropertyConversion [{argumentsWithNames}]")
+	@ValueSource(classes = {Property.class, SetProperty.class, ListProperty.class, ConfigurableFileCollection.class, RegularFileProperty.class, DirectoryProperty.class})
+	void throwsExceptionOnInvalidMapPropertyConversion(Class<? extends HasConfigurableValue> invalidPropertyType) {
+		assertThrows(RuntimeException.class, () -> subject.asProperty(of(invalidPropertyType)));
+	}
+
+	@ParameterizedTest(name = "doesNotRealizeModelPropertyOnGradleMapPropertyConversion [{argumentsWithNames}]")
+	@ValueSource(classes = {SetProperty.class, ListProperty.class, MapProperty.class, ConfigurableFileCollection.class, RegularFileProperty.class, DirectoryProperty.class, Property.class})
+	void doesNotRealizeModelPropertyOnGradleMapPropertyConversion(Class<? extends HasConfigurableValue> propertyType) {
+		assertDoesNotChangeEntityState(node, () -> subject.asProperty(of(propertyType)));
+	}
+
+	@Test
+	void canSetValueViaGradleMapProperty() {
+		val expectedValue = ImmutableMap.of("k0", Mockito.mock(MyType.class));
+		subject.asProperty(mapProperty(of(String.class), of(MyType.class))).set(expectedValue);
+		assertEquals(expectedValue, subject.get());
+	}
+
+	private static void assertDoesNotChangeEntityState(ModelNode entity, Executable executable) {
+		val expectedState = ModelStates.getState(entity);
+		try {
+			executable.execute();
+		} catch (Throwable ex) {
+			// ignore exception
+		}
+		assertEquals(expectedState, ModelStates.getState(entity));
+	}
+
+	interface MyType {}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyGradleMapPropertyIntegrationTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyGradleMapPropertyIntegrationTest.java
@@ -52,6 +52,7 @@ class DefaultModelPropertyGradleMapPropertyIntegrationTest {
 		val entity = node("jeja", builder -> builder.withConfigurer(modelConfigurer));
 		entity.addComponent(ModelPropertyTag.instance());
 		entity.addComponent(new GradlePropertyComponent(property));
+		entity.addComponent(new ModelPropertyTypeComponent(map(of(String.class), of(MyType.class))));
 		entity.addComponent(ModelIdentifier.of("jeja", Object.class));
 		return entity;
 	}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyGradlePropertyIntegrationTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyGradlePropertyIntegrationTest.java
@@ -48,6 +48,7 @@ class DefaultModelPropertyGradlePropertyIntegrationTest {
 		val entity = node("beho", builder -> builder.withConfigurer(modelConfigurer));
 		entity.addComponent(ModelPropertyTag.instance());
 		entity.addComponent(new GradlePropertyComponent(property));
+		entity.addComponent(new ModelPropertyTypeComponent(of(MyType.class)));
 		entity.addComponent(ModelIdentifier.of("beho", Object.class));
 		return entity;
 	}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyGradlePropertyIntegrationTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyGradlePropertyIntegrationTest.java
@@ -97,5 +97,17 @@ class DefaultModelPropertyGradlePropertyIntegrationTest {
 		assertEquals(expectedState, ModelStates.getState(entity));
 	}
 
+	@Test
+	void hasModelPropertyTypeAsUntypedModelProperty() {
+		assertEquals(of(MyType.class).getConcreteType(), factory.createProperty(node).getType());
+	}
+
+	@Test
+	void hasModelPropertyTypeAsModelElement() {
+		assertTrue(factory.createElement(node) instanceof ModelProperty);
+		assertEquals(of(MyType.class).getConcreteType(), ((ModelProperty<?>) factory.createElement(node)).getType());
+	}
+
+
 	interface MyType {}
 }

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyGradlePropertyIntegrationTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyGradlePropertyIntegrationTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal;
+
+import dev.nokee.model.internal.core.*;
+import dev.nokee.model.internal.registry.ModelConfigurer;
+import dev.nokee.model.internal.state.ModelStates;
+import lombok.val;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
+
+import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
+import static dev.nokee.model.internal.core.ModelTestUtils.node;
+import static dev.nokee.model.internal.type.GradlePropertyTypes.property;
+import static dev.nokee.model.internal.type.ModelType.of;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isA;
+import static org.junit.jupiter.api.Assertions.*;
+
+class DefaultModelPropertyGradlePropertyIntegrationTest {
+	private final ModelConfigurer modelConfigurer = Mockito.mock(ModelConfigurer.class);
+	private final ModelNode node = newEntity(modelConfigurer);
+	private final ModelElementFactory factory = new ModelElementFactory(objectFactory()::newInstance);
+	private final ModelProperty<MyType> subject = factory.createProperty(node, of(MyType.class));
+
+	private static ModelNode newEntity(ModelConfigurer modelConfigurer) {
+		val property = objectFactory().property(MyType.class);
+		val entity = node("beho", builder -> builder.withConfigurer(modelConfigurer));
+		entity.addComponent(ModelPropertyTag.instance());
+		entity.addComponent(new GradlePropertyComponent(property));
+		entity.addComponent(ModelIdentifier.of("beho", Object.class));
+		return entity;
+	}
+
+	@Test
+	void canConvertToPropertyUsingRawPropertyType() {
+		assertThat(assertDoesNotThrow(() -> subject.asProperty(of(Property.class))), isA(Property.class));
+	}
+
+	@Test
+	void canConvertToPropertyUsingModelPropertyType() {
+		assertThat(assertDoesNotThrow(() -> subject.asProperty(property(of(MyType.class)))), isA(Property.class));
+	}
+
+	@Test
+	void throwsExceptionPropertyTypeOfObjectConversion() {
+		assertThrows(RuntimeException.class, () -> subject.asProperty(property(of(Object.class))));
+	}
+
+	@ParameterizedTest(name = "throwsExceptionOnInvalidPropertyConversion [{argumentsWithNames}]")
+	@ValueSource(classes = {SetProperty.class, ListProperty.class, MapProperty.class, ConfigurableFileCollection.class, RegularFileProperty.class, DirectoryProperty.class})
+	void throwsExceptionOnInvalidPropertyConversion(Class<? extends HasConfigurableValue> invalidPropertyType) {
+		assertThrows(RuntimeException.class, () -> subject.asProperty(of(invalidPropertyType)));
+	}
+
+	@ParameterizedTest(name = "doesNotRealizeModelPropertyOnGradlePropertyConversion [{argumentsWithNames}]")
+	@ValueSource(classes = {SetProperty.class, ListProperty.class, MapProperty.class, ConfigurableFileCollection.class, RegularFileProperty.class, DirectoryProperty.class, Property.class})
+	void doesNotRealizeModelPropertyOnGradlePropertyConversion(Class<? extends HasConfigurableValue> propertyType) {
+		assertDoesNotChangeEntityState(node, () -> subject.asProperty(of(propertyType)));
+	}
+
+	@Test
+	void canSetValueViaGradleProperty() {
+		val expectedValue = Mockito.mock(MyType.class);
+		subject.asProperty(property(of(MyType.class))).set(expectedValue);
+		assertSame(expectedValue, subject.get());
+	}
+
+	private static void assertDoesNotChangeEntityState(ModelNode entity, Executable executable) {
+		val expectedState = ModelStates.getState(entity);
+		try {
+			executable.execute();
+		} catch (Throwable ex) {
+			// ignore exception
+		}
+		assertEquals(expectedState, ModelStates.getState(entity));
+	}
+
+	interface MyType {}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyGradleSetPropertyIntegrationTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyGradleSetPropertyIntegrationTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal;
+
+import com.google.common.collect.ImmutableSet;
+import dev.nokee.model.internal.core.*;
+import dev.nokee.model.internal.registry.ModelConfigurer;
+import dev.nokee.model.internal.state.ModelStates;
+import lombok.val;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
+
+import java.util.Set;
+
+import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
+import static dev.nokee.model.internal.core.ModelTestUtils.node;
+import static dev.nokee.model.internal.type.GradlePropertyTypes.setProperty;
+import static dev.nokee.model.internal.type.ModelType.of;
+import static dev.nokee.model.internal.type.ModelTypes.set;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isA;
+import static org.junit.jupiter.api.Assertions.*;
+
+class DefaultModelPropertyGradleSetPropertyIntegrationTest {
+	private final ModelConfigurer modelConfigurer = Mockito.mock(ModelConfigurer.class);
+	private final ModelNode node = newEntity(modelConfigurer);
+	private final ModelElementFactory factory = new ModelElementFactory(objectFactory()::newInstance);
+	private final ModelProperty<Set<MyType>> subject = factory.createProperty(node, set(of(MyType.class)));
+
+	private static ModelNode newEntity(ModelConfigurer modelConfigurer) {
+		val property = objectFactory().setProperty(MyType.class);
+		val entity = node("zimu", builder -> builder.withConfigurer(modelConfigurer));
+		entity.addComponent(ModelPropertyTag.instance());
+		entity.addComponent(new GradlePropertyComponent(property));
+		entity.addComponent(ModelIdentifier.of("zimu", Object.class));
+		return entity;
+	}
+
+	@Test
+	void canConvertToSetPropertyUsingRawSetPropertyType() {
+		assertThat(assertDoesNotThrow(() -> subject.asProperty(of(SetProperty.class))), isA(SetProperty.class));
+	}
+
+	@Test
+	void canConvertToSetPropertyUsingModelSetPropertyType() {
+		assertThat(assertDoesNotThrow(() -> subject.asProperty(setProperty(of(MyType.class)))), isA(SetProperty.class));
+	}
+
+	@Test
+	void throwsExceptionSetPropertyTypeOfObjectConversion() {
+		assertThrows(RuntimeException.class, () -> subject.asProperty(setProperty(of(Object.class))));
+	}
+
+	@ParameterizedTest(name = "throwsExceptionOnInvalidSetPropertyConversion [{argumentsWithNames}]")
+	@ValueSource(classes = {Property.class, ListProperty.class, MapProperty.class, ConfigurableFileCollection.class, RegularFileProperty.class, DirectoryProperty.class})
+	void throwsExceptionOnInvalidSetPropertyConversion(Class<? extends HasConfigurableValue> invalidPropertyType) {
+		assertThrows(RuntimeException.class, () -> subject.asProperty(of(invalidPropertyType)));
+	}
+
+	@ParameterizedTest(name = "doesNotRealizeModelPropertyOnGradleSetPropertyConversion [{argumentsWithNames}]")
+	@ValueSource(classes = {SetProperty.class, ListProperty.class, MapProperty.class, ConfigurableFileCollection.class, RegularFileProperty.class, DirectoryProperty.class, Property.class})
+	void doesNotRealizeModelPropertyOnGradleSetPropertyConversion(Class<? extends HasConfigurableValue> propertyType) {
+		assertDoesNotChangeEntityState(node, () -> subject.asProperty(of(propertyType)));
+	}
+
+	@Test
+	void canSetValueViaGradleSetProperty() {
+		val expectedValue = ImmutableSet.of(Mockito.mock(MyType.class));
+		subject.asProperty(setProperty(of(MyType.class))).set(expectedValue);
+		assertEquals(expectedValue, subject.get());
+	}
+
+	private static void assertDoesNotChangeEntityState(ModelNode entity, Executable executable) {
+		val expectedState = ModelStates.getState(entity);
+		try {
+			executable.execute();
+		} catch (Throwable ex) {
+			// ignore exception
+		}
+		assertEquals(expectedState, ModelStates.getState(entity));
+	}
+
+	interface MyType {}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyGradleSetPropertyIntegrationTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyGradleSetPropertyIntegrationTest.java
@@ -52,6 +52,7 @@ class DefaultModelPropertyGradleSetPropertyIntegrationTest {
 		val entity = node("zimu", builder -> builder.withConfigurer(modelConfigurer));
 		entity.addComponent(ModelPropertyTag.instance());
 		entity.addComponent(new GradlePropertyComponent(property));
+		entity.addComponent(new ModelPropertyTypeComponent(set(of(MyType.class))));
 		entity.addComponent(ModelIdentifier.of("zimu", Object.class));
 		return entity;
 	}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyGradleSetPropertyIntegrationTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyGradleSetPropertyIntegrationTest.java
@@ -101,5 +101,17 @@ class DefaultModelPropertyGradleSetPropertyIntegrationTest {
 		assertEquals(expectedState, ModelStates.getState(entity));
 	}
 
+	@Test
+	void hasModelPropertyTypeAsUntypedModelProperty() {
+		assertEquals(set(of(MyType.class)).getConcreteType(), factory.createProperty(node).getType());
+	}
+
+	@Test
+	void hasModelPropertyTypeAsModelElement() {
+		assertTrue(factory.createElement(node) instanceof ModelProperty);
+		assertEquals(set(of(MyType.class)).getConcreteType(), ((ModelProperty<?>) factory.createElement(node)).getType());
+	}
+
+
 	interface MyType {}
 }

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelPropertyTest.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal;
+
+import com.google.common.testing.EqualsTester;
+import com.google.common.testing.NullPointerTester;
+import dev.nokee.model.DomainObjectIdentifier;
+import dev.nokee.model.DomainObjectProvider;
+import dev.nokee.model.internal.core.*;
+import dev.nokee.model.internal.type.ModelType;
+import dev.nokee.utils.ClosureWrappedConfigureAction;
+import lombok.val;
+import org.gradle.api.NamedDomainObjectProvider;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import java.util.function.Supplier;
+
+import static com.google.common.base.Suppliers.ofInstance;
+import static dev.nokee.model.internal.type.ModelType.of;
+import static dev.nokee.utils.ActionTestUtils.doSomething;
+import static dev.nokee.utils.ClosureTestUtils.doSomething;
+import static dev.nokee.utils.TransformerTestUtils.aTransformer;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class DefaultModelPropertyTest {
+	private final NamedStrategy namedStrategy = mock(NamedStrategy.class);
+	@SuppressWarnings("unchecked") private final Supplier<DomainObjectIdentifier> identifierSupplier = mock(Supplier.class);
+	private final ConfigurableProviderConvertibleStrategy providerConvertibleStrategy = mock(ConfigurableProviderConvertibleStrategy.class);
+	private final PropertyConvertibleStrategy propertyConvertibleStrategy = mock(PropertyConvertibleStrategy.class);
+	private final ConfigurableStrategy configurableStrategy = mock(ConfigurableStrategy.class);
+	private final ModelCastableStrategy castableStrategy = mock(ModelCastableStrategy.class);
+	private final ModelPropertyLookupStrategy propertyLookupStrategy = mock(ModelPropertyLookupStrategy.class);
+	private final ModelElementLookupStrategy elementLookupStrategy = mock(ModelElementLookupStrategy.class);
+	private final ModelMixInStrategy mixInStrategy = mock(ModelMixInStrategy.class);
+	@SuppressWarnings("unchecked") private final Supplier<MyType> valueSupplier = mock(Supplier.class);
+	@SuppressWarnings("unchecked") private final Supplier<ModelNode> entitySupplier = mock(Supplier.class);
+	private final DefaultModelProperty<MyType> subject = new DefaultModelProperty<>(namedStrategy, identifierSupplier, of(MyType.class), providerConvertibleStrategy, propertyConvertibleStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, elementLookupStrategy, mixInStrategy, valueSupplier, entitySupplier);
+
+	@Test
+	@SuppressWarnings("UnstableApiUsage")
+	void checkNullsOnConstructor() {
+		new NullPointerTester().setDefault(ModelType.class, ModelType.untyped()).testAllPublicConstructors(DefaultModelProperty.class);
+	}
+
+	@Test
+	@SuppressWarnings("UnstableApiUsage")
+	void checkNullsOnPublicMethods() {
+		new NullPointerTester().setDefault(ModelType.class, ModelType.untyped()).testAllPublicInstanceMethods(subject);
+	}
+
+	//region KnownDomainObject
+	@Test
+	void forwardsIdentifierQueryToDelegate() {
+		val expectedIdentifier = mock(DomainObjectIdentifier.class);
+		when(identifierSupplier.get()).thenReturn(expectedIdentifier);
+
+		assertSame(expectedIdentifier, subject.getIdentifier());
+		verify(identifierSupplier).get();
+	}
+
+	@Test
+	void returnsSpecifiedType() {
+		assertSame(MyType.class, subject.getType());
+	}
+
+	@Test
+	void forwardsConfigureUsingActionToStrategy() {
+		subject.configure(doSomething());
+		verify(configurableStrategy).configure(of(MyType.class), doSomething());
+	}
+
+	@Test
+	void forwardsConfigureUsingClosureToStrategyAsAction() {
+		subject.configure(doSomething(MyType.class));
+		verify(configurableStrategy).configure(of(MyType.class), new ClosureWrappedConfigureAction<>(doSomething(MyType.class)));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void forwardsMapToProviderConvertibleValue() {
+		val result = mock(Provider.class);
+		val provider = mock(NamedDomainObjectProvider.class);
+		when(providerConvertibleStrategy.asProvider(any())).thenReturn(provider);
+		when(provider.map(any())).thenReturn(result);
+
+		assertEquals(result, subject.map(aTransformer()));
+		verify(providerConvertibleStrategy).asProvider(of(MyType.class));
+		verify(provider).map(aTransformer());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void forwardsFlatMapToProviderConvertibleValue() {
+		val result = mock(Provider.class);
+		val provider = mock(NamedDomainObjectProvider.class);
+		when(providerConvertibleStrategy.asProvider(any())).thenReturn(provider);
+		when(provider.flatMap(any())).thenReturn(result);
+
+		assertEquals(result, subject.flatMap(aTransformer()));
+		verify(providerConvertibleStrategy).asProvider(of(MyType.class));
+		verify(provider).flatMap(aTransformer());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void forwardsAsProviderToStrategy() {
+		val result = mock(NamedDomainObjectProvider.class);
+		when(providerConvertibleStrategy.asProvider(any())).thenReturn(result);
+
+		assertEquals(result, subject.asProvider());
+		verify(providerConvertibleStrategy).asProvider(of(MyType.class));
+	}
+	//endregion
+
+	//region ModelElement
+	@Test
+	void forwardsNameQueryToSupplier() {
+		val expectedName = "taxe";
+		when(namedStrategy.getAsString()).thenReturn(expectedName);
+
+		assertSame(expectedName, subject.getName());
+		verify(namedStrategy).getAsString();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void forwardsTypeCastOperatorUsingModelTypeToDelegate() {
+		val expectedObject = mock(DomainObjectProvider.class);
+		when(castableStrategy.castTo(any())).thenReturn(expectedObject);
+
+		assertSame(expectedObject, subject.as(of(MyType.class)));
+		verify(castableStrategy).castTo(of(MyType.class));
+	}
+
+	@Test
+	void forwardsInstanceOfOperatorUsingModelTypeToStrategy() {
+		when(castableStrategy.instanceOf(of(MyType.class))).thenReturn(Boolean.TRUE);
+		when(castableStrategy.instanceOf(of(WrongType.class))).thenReturn(Boolean.FALSE);
+		assertAll(
+			() -> {
+				assertTrue(subject.instanceOf(of(MyType.class)));
+				verify(castableStrategy).instanceOf(of(MyType.class));
+			},
+			() -> {
+				assertFalse(subject.instanceOf(of(WrongType.class)));
+				verify(castableStrategy).instanceOf(of(WrongType.class));
+			}
+		);
+	}
+
+	@Test
+	void forwardsPropertyQueryToStrategy() {
+		val result = mock(ModelElement.class);
+		when(propertyLookupStrategy.get(any())).thenReturn(result);
+
+		assertEquals(result, subject.property("dumo"));
+		verify(propertyLookupStrategy).get("dumo");
+	}
+
+	@Test
+	void forwardsConfigureUsingModelTypeAndActionToStrategy() {
+		assertSame(subject, subject.configure(of(MyType.class), doSomething()));
+		verify(configurableStrategy).configure(of(MyType.class), doSomething());
+	}
+
+	@Test
+	void forwardsMixinToStrategy() {
+		val result = mock(DomainObjectProvider.class);
+		when(mixInStrategy.mixin(any())).thenReturn(result);
+
+		assertSame(result, subject.mixin(of(MyOtherTypeMixIn.class)));
+		verify(mixInStrategy).mixin(of(MyOtherTypeMixIn.class));
+	}
+
+	@Test
+	void forwardsElementUsingNameOnlyQueryToStrategy() {
+		val result = mock(ModelElement.class);
+		when(elementLookupStrategy.get(any())).thenReturn(result);
+
+		assertSame(result, subject.element("hiji"));
+		verify(elementLookupStrategy).get("hiji");
+	}
+
+	@Test
+	void forwardsElementUsingClassQueryToStrategy() {
+		val result = mock(DomainObjectProvider.class);
+		when(elementLookupStrategy.get(any(), any())).thenReturn(result);
+
+		assertSame(result, subject.element("guha", DefaultModelObjectTest.MyType.class));
+		verify(elementLookupStrategy).get("guha", of(DefaultModelObjectTest.MyType.class));
+	}
+
+	@Test
+	void forwardsElementUsingModelTypeQueryToStrategy() {
+		val result = mock(DomainObjectProvider.class);
+		when(elementLookupStrategy.get(any(), any())).thenReturn(result);
+
+		assertSame(result, subject.element("poji", of(DefaultModelObjectTest.MyType.class)));
+		verify(elementLookupStrategy).get("poji", of(DefaultModelObjectTest.MyType.class));
+	}
+	//endregion
+
+	@Test
+	void forwardsValueQueryToStrategy() {
+		val expectedValue = mock(MyType.class);
+		when(valueSupplier.get()).thenReturn(expectedValue);
+
+		assertSame(expectedValue, subject.get());
+		verify(valueSupplier).get();
+	}
+
+	@Test
+	void forwardsAsPropertyToStrategy() {
+		assertAll(
+			assertForwardsPropertyType(Property.class),
+			assertForwardsPropertyType(MapProperty.class),
+			assertForwardsPropertyType(SetProperty.class),
+			assertForwardsPropertyType(ListProperty.class),
+			assertForwardsPropertyType(DirectoryProperty.class),
+			assertForwardsPropertyType(RegularFileProperty.class),
+			assertForwardsPropertyType(ConfigurableFileCollection.class)
+		);
+	}
+	private Executable assertForwardsPropertyType(Class<? extends HasConfigurableValue> propertyType) {
+		return () -> {
+			reset(propertyConvertibleStrategy);
+			val result = mock(propertyType);
+			when(propertyConvertibleStrategy.asProperty(any())).thenReturn(result);
+
+			assertEquals(result, subject.asProperty(of(propertyType)));
+			verify(propertyConvertibleStrategy).asProperty(of(propertyType));
+		};
+	}
+
+	@Test
+	void throwsExceptionWhenCastingUsingGroovyTypeCastOperator() {
+		val ex = assertThrows(UnsupportedOperationException.class, () -> subject.asType(MyType.class));
+		assertEquals("Use ModelProperty#as(ModelType) instead.", ex.getMessage());
+	}
+
+	@Test
+	@SuppressWarnings("UnstableApiUsage")
+	void checkEquals() {
+		val identifier = mock(DomainObjectIdentifier.class);
+		new EqualsTester()
+			.addEqualityGroup(
+				new DefaultModelProperty<>(namedStrategy, ofInstance(identifier), of(MyType.class), providerConvertibleStrategy, propertyConvertibleStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, elementLookupStrategy, mixInStrategy, valueSupplier, entitySupplier),
+				new DefaultModelProperty<>(mock(NamedStrategy.class), ofInstance(identifier), of(MyType.class), providerConvertibleStrategy, propertyConvertibleStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, elementLookupStrategy, mixInStrategy, valueSupplier, entitySupplier),
+				new DefaultModelProperty<>(namedStrategy, ofInstance(identifier), of(MyType.class), mock(ConfigurableProviderConvertibleStrategy.class), propertyConvertibleStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, elementLookupStrategy, mixInStrategy, valueSupplier, entitySupplier),
+				new DefaultModelProperty<>(namedStrategy, ofInstance(identifier), of(MyType.class), providerConvertibleStrategy, mock(PropertyConvertibleStrategy.class), configurableStrategy, castableStrategy, propertyLookupStrategy, elementLookupStrategy, mixInStrategy, valueSupplier, entitySupplier),
+				new DefaultModelProperty<>(namedStrategy, ofInstance(identifier), of(MyType.class), providerConvertibleStrategy, propertyConvertibleStrategy, mock(ConfigurableStrategy.class), castableStrategy, propertyLookupStrategy, elementLookupStrategy, mixInStrategy, valueSupplier, entitySupplier),
+				new DefaultModelProperty<>(namedStrategy, ofInstance(identifier), of(MyType.class), providerConvertibleStrategy, propertyConvertibleStrategy, configurableStrategy, mock(ModelCastableStrategy.class), propertyLookupStrategy, elementLookupStrategy, mixInStrategy, valueSupplier, entitySupplier),
+				new DefaultModelProperty<>(namedStrategy, ofInstance(identifier), of(MyType.class), providerConvertibleStrategy, propertyConvertibleStrategy, configurableStrategy, castableStrategy, mock(ModelPropertyLookupStrategy.class), elementLookupStrategy, mixInStrategy, valueSupplier, entitySupplier),
+				new DefaultModelProperty<>(namedStrategy, ofInstance(identifier), of(MyType.class), providerConvertibleStrategy, propertyConvertibleStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, mock(ModelElementLookupStrategy.class), mixInStrategy, valueSupplier, entitySupplier),
+				new DefaultModelProperty<>(namedStrategy, ofInstance(identifier), of(MyType.class), providerConvertibleStrategy, propertyConvertibleStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, elementLookupStrategy, mock(ModelMixInStrategy.class), valueSupplier, entitySupplier),
+				new DefaultModelProperty<>(namedStrategy, ofInstance(identifier), of(MyType.class), providerConvertibleStrategy, propertyConvertibleStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, elementLookupStrategy, mixInStrategy, mock(Supplier.class), entitySupplier),
+				new DefaultModelProperty<>(namedStrategy, ofInstance(identifier), of(MyType.class), providerConvertibleStrategy, propertyConvertibleStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, elementLookupStrategy, mixInStrategy, valueSupplier, mock(Supplier.class))
+			)
+			.addEqualityGroup(new DefaultModelProperty<>(namedStrategy, ofInstance(identifier), of(Object.class), providerConvertibleStrategy, propertyConvertibleStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, elementLookupStrategy, mixInStrategy, valueSupplier, entitySupplier))
+			.addEqualityGroup(new DefaultModelProperty<>(namedStrategy, ofInstance(mock(DomainObjectIdentifier.class)), of(MyType.class), providerConvertibleStrategy, propertyConvertibleStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, elementLookupStrategy, mixInStrategy, valueSupplier, entitySupplier))
+			.addEqualityGroup(new DefaultModelProperty<>(namedStrategy, ofInstance(mock(DomainObjectIdentifier.class)), of(Object.class), providerConvertibleStrategy, propertyConvertibleStrategy, configurableStrategy, castableStrategy, propertyLookupStrategy, elementLookupStrategy, mixInStrategy, valueSupplier, entitySupplier))
+			.testEquals();
+	}
+
+	interface MyType {}
+	interface MyOtherTypeMixIn {}
+	interface WrongType {}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/ModelElementFactoryModelObjectTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/ModelElementFactoryModelObjectTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal;
+
+import dev.nokee.model.DomainObjectProvider;
+import dev.nokee.model.internal.core.ModelNode;
+import dev.nokee.model.internal.core.ModelPropertyTag;
+import lombok.val;
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
+import static dev.nokee.model.internal.core.ModelProjections.ofInstance;
+import static dev.nokee.model.internal.type.ModelType.of;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isA;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ModelElementFactoryModelObjectTest {
+	private final ModelElementFactory subject = new ModelElementFactory(objectFactory()::newInstance);
+	private final ModelNode entity = createObjectEntity();
+
+	private static ModelNode createObjectEntity() {
+		val result = new ModelNode();
+		result.addComponent(ofInstance(objectFactory().newInstance(MyType.class)));
+		result.addComponent(ofInstance(objectFactory().newInstance(MyOtherType.class)));
+		return result;
+	}
+
+	@Test
+	void canCreateObjectOfValidType() {
+		assertThat(subject.createObject(entity, of(MyType.class)), isA(DomainObjectProvider.class));
+		assertThat(subject.createObject(entity, of(MyOtherType.class)), isA(DomainObjectProvider.class));
+	}
+
+	@Test
+	void returnsModelObjectOfFullType() {
+		assertEquals(of(MyType.class).getConcreteType(), subject.createObject(entity, of(IMyType.class)).getType());
+	}
+
+	@Test
+	void throwsExceptionWhenCreateProperty() {
+		assertThrows(RuntimeException.class, () -> subject.createProperty(entity, of(MyType.class)));
+		assertThrows(RuntimeException.class, () -> subject.createProperty(entity, of(MyOtherType.class)));
+		assertThrows(RuntimeException.class, () -> subject.createProperty(entity, of(WrongType.class)));
+	}
+
+	@Test
+	void throwsExceptionWhenCreateObjectOfWrongType() {
+		assertThrows(RuntimeException.class, () -> subject.createObject(entity, of(WrongType.class)));
+	}
+
+	interface IMyType {}
+	interface MyType extends IMyType {}
+	interface MyOtherType {}
+	interface WrongType {}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/ModelElementFactoryModelPropertyTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/ModelElementFactoryModelPropertyTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal;
+
+import com.google.common.reflect.TypeToken;
+import dev.nokee.model.DomainObjectProvider;
+import dev.nokee.model.internal.core.*;
+import dev.nokee.model.internal.type.ModelType;
+import dev.nokee.model.internal.type.TypeOf;
+import lombok.val;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
+import static dev.nokee.model.internal.core.ModelProjections.ofInstance;
+import static dev.nokee.model.internal.type.ModelType.of;
+import static dev.nokee.model.internal.type.ModelType.untyped;
+import static dev.nokee.model.internal.type.ModelTypes.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ModelElementFactoryModelPropertyTest {
+	private final ModelElementFactory subject = new ModelElementFactory(objectFactory()::newInstance);
+	private final ModelNode entity = createPropertyEntity();
+
+	private static ModelNode createPropertyEntity() {
+		val result = new ModelNode();
+		result.addComponent(ModelPropertyTag.instance());
+		result.addComponent(ofInstance(objectFactory().newInstance(MyOtherType.class)));
+		return result;
+	}
+
+	interface ModelPropertyFactoryTester<T> {
+		ModelElementFactory subject();
+
+		@SuppressWarnings({"unchecked", "UnstableApiUsage"})
+		default ModelType<T> propertyType() {
+			return (ModelType<T>) of(new TypeToken<T>(getClass()) {}.getType());
+		}
+
+		ModelNode entity();
+
+		@Test
+		default void returnsModelPropertyOnCreateElement() {
+			assertThat(subject().createElement(entity()), isA(ModelProperty.class));
+		}
+
+		@Test
+		default void defaultsToPropertyTypeOnCreateElement() {
+			assertEquals(propertyType().getConcreteType(), ((ModelProperty<?>) subject().createElement(entity())).getType());
+		}
+
+		@Test
+		default void defaultsToPropertyTypeOnCreatePropertyByEntityOnly() {
+			assertEquals(propertyType().getConcreteType(), subject().createProperty(entity()).getType());
+		}
+
+		@Test
+		default void returnsModelPropertyOnCreateObjectOfPropertyType() {
+			assertThat(subject().createObject(entity(), propertyType()), isA(ModelProperty.class));
+		}
+
+		@Test
+		default void returnsModelObjectOnCreateObjectOfNonPropertyType() {
+			assertThat(subject().createObject(entity(), of(MyOtherType.class)),
+				allOf(isA(DomainObjectProvider.class), not(isA(ModelProperty.class))));
+		}
+
+		@Test
+		default void throwsExceptionWhenCreatePropertyOfWrongType() {
+			assertThrows(RuntimeException.class, () -> subject().createProperty(entity(), of(WrongType.class)));
+		}
+
+		@Test
+		default void throwsExceptionWhenCreateObjectOfWrongType() {
+			assertThrows(RuntimeException.class, () -> subject().createObject(entity(), of(WrongType.class)));
+		}
+
+		@Test
+		default void canCreatePropertyOfObjectType() {
+			assertEquals(propertyType().getConcreteType(), subject().createProperty(entity(), untyped()).getType());
+		}
+	}
+
+	@Nested
+	class GradleSetPropertyTest implements ModelPropertyFactoryTester<Set<MyType>> {
+		@BeforeEach
+		void configureEntity() {
+			entity.addComponent(new GradlePropertyComponent(objectFactory().setProperty(MyType.class)));
+			entity.addComponent(new ModelPropertyTypeComponent(propertyType()));
+		}
+
+		public ModelElementFactory subject() {
+			return subject;
+		}
+
+		public ModelNode entity() {
+			return entity;
+		}
+
+		@Test
+		void returnsModelPropertyOfFullTypeOnCreateObject() {
+			assertEquals(set(of(MyType.class)).getConcreteType(), subject.createObject(entity, of(new TypeOf<Set<? extends IMyType>>() {})).getType());
+		}
+
+		@Test
+		void returnsModelPropertyOfFullTypeOnCreateProject() {
+			assertEquals(set(of(MyType.class)).getConcreteType(), subject.createProperty(entity, of(new TypeOf<Set<? extends IMyType>>() {})).getType());
+		}
+	}
+
+	@Nested
+	class GradleListPropertyTest implements ModelPropertyFactoryTester<List<MyType>> {
+		@BeforeEach
+		void configureEntity() {
+			entity.addComponent(new GradlePropertyComponent(objectFactory().listProperty(MyType.class)));
+			entity.addComponent(new ModelPropertyTypeComponent(propertyType()));
+		}
+
+		public ModelElementFactory subject() {
+			return subject;
+		}
+
+		public ModelNode entity() {
+			return entity;
+		}
+
+		@Test
+		void returnsModelPropertyOfFullTypeOnCreateObject() {
+			assertEquals(list(of(MyType.class)).getConcreteType(), subject.createObject(entity, of(new TypeOf<List<? extends IMyType>>() {})).getType());
+		}
+
+		@Test
+		void returnsModelPropertyOfFullTypeOnCreateProject() {
+			assertEquals(list(of(MyType.class)).getConcreteType(), subject.createProperty(entity, of(new TypeOf<List<? extends IMyType>>() {})).getType());
+		}
+	}
+
+	@Nested
+	class GradleMapPropertyTest implements ModelPropertyFactoryTester<Map<Integer, MyType>> {
+		@BeforeEach
+		void configureEntity() {
+			entity.addComponent(new GradlePropertyComponent(objectFactory().mapProperty(Integer.class, MyType.class)));
+			entity.addComponent(new ModelPropertyTypeComponent(propertyType()));
+		}
+
+		public ModelElementFactory subject() {
+			return subject;
+		}
+
+		public ModelNode entity() {
+			return entity;
+		}
+
+		@Test
+		void returnsModelPropertyOfFullTypeOnCreateObject() {
+			assertEquals(map(of(Integer.class), of(MyType.class)).getConcreteType(), subject.createObject(entity, of(new TypeOf<Map<? extends Number, ? extends IMyType>>() {})).getType());
+		}
+
+		@Test
+		void returnsModelPropertyOfFullTypeOnCreateProject() {
+			assertEquals(map(of(Integer.class), of(MyType.class)).getConcreteType(), subject.createProperty(entity, of(new TypeOf<Map<? extends Number, ? extends IMyType>>() {})).getType());
+		}
+	}
+
+
+	@Nested
+	class GradlePropertyTest implements ModelPropertyFactoryTester<MyType> {
+		@BeforeEach
+		void configureEntity() {
+			entity.addComponent(new GradlePropertyComponent(objectFactory().property(MyType.class)));
+			entity.addComponent(new ModelPropertyTypeComponent(propertyType()));
+		}
+
+		public ModelElementFactory subject() {
+			return subject;
+		}
+
+		public ModelNode entity() {
+			return entity;
+		}
+
+		@Test
+		void returnsModelPropertyOfFullTypeOnCreateObject() {
+			assertEquals(of(MyType.class).getConcreteType(), subject.createObject(entity, of(IMyType.class)).getType());
+		}
+
+		@Test
+		void returnsModelPropertyOfFullTypeOnCreateProject() {
+			assertEquals(of(MyType.class).getConcreteType(), subject.createProperty(entity, of(IMyType.class)).getType());
+		}
+	}
+
+	@Nested
+	class GradleFileCollectionTest implements ModelPropertyFactoryTester<Set<File>> {
+		@BeforeEach
+		void configureEntity() {
+			entity.addComponent(new GradlePropertyComponent(objectFactory().fileCollection()));
+			entity.addComponent(new ModelPropertyTypeComponent(propertyType()));
+		}
+
+		public ModelElementFactory subject() {
+			return subject;
+		}
+
+		public ModelNode entity() {
+			return entity;
+		}
+	}
+
+	interface IMyType {}
+	interface MyType extends IMyType {}
+	interface MyOtherType {}
+	interface WrongType {}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/ModelElementFactoryTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/ModelElementFactoryTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal;
+
+import com.google.common.testing.NullPointerTester;
+import dev.nokee.model.internal.type.ModelType;
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
+
+class ModelElementFactoryTest {
+	private final ModelElementFactory subject = new ModelElementFactory(objectFactory()::newInstance);
+
+	@Test
+	@SuppressWarnings("UnstableApiUsage")
+	void checkNullsOnPublicConstructor() {
+		new NullPointerTester().testAllPublicConstructors(ModelElementFactory.class);
+	}
+
+	@Test
+	@SuppressWarnings("UnstableApiUsage")
+	void checkNullsOnPublicMethods() {
+		new NullPointerTester().setDefault(ModelType.class, ModelType.untyped()).testAllPublicInstanceMethods(subject);
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/type/GradlePropertyTypes_ConfigurableFileCollectionTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/type/GradlePropertyTypes_ConfigurableFileCollectionTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.type;
+
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
+import static dev.nokee.model.internal.type.ModelType.of;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SuppressWarnings("UnstableApiUsage")
+class GradlePropertyTypes_ConfigurableFileCollectionTest {
+	@Test
+	void returnsModelTypeForConfigurableFileCollectionInstance() {
+		assertEquals(of(ConfigurableFileCollection.class), GradlePropertyTypes.of(objectFactory().fileCollection()));
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/type/GradlePropertyTypes_ListPropertyTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/type/GradlePropertyTypes_ListPropertyTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.type;
+
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.SetProperty;
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
+import static dev.nokee.model.internal.type.GradlePropertyTypes.listProperty;
+import static dev.nokee.model.internal.type.ModelType.of;
+import static dev.nokee.model.internal.type.ModelType.untyped;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GradlePropertyTypes_ListPropertyTest {
+	@Test
+	void returnsListPropertyOfMyTypeModelType() {
+		assertEquals(of(new TypeOf<ListProperty<MyType>>() {}), listProperty(of(MyType.class)));
+	}
+
+	@Test
+	void returnsListPropertyOfObjectModelType() {
+		assertEquals(of(new TypeOf<ListProperty<Object>>() {}), listProperty(untyped()));
+	}
+
+	@Test
+	void returnsModelTypeForListPropertyOfMyTypeInstance() {
+		assertEquals(of(new TypeOf<ListProperty<MyType>>() {}), GradlePropertyTypes.of(objectFactory().listProperty(MyType.class)));
+	}
+
+	private interface MyType {}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/type/GradlePropertyTypes_MapPropertyTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/type/GradlePropertyTypes_MapPropertyTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.type;
+
+import org.gradle.api.provider.MapProperty;
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
+import static dev.nokee.model.internal.type.GradlePropertyTypes.mapProperty;
+import static dev.nokee.model.internal.type.ModelType.of;
+import static dev.nokee.model.internal.type.ModelType.untyped;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SuppressWarnings("UnstableApiUsage")
+class GradlePropertyTypes_MapPropertyTest {
+	@Test
+	void returnsMapPropertyOfStringAndMyTypeModelType() {
+		assertEquals(of(new TypeOf<MapProperty<String, MyType>>() {}), mapProperty(of(String.class), of(MyType.class)));
+	}
+
+	@Test
+	void returnsMapPropertyOfObjectAndObjectModelType() {
+		assertEquals(of(new TypeOf<MapProperty<Object, Object>>() {}), mapProperty(untyped(), untyped()));
+	}
+
+	@Test
+	void returnsModelTypeForMapPropertyOfStringAndMyTypeInstance() {
+		assertEquals(of(new TypeOf<MapProperty<String, MyType>>() {}), GradlePropertyTypes.of(objectFactory().mapProperty(String.class, MyType.class)));
+	}
+
+	private interface MyType {}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/type/GradlePropertyTypes_PropertyTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/type/GradlePropertyTypes_PropertyTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.type;
+
+import org.gradle.api.provider.Property;
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
+import static dev.nokee.model.internal.type.GradlePropertyTypes.property;
+import static dev.nokee.model.internal.type.ModelType.of;
+import static dev.nokee.model.internal.type.ModelType.untyped;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GradlePropertyTypes_PropertyTest {
+	@Test
+	void returnsPropertyOfMyTypeModelType() {
+		assertEquals(of(new TypeOf<Property<MyType>>() {}), property(of(MyType.class)));
+	}
+
+	@Test
+	void returnsPropertyOfObjectModelType() {
+		assertEquals(of(new TypeOf<Property<Object>>() {}), property(untyped()));
+	}
+
+	@Test
+	void returnsModelTypeForPropertyOfMyTypeInstance() {
+		assertEquals(of(new TypeOf<Property<MyType>>() {}), GradlePropertyTypes.of(objectFactory().property(MyType.class)));
+	}
+
+	private interface MyType {}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/type/GradlePropertyTypes_SetPropertyTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/type/GradlePropertyTypes_SetPropertyTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.type;
+
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
+import static dev.nokee.model.internal.type.GradlePropertyTypes.setProperty;
+import static dev.nokee.model.internal.type.ModelType.of;
+import static dev.nokee.model.internal.type.ModelType.untyped;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GradlePropertyTypes_SetPropertyTest {
+	@Test
+	void returnsSetPropertyOfMyTypeModelType() {
+		assertEquals(of(new TypeOf<SetProperty<MyType>>() {}), setProperty(of(MyType.class)));
+	}
+
+	@Test
+	void returnsSetPropertyOfObjectModelType() {
+		assertEquals(of(new TypeOf<SetProperty<Object>>() {}), setProperty(untyped()));
+	}
+
+	@Test
+	void returnsModelTypeForSetPropertyOfMyTypeInstance() {
+		assertEquals(of(new TypeOf<SetProperty<MyType>>() {}), GradlePropertyTypes.of(objectFactory().setProperty(MyType.class)));
+	}
+
+	private interface MyType {}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/type/ModelType_TypeOfTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/type/ModelType_TypeOfTest.java
@@ -17,6 +17,7 @@ package dev.nokee.model.internal.type;
 
 import org.junit.jupiter.api.Test;
 
+import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
 import static dev.nokee.model.internal.type.ModelType.of;
 import static dev.nokee.model.internal.type.ModelType.typeOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -27,5 +28,10 @@ class ModelType_TypeOfTest {
 		assertEquals(of(MyType.class), typeOf(new MyType()), "type of MyType instance is expected to be MyType");
 	}
 
-	static final class MyType {}
+	@Test
+	void usesUndecoratedInstanceType() {
+		assertEquals(of(MyType.class), typeOf(objectFactory().newInstance(MyType.class)));
+	}
+
+	static class MyType {}
 }

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/type/ModelType_TypeOfTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/type/ModelType_TypeOfTest.java
@@ -33,5 +33,5 @@ class ModelType_TypeOfTest {
 		assertEquals(of(MyType.class), typeOf(objectFactory().newInstance(MyType.class)));
 	}
 
-	static class MyType {}
+	public static class MyType {}
 }

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/type/ModelTypes_ListTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/type/ModelTypes_ListTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.type;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static dev.nokee.model.internal.type.ModelType.of;
+import static dev.nokee.model.internal.type.ModelType.untyped;
+import static dev.nokee.model.internal.type.ModelTypes.list;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ModelTypes_ListTest {
+	@Test
+	void returnsListOfMyTypeModelType() {
+		assertEquals(of(new TypeOf<List<MyType>>() {}), list(of(MyType.class)));
+	}
+
+	@Test
+	void returnsListOfObjectModelType() {
+		assertEquals(of(new TypeOf<List<Object>>() {}), list(untyped()));
+	}
+
+	private interface MyType {}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/type/ModelTypes_MapTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/type/ModelTypes_MapTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.type;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static dev.nokee.model.internal.type.ModelType.of;
+import static dev.nokee.model.internal.type.ModelType.untyped;
+import static dev.nokee.model.internal.type.ModelTypes.map;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ModelTypes_MapTest {
+	@Test
+	void returnsMapOfStringAndMyTypeModelType() {
+		assertEquals(of(new TypeOf<Map<String, MyType>>() {}), map(of(String.class), of(MyType.class)));
+	}
+
+	@Test
+	void returnsMapOfObjectAndObjectModelType() {
+		assertEquals(of(new TypeOf<Map<Object, Object>>() {}), map(untyped(), untyped()));
+	}
+
+	private interface MyType {}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/type/ModelTypes_SetTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/type/ModelTypes_SetTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.type;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static dev.nokee.model.internal.type.ModelType.of;
+import static dev.nokee.model.internal.type.ModelType.untyped;
+import static dev.nokee.model.internal.type.ModelTypes.set;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ModelTypes_SetTest {
+	@Test
+	void returnsSetOfMyTypeModelType() {
+		assertEquals(of(new TypeOf<Set<MyType>>() {}), set(of(MyType.class)));
+	}
+
+	@Test
+	void returnsSetOfObjectModelType() {
+		assertEquals(of(new TypeOf<Set<Object>>() {}), set(untyped()));
+	}
+
+	private interface MyType {}
+}


### PR DESCRIPTION
The `ModelProperty` aims at replacing the Gradle property in the middle layer of the universal model. Regardless of the property type, the model will always be the same. It also supports mixin which can be seen as jackets over the property. There is a distinction between `PropertyConvertible` and mixin. Converting to property aims at the Gradle DSL compatibility by "casting" the `ModelProperty` while mixin allows a different view over the property (aka `ConfigurableSourceSet` or `TaskView`, etc.).

Later on, we want to allow mutation of the property values. We also want to allow manipulation of the data holder (value/convention) as well as adding more data holders. We also want some access to the merging process between different data holders. Finally, we also want to make a distinction between the current value and the final value. This distinction will allow `mapInPlace` operation.