### PR TITLE
Configure SDKROOT for normal projects

### DIFF
--- a/subprojects/ide-xcode/src/functionalTest/groovy/dev/nokee/ide/xcode/fixtures/XcodeIdeProjectFixture.groovy
+++ b/subprojects/ide-xcode/src/functionalTest/groovy/dev/nokee/ide/xcode/fixtures/XcodeIdeProjectFixture.groovy
@@ -403,7 +403,7 @@ class XcodeIdeProjectFixture implements IdeProjectFixture {
 					assert it.contains('-Pdev.nokee.internal.xcode.bridge.TARGET_NAME="${TARGET_NAME}"')
 					assert it.contains(':_xcode__${ACTION}_${PROJECT_NAME}_${TARGET_NAME}_${CONFIGURATION}')
 				}
-				assert getObject('passBuildSettingsInEnvironment').toString() == '0'
+				assert getObject('passBuildSettingsInEnvironment').toString() == '1' // true only as a work around for passing SDKROOT
 				return this
 			}
 		}

--- a/subprojects/ide-xcode/src/main/java/dev/nokee/ide/xcode/internal/tasks/GenerateXcodeIdeProjectTask.java
+++ b/subprojects/ide-xcode/src/main/java/dev/nokee/ide/xcode/internal/tasks/GenerateXcodeIdeProjectTask.java
@@ -428,6 +428,11 @@ public abstract class GenerateXcodeIdeProjectTask extends DefaultTask {
 		// If you are a user of the Nokee plugins reading this, feel free to open an feature request with your use cases.
 		target.setPassBuildSettingsInEnvironment(false);
 
+		// For now, we want to pass the build settings in environment **only** so SDKROOT is picked up by clang.
+		// Note that we keep the previous setting as this override is a simple workaround.
+		//   See https://github.com/nokeedev/gradle-native/issues/334
+		target.setPassBuildSettingsInEnvironment(true);
+
 		xcodeTarget.getBuildConfigurations().forEach(buildConfiguration -> {
 			NSDictionary settings = target.getBuildConfigurationList().getBuildConfigurationsByName().getUnchecked(buildConfiguration.getName()).getBuildSettings();
 			settings.put("__DO_NOT_CHANGE_ANY_VALUE_HERE__", "Instead, use the build.gradle[.kts] files.");
@@ -440,6 +445,11 @@ public abstract class GenerateXcodeIdeProjectTask extends DefaultTask {
 			// With PBXLegacyTarget Xcode ignores the product reference on the target for the path.
 			// Instead, it uses the PRODUCT_NAME settings to infer the path inside the BUILT_PRODUCT_DIR.
 			settings.put("PRODUCT_NAME", xcodeTarget.getProductReference().get());
+
+			// For now, lets always assume macosx as SDKROOT.
+			// Later, Gradle should handle the sdk and sysroot properly.
+			//   See https://github.com/nokeedev/gradle-native/issues/334
+			settings.put("SDKROOT", "macosx");
 		});
 
 		return target;


### PR DESCRIPTION
Although the SDKROOT value doesn't reflect the reality, it's a good
enough work around for now.

Fixes https://github.com/nokeedev/gradle-native/issues/334