### PR TITLE
Ignores `internal` Java package when generating Javadoc

### DIFF
--- a/gradle/plugins/nokeebuild-plugins/build-platform/build.gradle
+++ b/gradle/plugins/nokeebuild-plugins/build-platform/build.gradle
@@ -11,5 +11,6 @@ dependencies {
 		api 'org.shipkit:shipkit-auto-version:1.1.19'
 
 		// Java libraries
+		api 'org.apache.commons:commons-lang3:3.12.0'
 	}
 }

--- a/gradle/plugins/nokeebuild-plugins/build-platform/build.gradle
+++ b/gradle/plugins/nokeebuild-plugins/build-platform/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 		api 'org.shipkit:shipkit-auto-version:1.1.19'
 
 		// Java libraries
+		api 'com.google.guava:guava:31.0.1-jre'
 		api 'org.apache.commons:commons-lang3:3.12.0'
 	}
 }

--- a/gradle/plugins/nokeebuild-plugins/jvm-basics/build.gradle
+++ b/gradle/plugins/nokeebuild-plugins/jvm-basics/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 
 dependencies {
+	implementation 'com.google.guava:guava'
 	runtimeOnly project(':basics')
 }
 

--- a/gradle/plugins/nokeebuild-plugins/jvm-basics/build.gradle
+++ b/gradle/plugins/nokeebuild-plugins/jvm-basics/build.gradle
@@ -8,9 +8,13 @@ dependencies {
 
 gradlePlugin {
 	plugins {
-		base {
+		jvmBase {
 			id = 'nokeebuild.jvm-base'
 			implementationClass = 'nokeebuild.JvmBasePlugin'
+		}
+		javadocBase {
+			id = 'nokeebuild.javadoc-base'
+			implementationClass = 'nokeebuild.javadoc.JavadocBasePlugin'
 		}
 	}
 }

--- a/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/JvmBasePlugin.java
+++ b/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/JvmBasePlugin.java
@@ -34,6 +34,7 @@ abstract /*final*/ class JvmBasePlugin implements Plugin<Project> {
 	@Override
 	public void apply(Project project) {
 		project.getPluginManager().apply("nokeebuild.lifecycle-base");
+		project.getPluginManager().apply("nokeebuild.javadoc-base");
 		project.getPluginManager().withPlugin("java-base", ignored -> {
 			project.getPluginManager().apply("nokeebuild.repositories");
 			sourceSets(project).configureEach(new UseLombok(project, lombokVersion(project)));

--- a/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/JvmBasePlugin.java
+++ b/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/JvmBasePlugin.java
@@ -21,6 +21,7 @@ import org.gradle.api.Project;
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.compile.JavaCompile;
+import org.gradle.api.tasks.javadoc.Javadoc;
 
 import javax.inject.Inject;
 import java.util.function.Function;
@@ -40,6 +41,7 @@ abstract /*final*/ class JvmBasePlugin implements Plugin<Project> {
 			sourceSets(project).configureEach(new UseLombok(project, lombokVersion(project)));
 		});
 		project.getTasks().withType(JavaCompile.class).configureEach(registerExtension("strictCompile", StrictJavaCompileExtension::new));
+		project.getTasks().withType(Javadoc.class).configureEach(new UseUtf8Encoding());
 	}
 
 	private static SourceSetContainer sourceSets(Project project) {

--- a/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/UseUtf8Encoding.java
+++ b/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/UseUtf8Encoding.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nokeebuild;
+
+import org.gradle.api.Action;
+import org.gradle.api.tasks.javadoc.Javadoc;
+import org.gradle.external.javadoc.StandardJavadocDocletOptions;
+
+final class UseUtf8Encoding implements Action<Javadoc> {
+	@Override
+	public void execute(Javadoc task) {
+		final StandardJavadocDocletOptions options = (StandardJavadocDocletOptions) task.getOptions();
+		options.setEncoding("utf-8");
+		options.setDocEncoding("utf-8");
+		options.setCharSet("utf-8");
+	}
+}

--- a/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/javadoc/JavadocAdditionalArgsOption.java
+++ b/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/javadoc/JavadocAdditionalArgsOption.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nokeebuild.javadoc;
+
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.tasks.javadoc.Javadoc;
+
+public final class JavadocAdditionalArgsOption implements Action<Javadoc> {
+	private static final String ADDITIONAL_ARGS_EXTENSION_NAME = "additionalArgs";
+	private final Project project;
+
+	JavadocAdditionalArgsOption(Project project) {
+		this.project = project;
+	}
+
+	@Override
+	public void execute(Javadoc task) {
+		new JavadocPropertyFactory(project).named(ADDITIONAL_ARGS_EXTENSION_NAME).apply(task);
+	}
+
+	@SuppressWarnings("unchecked")
+	public static ListProperty<String> additionalArgs(Javadoc self) {
+		return (ListProperty<String>) self.getExtensions().getByName(ADDITIONAL_ARGS_EXTENSION_NAME);
+	}
+}

--- a/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/javadoc/JavadocBasePlugin.java
+++ b/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/javadoc/JavadocBasePlugin.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nokeebuild.javadoc;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.TaskCollection;
+import org.gradle.api.tasks.javadoc.Javadoc;
+
+import javax.inject.Inject;
+
+class JavadocBasePlugin implements Plugin<Project> {
+	@Inject
+	public JavadocBasePlugin() {}
+
+	@Override
+	public void apply(Project project) {
+		final TaskCollection<Javadoc> javadocTasks = project.getTasks().withType(Javadoc.class);
+		javadocTasks.configureEach(new JavadocLinksOption(project));
+		javadocTasks.configureEach(new JavadocSourcePathsOption(project));
+		javadocTasks.configureEach(new JavadocTitleOption(project));
+		javadocTasks.configureEach(new JavadocExcludeOption(project));
+		javadocTasks.configureEach(new JavadocSubpackagesOption(project));
+		javadocTasks.configureEach(new JavadocAdditionalArgsOption(project));
+		javadocTasks.configureEach(new JavadocSourcesOption(project));
+	}
+}

--- a/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/javadoc/JavadocExcludeOption.java
+++ b/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/javadoc/JavadocExcludeOption.java
@@ -15,6 +15,7 @@
  */
 package nokeebuild.javadoc;
 
+import com.google.common.collect.Iterables;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.Transformer;
@@ -25,6 +26,7 @@ import org.gradle.api.tasks.javadoc.Javadoc;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.Collections;
 
 import static java.lang.String.join;
 import static java.util.Collections.emptyList;
@@ -53,9 +55,14 @@ public final class JavadocExcludeOption implements Action<Javadoc> {
 		args.value(exclude.map(asExcludeFlags()).orElse(emptyList())).disallowChanges();
 	}
 
-	// TODO: ignore emptyt list
 	private static Transformer<Iterable<String>, Iterable<String>> asExcludeFlags() {
-		return values -> Arrays.asList("-exclude", join(File.pathSeparator, values));
+		return values -> {
+			if (Iterables.isEmpty(values)) {
+				return Collections.emptyList();
+			} else {
+				return Arrays.asList("-exclude", join(File.pathSeparator, values));
+			}
+		};
 	}
 
 	@SuppressWarnings("unchecked")

--- a/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/javadoc/JavadocExcludeOption.java
+++ b/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/javadoc/JavadocExcludeOption.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nokeebuild.javadoc;
+
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.Transformer;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.api.reflect.TypeOf;
+import org.gradle.api.tasks.javadoc.Javadoc;
+
+import java.io.File;
+import java.util.Arrays;
+
+import static java.lang.String.join;
+import static java.util.Collections.emptyList;
+
+/**
+ * Unconditionally, excludes the specified packages and their subpackages from the list formed by {@literal -subpackages}.
+ * It excludes those packages even when they would otherwise be included by some earlier or later {@literal -subpackages} option.
+ */
+public final class JavadocExcludeOption implements Action<Javadoc> {
+	private static final String EXCLUDE_EXTENSION_NAME = "exclude";
+	private static final TypeOf<SetProperty<String>> EXCLUDE_EXTENSION_TYPE = new TypeOf<SetProperty<String>>() {};
+	private final Project project;
+
+	JavadocExcludeOption(Project project) {
+		this.project = project;
+	}
+
+	@Override
+	@SuppressWarnings("UnstableApiUsage")
+	public void execute(Javadoc task) {
+
+		final SetProperty<String> exclude = project.getObjects().setProperty(String.class);
+		task.getExtensions().add(EXCLUDE_EXTENSION_TYPE, EXCLUDE_EXTENSION_NAME, exclude);
+
+		final ListProperty<String> args = new JavadocPropertyFactory(project).named(EXCLUDE_EXTENSION_NAME + "Args").apply(task);
+		args.value(exclude.map(asExcludeFlags()).orElse(emptyList())).disallowChanges();
+	}
+
+	// TODO: ignore emptyt list
+	private static Transformer<Iterable<String>, Iterable<String>> asExcludeFlags() {
+		return values -> Arrays.asList("-exclude", join(File.pathSeparator, values));
+	}
+
+	@SuppressWarnings("unchecked")
+	public static SetProperty<String> exclude(Javadoc self) {
+		return (SetProperty<String>) self.getExtensions().getByName(EXCLUDE_EXTENSION_NAME);
+	}
+}

--- a/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/javadoc/JavadocLinksOption.java
+++ b/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/javadoc/JavadocLinksOption.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nokeebuild.javadoc;
+
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.Transformer;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.api.reflect.TypeOf;
+import org.gradle.api.tasks.javadoc.Javadoc;
+
+import java.net.URI;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.StreamSupport.stream;
+
+public class JavadocLinksOption implements Action<Javadoc> {
+	private static final String LINKS_EXTENSION_NAME = "links";
+	private static final TypeOf<SetProperty<URI>> LINKS_EXTENSION_TYPE = new TypeOf<SetProperty<URI>>() {};
+	private final Project project;
+
+	JavadocLinksOption(Project project) {
+		this.project = project;
+	}
+
+	@Override
+	@SuppressWarnings("UnstableApiUsage")
+	public void execute(Javadoc task) {
+		final SetProperty<URI> links = project.getObjects().setProperty(URI.class);
+		task.getExtensions().add(LINKS_EXTENSION_TYPE, LINKS_EXTENSION_NAME, links);
+
+		final ListProperty<String> args = new JavadocPropertyFactory(project).named(LINKS_EXTENSION_NAME + "Args").apply(task);
+		args.value(links.map(asLinkFlags()).orElse(emptyList())).disallowChanges();
+	}
+
+	private static Transformer<Iterable<String>, Iterable<URI>> asLinkFlags() {
+		return values -> stream(values.spliterator(), false)
+			.flatMap(it -> Stream.of("-link", it.toString()))
+			.collect(toList());
+	}
+
+	@SuppressWarnings("unchecked")
+	public static SetProperty<URI> links(Javadoc self) {
+		return (SetProperty<URI>) self.getExtensions().getByName(LINKS_EXTENSION_NAME);
+	}
+}

--- a/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/javadoc/JavadocPropertyAction.java
+++ b/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/javadoc/JavadocPropertyAction.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nokeebuild.javadoc;
+
+import org.gradle.api.Action;
+import org.gradle.api.Task;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.reflect.TypeOf;
+import org.gradle.api.tasks.javadoc.Javadoc;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.StandardOpenOption.*;
+
+final class JavadocPropertyAction {
+	private static final TypeOf<ListProperty<String>> ADDITIONAL_ARGS_EXTENSION_TYPE = new TypeOf<ListProperty<String>>() {};
+	private final ObjectFactory objects;
+	private final String name;
+
+	public JavadocPropertyAction(ObjectFactory objects, String name) {
+		this.objects = objects;
+		this.name = name;
+	}
+
+	@SuppressWarnings("UnstableApiUsage")
+	public ListProperty<String> apply(Javadoc task) {
+		// To delay the realization while keeping task dependencies, we _fake_ an input task property.
+		final ListProperty<String> args = objects.listProperty(String.class);
+		args.finalizeValueOnRead();
+
+		// We register the property as extension for debugging purpose.
+		task.getExtensions().add(ADDITIONAL_ARGS_EXTENSION_TYPE, name, args);
+
+		// We register the property as a task input allowing task dependencies to be kept.
+		task.getInputs().property(name, args);
+
+		// Finally, before the task executes, we write the additional arguments to an option file.
+		task.doFirst(new TaskAction<>(new PrepareAdditionalArgsOptionFile()));
+
+		return args;
+	}
+
+	private static final class TaskAction<T extends Task> implements Action<Task> {
+		private final Action<? super T> delegate;
+
+		public TaskAction(Action<? super T> delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public void execute(Task task) {
+			delegate.execute((T) task);
+		}
+	}
+
+	private final class PrepareAdditionalArgsOptionFile implements Action<Javadoc> {
+		@Override
+		public void execute(Javadoc task) {
+			if (!additionalArgs(task).isEmpty()) {
+				task.getOptions().optionFiles(writeAdditionalArgsOptionFile(task));
+			}
+		}
+
+		private File writeAdditionalArgsOptionFile(Javadoc self) {
+			try {
+				return Files.write(optionFilePath(self), additionalArgs(self), UTF_8, CREATE, TRUNCATE_EXISTING).toFile();
+			} catch (IOException e) {
+				throw new UncheckedIOException(e);
+			}
+		}
+
+		@SuppressWarnings("unchecked")
+		private List<String> additionalArgs(Javadoc self) {
+			return ((Provider<List<String>>) self.getExtensions().getByName(name)).get();
+		}
+
+		private Path optionFilePath(Javadoc self) {
+			return self.getTemporaryDir().toPath().resolve(name + ".options");
+		}
+	}
+}

--- a/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/javadoc/JavadocPropertyFactory.java
+++ b/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/javadoc/JavadocPropertyFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nokeebuild.javadoc;
+
+import org.gradle.api.Project;
+
+final class JavadocPropertyFactory {
+	private final Project project;
+
+
+	public JavadocPropertyFactory(Project project) {
+		this.project = project;
+	}
+
+	public JavadocPropertyAction named(String name) {
+		return new JavadocPropertyAction(project.getObjects(), name);
+	}
+}

--- a/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/javadoc/JavadocSourcePathsOption.java
+++ b/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/javadoc/JavadocSourcePathsOption.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nokeebuild.javadoc;
+
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.Transformer;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.FileSystemLocation;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.tasks.javadoc.Javadoc;
+
+import java.io.File;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.StreamSupport.stream;
+
+/**
+ * Specifies the search paths for finding source files when passing package names or the {@literal -subpackages} option into the {@literal javadoc} command.
+ */
+public final class JavadocSourcePathsOption implements Action<Javadoc> {
+	private static final String SOURCE_PATHS_EXTENSION_NAME = "sourcePaths";
+	private final Project project;
+
+	JavadocSourcePathsOption(Project project) {
+		this.project = project;
+	}
+
+	@Override
+	@SuppressWarnings("UnstableApiUsage")
+	public void execute(Javadoc task) {
+		final ConfigurableFileCollection sourcePaths = project.getObjects().fileCollection();
+		task.getExtensions().add(ConfigurableFileCollection.class, SOURCE_PATHS_EXTENSION_NAME, sourcePaths);
+
+		final ListProperty<String> args = new JavadocPropertyFactory(project).named(SOURCE_PATHS_EXTENSION_NAME + "Args").apply(task);
+		args.value(sourcePaths.getElements().map(asSourcePathFlags()).orElse(emptyList())).disallowChanges();
+	}
+
+	// TODO: Ignore empty iterable
+	private static Transformer<Iterable<String>, Iterable<FileSystemLocation>> asSourcePathFlags() {
+		return values -> asList("-sourcepath", stream(values.spliterator(), false).map(it -> it.getAsFile().getAbsolutePath()).collect(Collectors.joining(File.pathSeparator)));
+	}
+
+	public static ConfigurableFileCollection sourcePaths(Javadoc self) {
+		return (ConfigurableFileCollection) self.getExtensions().getByName(SOURCE_PATHS_EXTENSION_NAME);
+	}
+}

--- a/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/javadoc/JavadocSourcePathsOption.java
+++ b/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/javadoc/JavadocSourcePathsOption.java
@@ -15,6 +15,7 @@
  */
 package nokeebuild.javadoc;
 
+import com.google.common.collect.Iterables;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.Transformer;
@@ -24,6 +25,7 @@ import org.gradle.api.provider.ListProperty;
 import org.gradle.api.tasks.javadoc.Javadoc;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -53,9 +55,14 @@ public final class JavadocSourcePathsOption implements Action<Javadoc> {
 		args.value(sourcePaths.getElements().map(asSourcePathFlags()).orElse(emptyList())).disallowChanges();
 	}
 
-	// TODO: Ignore empty iterable
 	private static Transformer<Iterable<String>, Iterable<FileSystemLocation>> asSourcePathFlags() {
-		return values -> asList("-sourcepath", stream(values.spliterator(), false).map(it -> it.getAsFile().getAbsolutePath()).collect(Collectors.joining(File.pathSeparator)));
+		return values -> {
+			if (Iterables.isEmpty(values)) {
+				return Collections.emptyList();
+			} else {
+				return asList("-sourcepath", stream(values.spliterator(), false).map(it -> it.getAsFile().getAbsolutePath()).collect(Collectors.joining(File.pathSeparator)));
+			}
+		};
 	}
 
 	public static ConfigurableFileCollection sourcePaths(Javadoc self) {

--- a/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/javadoc/JavadocSourcesOption.java
+++ b/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/javadoc/JavadocSourcesOption.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nokeebuild.javadoc;
+
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.tasks.javadoc.Javadoc;
+
+public class JavadocSourcesOption implements Action<Javadoc> {
+	private static final String SOURCES_EXTENSION_NAME = "sources";
+	private final Project project;
+
+	JavadocSourcesOption(Project project) {
+		this.project = project;
+	}
+
+	@Override
+	@SuppressWarnings("UnstableApiUsage")
+	public void execute(Javadoc task) {
+		final ConfigurableFileCollection sources = project.getObjects().fileCollection();
+		task.getExtensions().add(ConfigurableFileCollection.class, SOURCES_EXTENSION_NAME, sources);
+		task.getInputs().files(sources.getAsFileTree());
+	}
+
+	public static ConfigurableFileCollection sources(Javadoc self) {
+		return (ConfigurableFileCollection) self.getExtensions().getByName(SOURCES_EXTENSION_NAME);
+	}
+}

--- a/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/javadoc/JavadocSubpackagesOption.java
+++ b/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/javadoc/JavadocSubpackagesOption.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nokeebuild.javadoc;
+
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.Transformer;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.api.reflect.TypeOf;
+import org.gradle.api.tasks.javadoc.Javadoc;
+
+import java.io.File;
+import java.util.Arrays;
+
+import static java.lang.String.join;
+import static java.util.Collections.emptyList;
+
+/**
+ * Generates documentation from source files in the specified packages and recursively in their subpackages.
+ * This option is useful when adding new subpackages to the source code because they're automatically included.
+ * Each package argument is any top-level subpackage (such as {@literal java}) or fully qualified package (such as {@literal javax.swing}) that doesn't need to contain source files.
+ * Arguments are separated by colons on all operating systems.
+ * Wild cards aren't allowed.
+ * Use {@literal -sourcepath} to specify where to find the packages.
+ * This option doesn't process source files that are in the source tree but don't belong to the packages.
+ */
+public final class JavadocSubpackagesOption implements Action<Javadoc> {
+	private static final String SUBPACKAGES_EXTENSION_NAME = "subpackages";
+	private static final TypeOf<SetProperty<String>> SUBPACKAGES_EXTENSION_TYPE = new TypeOf<SetProperty<String>>() {};
+	private final Project project;
+
+	JavadocSubpackagesOption(Project project) {
+		this.project = project;
+	}
+
+	@Override
+	@SuppressWarnings("UnstableApiUsage")
+	public void execute(Javadoc task) {
+		final SetProperty<String> subpackages = project.getObjects().setProperty(String.class);
+		task.getExtensions().add(SUBPACKAGES_EXTENSION_TYPE, SUBPACKAGES_EXTENSION_NAME, subpackages);
+
+		final ListProperty<String> args = new JavadocPropertyFactory(project).named(SUBPACKAGES_EXTENSION_NAME + "Args").apply(task);
+		args.value(subpackages.map(asSubpackagesFlags()).orElse(emptyList())).disallowChanges();
+	}
+
+	// TODO: ignore empty list
+	private static Transformer<Iterable<String>, Iterable<String>> asSubpackagesFlags() {
+		return values -> Arrays.asList("-subpackages", join(File.pathSeparator, values));
+	}
+
+	@SuppressWarnings("unchecked")
+	public static SetProperty<String> subpackages(Javadoc self) {
+		return (SetProperty<String>) self.getExtensions().getByName(SUBPACKAGES_EXTENSION_NAME);
+	}
+}

--- a/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/javadoc/JavadocSubpackagesOption.java
+++ b/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/javadoc/JavadocSubpackagesOption.java
@@ -15,6 +15,7 @@
  */
 package nokeebuild.javadoc;
 
+import com.google.common.collect.Iterables;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.Transformer;
@@ -25,6 +26,7 @@ import org.gradle.api.tasks.javadoc.Javadoc;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.Collections;
 
 import static java.lang.String.join;
 import static java.util.Collections.emptyList;
@@ -57,9 +59,14 @@ public final class JavadocSubpackagesOption implements Action<Javadoc> {
 		args.value(subpackages.map(asSubpackagesFlags()).orElse(emptyList())).disallowChanges();
 	}
 
-	// TODO: ignore empty list
 	private static Transformer<Iterable<String>, Iterable<String>> asSubpackagesFlags() {
-		return values -> Arrays.asList("-subpackages", join(File.pathSeparator, values));
+		return values -> {
+			if (Iterables.isEmpty(values)) {
+				return Collections.emptyList();
+			} else {
+				return Arrays.asList("-subpackages", join(File.pathSeparator, values));
+			}
+		};
 	}
 
 	@SuppressWarnings("unchecked")

--- a/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/javadoc/JavadocTitleOption.java
+++ b/gradle/plugins/nokeebuild-plugins/jvm-basics/src/main/java/nokeebuild/javadoc/JavadocTitleOption.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nokeebuild.javadoc;
+
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.Transformer;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.reflect.TypeOf;
+import org.gradle.api.tasks.javadoc.Javadoc;
+
+import java.util.Arrays;
+
+import static java.util.Collections.emptyList;
+
+public final class JavadocTitleOption implements Action<Javadoc> {
+	private static final String TITLE_EXTENSION_NAME = "title";
+	private static final TypeOf<Property<String>> TITLE_EXTENSION_TYPE = new TypeOf<Property<String>>() {};
+	private final Project project;
+
+	JavadocTitleOption(Project project) {
+		this.project = project;
+	}
+
+	@Override
+	@SuppressWarnings("UnstableApiUsage")
+	public void execute(Javadoc task) {
+		final Property<String> title = project.getObjects().property(String.class);
+		task.getExtensions().add(TITLE_EXTENSION_TYPE, TITLE_EXTENSION_NAME, title);
+
+		final ListProperty<String> args = new JavadocPropertyFactory(project).named(TITLE_EXTENSION_NAME + "Args").apply(task);
+		args.addAll(title.map(asDocTitleFlags()).orElse(emptyList()));
+		args.addAll(title.map(asWindowTitleFlags()).orElse(emptyList()));
+		args.disallowChanges();
+	}
+
+	private static Transformer<Iterable<String>, String> asDocTitleFlags() {
+		return value -> Arrays.asList("-doctitle", quote(value));
+	}
+
+	private static Transformer<Iterable<String>, String> asWindowTitleFlags() {
+		return value -> Arrays.asList("-windowtitle", quote(value));
+	}
+
+	private static String quote(String stringToQuote) {
+		return "\"" + stringToQuote + "\"";
+	}
+
+	@SuppressWarnings("unchecked")
+	public static Property<String> title(Javadoc self) {
+		return (Property<String>) self.getExtensions().getByName(TITLE_EXTENSION_NAME);
+	}
+}

--- a/gradle/plugins/nokeebuild-plugins/uber-plugins/build.gradle
+++ b/gradle/plugins/nokeebuild-plugins/uber-plugins/build.gradle
@@ -3,6 +3,8 @@ plugins {
 }
 
 dependencies {
+	implementation project(':jvm-basics')
+	implementation 'org.apache.commons:commons-lang3'
 	runtimeOnly project(':jvm-basics')
 	compileOnly 'dev.gradleplugins:gradle-plugin-development'
 }

--- a/gradle/plugins/nokeebuild-plugins/uber-plugins/src/main/java/nokeebuild/JavaGradleLibraryDevelopmentPlugin.java
+++ b/gradle/plugins/nokeebuild-plugins/uber-plugins/src/main/java/nokeebuild/JavaGradleLibraryDevelopmentPlugin.java
@@ -19,6 +19,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.plugin.devel.GradlePluginDevelopmentExtension;
 
 import javax.inject.Inject;
@@ -41,6 +42,7 @@ abstract /*final*/ class JavaGradleLibraryDevelopmentPlugin implements Plugin<Pr
 		gradlePlugin(project, new ConfigureMinimumSupportedGradle(minimumGradleVersion(project)));
 		java(project, JavaPluginExtension::withJavadocJar);
 		java(project, JavaPluginExtension::withSourcesJar);
+		project.getTasks().named("javadoc", Javadoc.class, new JavadocGradleDevelopmentConvention(project));
 	}
 
 	private static Action<GradlePluginDevelopmentExtension> disallowPluginsRegistration() {

--- a/gradle/plugins/nokeebuild-plugins/uber-plugins/src/main/java/nokeebuild/JavaGradlePluginDevelopmentPlugin.java
+++ b/gradle/plugins/nokeebuild-plugins/uber-plugins/src/main/java/nokeebuild/JavaGradlePluginDevelopmentPlugin.java
@@ -18,6 +18,7 @@ package nokeebuild;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.tasks.javadoc.Javadoc;
 
 import javax.inject.Inject;
 
@@ -36,5 +37,6 @@ abstract /*final*/ class JavaGradlePluginDevelopmentPlugin implements Plugin<Pro
 		gradlePlugin(project, new ConfigureMinimumSupportedGradle(minimumGradleVersion(project)));
 		java(project, JavaPluginExtension::withJavadocJar);
 		java(project, JavaPluginExtension::withSourcesJar);
+		project.getTasks().named("javadoc", Javadoc.class, new JavadocGradleDevelopmentConvention(project));
 	}
 }

--- a/gradle/plugins/nokeebuild-plugins/uber-plugins/src/main/java/nokeebuild/JavadocGradleDevelopmentConvention.java
+++ b/gradle/plugins/nokeebuild-plugins/uber-plugins/src/main/java/nokeebuild/JavadocGradleDevelopmentConvention.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nokeebuild;
+
+import org.apache.commons.lang3.StringUtils;
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.file.*;
+import org.gradle.api.tasks.javadoc.Javadoc;
+import org.gradle.plugin.devel.GradlePluginDevelopmentExtension;
+import org.gradle.util.GUtil;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static dev.gradleplugins.GradlePluginDevelopmentCompatibilityExtension.compatibility;
+import static dev.gradleplugins.GradleRuntimeCompatibility.minimumJavaVersionFor;
+import static java.lang.String.join;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
+import static java.util.stream.Collectors.joining;
+import static nokeebuild.javadoc.JavadocExcludeOption.exclude;
+import static nokeebuild.javadoc.JavadocLinksOption.links;
+import static nokeebuild.javadoc.JavadocSourcePathsOption.sourcePaths;
+import static nokeebuild.javadoc.JavadocSourcesOption.sources;
+import static nokeebuild.javadoc.JavadocSubpackagesOption.subpackages;
+import static nokeebuild.javadoc.JavadocTitleOption.title;
+
+final class JavadocGradleDevelopmentConvention implements Action<Javadoc> {
+	private final Project project;
+
+	public JavadocGradleDevelopmentConvention(Project project) {
+		this.project = project;
+	}
+
+	@Override
+	public void execute(Javadoc task) {
+		task.setSource(callableOf(ofDummyFileToAvoidNoSourceTaskOutcomeBecauseUsingSourcePathJavadocOption(task)));
+
+		title(task).set(toWords(project.getName()).map(StringUtils::capitalize).collect(joining(" ")) + " " + project.getVersion());
+		subpackages(task).set(project.provider(() -> {
+			final List<String> result = new ArrayList<>();
+			sources(task).getAsFileTree().visit(new GuessSubPackageVisitor(result::add));
+			return result;
+		}));
+		exclude(task).set(project.provider(() -> {
+			final List<String> result = new ArrayList<>();
+			sources(task).getAsFileTree().visit(new ExcludesInternalPackages(result::add));
+			return result;
+		}));
+		sources(task).from(callableOf(this::pluginSourceFiles));
+		links(task).addAll(compatibility(gradlePlugin(project)).getMinimumGradleVersion().map(version -> {
+			return Arrays.asList(
+				project.uri("https://docs.oracle.com/javase/" + minimumJavaVersionFor(version).getMajorVersion() + "/docs/api"),
+				project.uri("https://docs.gradle.org/" + version + "/javadoc/")
+			);
+		}));
+		sourcePaths(task).from(callableOf(this::pluginSourceDirectories));
+	}
+
+	private static Callable<Object> ofDummyFileToAvoidNoSourceTaskOutcomeBecauseUsingSourcePathJavadocOption(Javadoc task) {
+		return () -> {
+			if (sources(task).isEmpty()) {
+				return Collections.emptyList();
+			} else {
+				try {
+					return Files.write(task.getTemporaryDir().toPath().resolve("Dummy.java"), Arrays.asList("package internal;", "class Dummy {}"), UTF_8, CREATE, TRUNCATE_EXISTING);
+				} catch (IOException e) {
+					throw new UncheckedIOException(e);
+				}
+			}
+		};
+	}
+
+	private static Stream<String> toWords(String s) {
+		return Arrays.stream(GUtil.toWords(s, '+').split("\\+"));
+	}
+
+	private FileTree pluginSourceFiles() {
+		return gradlePlugin(project).getPluginSourceSet().getAllJava();
+	}
+
+	private FileCollection pluginSourceDirectories() {
+		return gradlePlugin(project).getPluginSourceSet().getAllJava().getSourceDirectories();
+	}
+
+	private static final class ExcludesInternalPackages implements FileVisitor {
+		private final Consumer<? super String> packageToExcludeListener;
+
+		private ExcludesInternalPackages(Consumer<? super String> packageToExcludeListener) {
+			this.packageToExcludeListener = packageToExcludeListener;
+		}
+
+		@Override
+		public void visitDir(FileVisitDetails details) {
+			if (details.getName().equals("internal")) {
+				packageToExcludeListener.accept(toPackage(details.getRelativePath()));
+			}
+		}
+
+		private String toPackage(RelativePath path) {
+			return join(".", path.getSegments());
+		}
+
+		@Override
+		public void visitFile(FileVisitDetails details) {
+			// ignore
+		}
+	}
+
+	private static final class GuessSubPackageVisitor implements FileVisitor {
+		private final Consumer<? super String> subpackageListener;
+
+		public GuessSubPackageVisitor(Consumer<? super String> subpackageListener) {
+			this.subpackageListener = subpackageListener;
+		}
+
+		@Override
+		public void visitDir(FileVisitDetails details) {
+			subpackageListener.accept(details.getRelativePath().getSegments()[0]);
+			details.stopVisiting();
+		}
+
+		@Override
+		public void visitFile(FileVisitDetails details) {
+			// ignore
+		}
+	}
+
+	public static GradlePluginDevelopmentExtension gradlePlugin(Project project) {
+		return (GradlePluginDevelopmentExtension) project.getExtensions().getByName("gradlePlugin");
+	}
+
+	private static <T> Callable<T> callableOf(Callable<T> delegate) {
+		return new Callable<T>() {
+			private transient volatile boolean initialized;
+			private transient T value;
+
+			@Override
+			public T call() throws Exception {
+				// A 2-field variant of Double Checked Locking.
+				if (!initialized) {
+					synchronized (this) {
+						if (!initialized) {
+							T t = delegate.call();
+							value = t;
+							initialized = true;
+							return t;
+						}
+					}
+				}
+				// This is safe because we checked `initialized.`
+				return value;
+			}
+		};
+	}
+}


### PR DESCRIPTION
These Javadoc extensions were part of `documentation-kit` project. We moved them to `nokeebuild` and made them more composable.