### PR TITLE
Try fixing the status creation with build scan

### DIFF
--- a/.github/actions/gradle/action.yml
+++ b/.github/actions/gradle/action.yml
@@ -29,13 +29,12 @@ runs:
           uses: actions/github-script@v5
           if: failure()
           with:
-              github-token: ${{ inputs.github-token }}
               script: |
                   github.rest.repos.createCommitStatus({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
-                    sha: ${{ github.sha }},
-                    state: ${{ steps.gradle.outcome }},
-                    target_url: ${{ steps.gradle.outputs.build-scan-url }},
-                    context: '❌ ${{ github.workflow }} / ${{ github.job_id }}'
+                    sha: context.sha,
+                    state: '${{ steps.gradle.outcome }}',
+                    target_url: '${{ steps.gradle.outputs.build-scan-url }}',
+                    context: '❌ ${{ context.workflow }} / ${{ context.job }}'
                   })

--- a/.github/actions/gradle/action.yml
+++ b/.github/actions/gradle/action.yml
@@ -36,5 +36,5 @@ runs:
                     sha: context.sha,
                     state: '${{ steps.gradle.outcome }}',
                     target_url: '${{ steps.gradle.outputs.build-scan-url }}',
-                    context: '❌ ${{ context.workflow }} / ${{ context.job }}'
+                    context: `❌ ${context.workflow} / ${context.job}`
                   })


### PR DESCRIPTION
Just like last time, creating a status on commit with the build scan link seems to be quite troublesome. We are getting a syntax error. This PR try some new fixes.