### PR TITLE
Generalize toFamilyName implementation to support any OS

### DIFF
--- a/subprojects/language-native/src/main/java/dev/nokee/language/nativebase/internal/ToolChainSelectorInternal.java
+++ b/subprojects/language-native/src/main/java/dev/nokee/language/nativebase/internal/ToolChainSelectorInternal.java
@@ -225,7 +225,7 @@ public class ToolChainSelectorInternal {
 			} else if (operatingSystem.isFreeBSD()) {
 				return OperatingSystemFamily.FREE_BSD;
 			} else {
-				throw new UnsupportedOperationException(String.format("Unsupported operating system family of name '%s'", operatingSystem.getName()));
+				return OperatingSystemFamily.forName(operatingSystem.getName()).getCanonicalName();
 			}
 		}
 	}


### PR DESCRIPTION
This PR only act as a placeholder to remove obvious blocker when targeting other OS. Until we can have CI coverage for the target, we can't give our blessing regarding full support. We are confident that most scenarios are supported, some more painful than others, but we aim at painless builds.

Fixes https://github.com/nokeedev/gradle-native/issues/538