### PR TITLE
Add FreeBSD 12.3 test coverage on documentation via Vagrant image

### DIFF
--- a/.github/vagrants/freebsd-12.3/Vagrantfile
+++ b/.github/vagrants/freebsd-12.3/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 $script = <<-SCRIPT
-pkg install -y openjdk8 llvm90 gcc9 bash tree git
+pkg install -y openjdk8 llvm90 gcc9 bash tree git libobjc2
 SCRIPT
 
 Vagrant.configure("2") do |config|

--- a/.github/vagrants/freebsd-12.3/Vagrantfile
+++ b/.github/vagrants/freebsd-12.3/Vagrantfile
@@ -1,0 +1,22 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+$script = <<-SCRIPT
+pkg install -y openjdk8 llvm90 gcc9 bash tree git
+SCRIPT
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "freebsd/FreeBSD-12.3-STABLE"
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id, "--memory", "4096"]
+    vb.customize ["modifyvm", :id, "--cpus", "2"]
+  end
+  config.vm.provision "shell", inline: $script
+  config.vm.network "private_network", type: "dhcp"
+  config.disksize.size = "20GB"
+
+  config.ssh.shell = "sh"
+
+  # Sync repository to box
+#   config.vm.synced_folder "../../../", "/vagrant", type: "rsync"
+end

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,6 +95,24 @@ jobs:
                     build-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
                     build-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
                     github-token: ${{ secrets.GITHUB_TOKEN }}
+
+    check-documentations-freebsd:
+        runs-on: macos-10.15
+        steps:
+            -   uses: actions/checkout@v2
+            -   uses: nokeedev/actions/setup-vagrant@main
+                with:
+                    install-vagrant-if: 'false'
+                    install-virtualbox-if: 'false'
+            -   uses: nokeedev/actions/vagrant-provision@main
+                with:
+                    mem: 4096
+                    name: freebsd-12.3
+            -   uses: nokeedev/actions/vagrant-ssh@main
+                with:
+                    name: freebsd-12.3
+                    run: ./gradlew --scan --continue --no-daemon :docs:docsTest --no-build-cache -PskipAllAsciinemaTasks
+
     publish-head-milestone:
         if: github.ref == 'refs/heads/master'
         needs: [quick-test, full-test, check-documentations, check-baked-documentation]

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build
 .DS_Store
 .project
 .settings/
+.vagrant/


### PR DESCRIPTION
Use Vagrant to add test coverage on FreeBSD within GitHub action workflow.

**Why not choose Travis?** Travis used to be free for open source projects but seems to have recently changed their plan model. We can still request OSS credit but we need to contact their support. So far, my experience with support has been 50-50. I also don't have the time to deal with continuous contact with support to request additional credit. Their FreeBSD machines are also misconfigured for Gradle which made everything more complicated. Finally, the synchronization between GitHub actions and Travis is quite painful. It would be best to have everything on a single CI system.

**Why use Vagrant on macOS agents?** We would be willing to use self-host our own FreeBSD system. In fact, we did that back at the beginning using GitLab runners. However, GitHub runners only support major operating systems, i.e. Windows, macOS and Linux. No FreeBSD support. We could use a 3rd party runner but they have some limitations. [Gradle build action is thus not supported](https://github.com/gradle/gradle-build-action/issues/146). It seems to be recommended that users use Vagrant for other systems on macOS agents.

Using SSH to run commands on other systems is still an okay-ish solution. Lots of embedded development will resort to this type of support for testing. The idea is to build an abstract GitHub action capability that can run in a shell or via SSH so we can use the same workflow but different machines. We would work around the supported OS issue for the GitHub runners by using labels as a means to _type_ runners for certain OS and SSH to send the build to the right environment. At some point, we may abstract the checkout action to be environmentally aware and send a git clone via SSH. For now, we don't need all that abstraction so we will work with what we have.

Our actions abstraction will be hosted in [nokeedev/action](https://github.com/nokeedev/actions).

Note that for ARM, we may just acquire a Raspberry Pi vs using QEMU. GitHub runners support Linux on ARM.