### PR TITLE
Reduce performance regression to about 10%

### DIFF
--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/Bit.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/Bit.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.core;
+
+public enum Bit {
+	Zero {
+		@Override
+		public boolean isSet() {
+			return false;
+		}
+
+		@Override
+		public String toString() {
+			return "0";
+		}
+	},
+	One {
+		@Override
+		public boolean isSet() {
+			return true;
+		}
+
+		@Override
+		public String toString() {
+			return "1";
+		}
+	};
+
+	public abstract boolean isSet();
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/Bits.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/Bits.java
@@ -271,6 +271,9 @@ public final class Bits implements Iterable<Bit> {
 	public String toString() {
 		if (isEmpty()) {
 			return "empty bits";
+		} else if (hasSingleBitSet(this)) {
+			// Easier to read
+			return "single bit '" + "1 << " + (length() - 1) + "'";
 		} else {
 			val builder = new StringBuilder();
 			builder.append("bits '");
@@ -278,6 +281,16 @@ public final class Bits implements Iterable<Bit> {
 			builder.append("'");
 			return builder.toString();
 		}
+	}
+
+	private static boolean hasSingleBitSet(Bits self) {
+		for (int i = 0; i < self.bits.length - 2; ++i) {
+			if (self.bits[i] != 0) {
+				return false;
+			}
+		}
+		final int bitIndexInLastSegment = (self.length() - 1) % bitsPerSegment;
+		return self.bits[self.bits.length - 1] == (1L << bitIndexInLastSegment);
 	}
 
 	/**

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/Bits.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/Bits.java
@@ -250,8 +250,8 @@ public final class Bits implements Iterable<Bit> {
 	public int hashCode() {
 		final int word = length() / bitsPerSegment;
 		int hash = 0;
-		for (int i = 0; word >= i && word != 0; i++) {
-			hash = 127 * hash + (int)(bits[i] ^ (bits[i] >>> 32));
+		for (int i = 0; i < word && word != 0; i++) {
+			hash = 127 * hash + (int) (bits[i] ^ (bits[i] >>> 32));
 		}
 		return hash;
 	}
@@ -371,14 +371,14 @@ public final class Bits implements Iterable<Bit> {
 			// allocate bitset
 			long[] bitset = new long[count];
 			int offset = 0;
-			int i = others.length;
+			int i = others.length - 1;
 			while (offset < count) {
-				if (i >= 2) {
+				if (i >= 1) {
 					bitset[offset++] = toUnsignedLong(others[i--]) | (toUnsignedLong(others[i--]) << 32);
-				} else if (i == 1) {
+				} else if (i == 0) {
 					bitset[offset++] = toUnsignedLong(others[i--]) | (toUnsignedLong(leastSignificant) << 32);
 					bitset[offset++] = toUnsignedLong(to) | (toUnsignedLong(mostSignificant) << 32);
-				} else if (i == 0) {
+				} else if (i == -1) {
 					bitset[offset++] = toUnsignedLong(leastSignificant) | (toUnsignedLong(to) << 32);
 					bitset[offset++] = toUnsignedLong(mostSignificant);
 				}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/Bits.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/Bits.java
@@ -1,0 +1,428 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.core;
+
+import com.google.common.base.Preconditions;
+import lombok.val;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Objects;
+
+import static com.google.common.collect.ImmutableList.copyOf;
+import static java.lang.Integer.toUnsignedLong;
+import static java.lang.System.arraycopy;
+
+/**
+ * Represent a compact vector of bits.
+ */
+public final class Bits implements Iterable<Bit> {
+	private static final Bits EMPTY_BITS = new Bits();
+	private static final int bitsPerSegment = 64;
+
+	private final long[] bits;
+
+	private Bits() {
+		this.bits = new long[0];
+	}
+
+	private Bits(long bits) {
+		this.bits = new long[] { bits };
+	}
+
+	private Bits(long[] bits) {
+		this.bits = bits;
+	}
+
+	/**
+	 * Returns true if this bit set contains no bits that are set to {@literal true}.
+	 *
+	 * @return {@code true} if the bit set has no bits set or {@code false} otherwise
+	 */
+	public boolean isEmpty() {
+		return bits.length == 0;
+	}
+
+	/**
+	 * Returns the result of a logical <b>AND</b> between this bit set and the specified bit set.
+	 * This bit set is <b>not</b> modified and returns the result as a new value.
+	 * A bit in the result has the value true if and only if the corresponding bit in both operand bit set has the value true.
+	 *
+	 * @param other  the other bit set operand, must not be null
+	 * @return a new {@literal Bits} representing the result of the logical AND operation, never null
+	 */
+	public Bits and(Bits other) {
+		Objects.requireNonNull(other);
+		int commonWords = Math.min(bits.length, other.bits.length);
+		long[] newBits = new long[commonWords];
+		for (int i = 0; commonWords > i; i++) {
+			newBits[i] = bits[i] & other.bits[i];
+		}
+
+		return ofBits(newBits);
+	}
+
+	/**
+	 * Returns the result of a logical <b>OR</b> between this bit set and the specified bit set.
+	 * This bit set is <b>not</b> modified and returns the result as a new value.
+	 * A bit in the result has the value true if and only if either corresponding bit in operand's bit set has the value true.
+	 *
+	 * @param other  the other bit set operand, must not be null
+	 * @return a new {@literal Bits} representing the result of the bitwise or operation, never null
+	 */
+	public Bits or(Bits other) {
+		Objects.requireNonNull(other);
+		long[] bits = this.bits;
+		long[] otherBits = other.bits;
+		int otherBitsLength = otherBits.length;
+		int bitsLength = bits.length;
+		int newBitsLength = Math.max(bits.length, other.bits.length);
+		int commonWords = Math.min(bitsLength, otherBitsLength);
+		long[] newBits = new long[newBitsLength];
+		for (int i = 0; commonWords > i; i++) {
+			newBits[i] = bits[i] | other.bits[i];
+		}
+
+		arraycopy(commonWords < otherBitsLength ? otherBits : bits, commonWords,
+			newBits, commonWords, newBitsLength - commonWords);
+
+		return ofBits(newBits);
+	}
+
+	/**
+	 * Returns the result of a logical unsigned bit shift to the right of the specified count.
+	 *
+	 * @param count  the number of bits to shift to the right, must not be negative
+	 * @return a new {@literal Bits} representing the result of the bit shift operation, never null
+	 */
+	public Bits rightShift(int count) {
+		Preconditions.checkArgument(count >= 0, "Bit shift 'count' (%s) must be positive.", count);
+
+		// Not shifting required
+		if (count == 0) {
+			return this;
+		}
+
+		// Shortcut on one word bitset
+		if (bits.length == 1) {
+			return ofBits(bits[0] >>> count);
+		}
+
+		int length = this.length();
+
+		// Shifting more bit than available
+		if (length <= count) {
+			return empty();
+		}
+
+		int newCount = (length - count) / bitsPerSegment + ((length - count) % bitsPerSegment == 0 ? 0 : 1);
+		long[] newBits = new long[newCount];
+
+		// the word difference between source and destination shift, i.e. when shifting more than bitsPerSegment
+		int wordShiftCount = count / bitsPerSegment;
+
+		// the number of bits to shift within a word
+		int bitShiftCount = count % bitsPerSegment;
+
+		// the left shift required to keep bits between words, e.g. low bits becoming previous word's high bits
+		int maskBitShiftCount = bitsPerSegment - bitShiftCount;
+
+		for (int word = bits.length - 1; word >= 0 & word >= wordShiftCount; --word) {
+			int i = word - wordShiftCount;
+
+			// when high bits are kept
+			if (i < newBits.length) {
+				newBits[i] |= bits[word] >>> bitShiftCount;
+			}
+			if (i > 0) {
+				newBits[i - 1] = bits[word] << maskBitShiftCount;
+			}
+		}
+
+		return ofBits(newBits);
+	}
+
+	/**
+	 * Returns the <i>logical size</i> of this bitset, e.g. the index of the highest set bit in the bitset plus one.
+	 * If the bit set has no set bits, length will be zero.
+	 *
+	 * @return returns the logical size of this bitset, never negative
+	 */
+	public int length() {
+		long[] bits = this.bits;
+		for (int word = bits.length - 1; word >= 0; --word) {
+			long bitsAtWord = bits[word];
+			if (bitsAtWord != 0) {
+				for (int bit = 63; bit >= 0; --bit) {
+					if ((bitsAtWord & (1L << (bit & 0x3F))) != 0L) {
+						return (word << 6) + bit + 1;
+					}
+				}
+			}
+		}
+		return 0;
+	}
+
+	/**
+	 * Returns true if the specified bit set has any bits set to true that are also set to true in the specified bit set.
+	 *
+	 * @param other  a bit set
+	 * @return boolean indicating whether this bit set intersects the specified bit set
+	 */
+	public boolean intersects(Bits other) {
+		Objects.requireNonNull(other);
+		long[] bits = this.bits;
+		long[] otherBits = other.bits;
+		for (int i = Math.min(bits.length, otherBits.length) - 1; i >= 0; i--) {
+			if ((bits[i] & otherBits[i]) != 0) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Returns true if this bit set is a super set of the specified set,
+	 * i.e. it has all bits set to true that are also set to true in the specified BitSet.
+	 *
+	 * @param other  a bit set
+	 * @return boolean indicating whether this bit set is a super set of the specified set
+	 */
+	public boolean containsAll(Bits other) {
+		Objects.requireNonNull(other);
+		long[] bits = this.bits;
+		long[] otherBits = other.bits;
+		int otherBitsLength = otherBits.length;
+		int bitsLength = bits.length;
+
+		for (int i = bitsLength; i < otherBitsLength; i++) {
+			if (otherBits[i] != 0) {
+				return false;
+			}
+		}
+		for (int i = Math.min(bitsLength, otherBitsLength) - 1; i >= 0; i--) {
+			if ((bits[i] & otherBits[i]) != otherBits[i]) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null) return false;
+		if (getClass() != o.getClass()) return false;
+
+		Bits other = (Bits)o;
+		long[] otherBits = other.bits;
+
+		int commonWords = Math.min(bits.length, otherBits.length);
+		for (int i = 0; commonWords > i; i++) {
+			if (bits[i] != otherBits[i]) return false;
+		}
+
+		if (bits.length == otherBits.length) return true;
+
+		return length() == other.length();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public int hashCode() {
+		final int word = length() / bitsPerSegment;
+		int hash = 0;
+		for (int i = 0; word >= i && word != 0; i++) {
+			hash = 127 * hash + (int)(bits[i] ^ (bits[i] >>> 32));
+		}
+		return hash;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Iterator<Bit> iterator() {
+		return new BitIterator(bits, length());
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String toString() {
+		if (isEmpty()) {
+			return "empty bits";
+		} else {
+			val builder = new StringBuilder();
+			builder.append("bits '");
+			copyOf(this).reverse().forEach(builder::append);
+			builder.append("'");
+			return builder.toString();
+		}
+	}
+
+	/**
+	 * Creates bitset where no bits are set.
+	 *
+	 * @return a unset bitset, never null
+	 */
+	public static Bits empty() {
+		return EMPTY_BITS;
+	}
+
+	/**
+	 * Creates bitset for the specified unsigned integer word.
+	 *
+	 * @param word  the unsigned integer bitset
+	 * @return a new bitset for the specified unsigned integer word, never null
+	 */
+	// For automatic unsigned long conversion
+	public static Bits ofBits(int word) {
+		return new Bits(toUnsignedLong(word));
+	}
+
+	/**
+	 * Creates bitset for the specified unsigned long word.
+	 *
+	 * @param word  the unsigned long bitset
+	 * @return a new bitset for the specified unsigned long word, never null
+	 */
+	public static Bits ofBits(long word) {
+		if (word == 0) {
+			return EMPTY_BITS;
+		} else {
+			return new Bits(word);
+		}
+	}
+
+	// For internal use only, removes unset high words
+	private static Bits ofBits(long[] words) {
+		int i = words.length - 1;
+		while (i >= 0 && words[i] == 0) {
+			--i;
+		}
+		if (i < 0) {
+			return EMPTY_BITS;
+		} else {
+			return new Bits(Arrays.copyOfRange(words, 0, i + 1));
+		}
+	}
+
+	/**
+	 * Creates bitset where the specified nth bit is set.
+	 *
+	 * @param index  the bit index to set, must be positive
+	 * @return a new bitset where the nth bit is set, never null
+	 */
+	public static Bits nthBit(int index) {
+		Preconditions.checkArgument(index >= 0, "Bit 'index' (%s) must be positive.", index);
+		int indexInLastSegment = index % bitsPerSegment;
+		int count = index / bitsPerSegment + 1; // an additional partial segment is required
+		long[] bitset = new long[count];
+		bitset[count - 1] = (1L << indexInLastSegment);
+		return new Bits(bitset);
+	}
+
+	// For automatic unsigned long conversion
+	public static Bits ofBits(int mostSignificant, int to, int leastSignificant, int... others) {
+		if (mostSignificant == 0) {
+			if (others.length > 0) {
+				return ofBits(to, leastSignificant, others[0], Arrays.copyOfRange(others, 1, others.length));
+			} else {
+				return ofBits(toUnsignedLong(leastSignificant) | (toUnsignedLong(to) << 32));
+			}
+		} else {
+			// count number of whole long words
+			int intWordCount = 3 + others.length; // first, count integer words
+			int count = intWordCount / 2 + (intWordCount % 2 == 0 ? 0 : 1); // then, round up
+
+			// allocate bitset
+			long[] bitset = new long[count];
+			int offset = 0;
+			int i = others.length;
+			while (offset < count) {
+				if (i >= 2) {
+					bitset[offset++] = toUnsignedLong(others[i--]) | (toUnsignedLong(others[i--]) << 32);
+				} else if (i == 1) {
+					bitset[offset++] = toUnsignedLong(others[i--]) | (toUnsignedLong(leastSignificant) << 32);
+					bitset[offset++] = toUnsignedLong(to) | (toUnsignedLong(mostSignificant) << 32);
+				} else if (i == 0) {
+					bitset[offset++] = toUnsignedLong(leastSignificant) | (toUnsignedLong(to) << 32);
+					bitset[offset++] = toUnsignedLong(mostSignificant);
+				}
+			}
+			return new Bits(bitset);
+		}
+	}
+
+	public static Bits ofBits(long mostSignificant, long toLeastSignificant, long... others) {
+		if (mostSignificant == 0) {
+			if (others.length > 0) {
+				return ofBits(toLeastSignificant, others[0], Arrays.copyOfRange(others, 1, others.length));
+			} else {
+				return ofBits(toLeastSignificant);
+			}
+		} else {
+			int count = 2 + others.length;
+			long[] bitset = new long[count];
+			int offset = 0;
+			for (int i = others.length; i > 0;) {
+				bitset[offset++] = others[--i];
+			}
+			bitset[offset++] = toLeastSignificant;
+			bitset[offset] = mostSignificant;
+
+			return new Bits(bitset);
+		}
+	}
+
+	private static final class BitIterator implements Iterator<Bit> {
+		private final long[] bits;
+		private final int bitCount;
+		private int currentCount = 0;
+
+		private BitIterator(long[] bits, int bitCount) {
+			this.bits = bits;
+			this.bitCount = bitCount;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return currentCount < bitCount;
+		}
+
+		@Override
+		public Bit next() {
+			return nextBit(currentCount++);
+		}
+
+		private Bit nextBit(int bitCount) {
+			int word = bitCount / bitsPerSegment;
+			int bitIndex = bitCount % bitsPerSegment;
+			if ((bits[word] & (1L << bitIndex)) == 0) {
+				return Bit.Zero;
+			} else {
+				return Bit.One;
+			}
+		}
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/HasInputs.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/HasInputs.java
@@ -19,4 +19,5 @@ import java.util.List;
 
 public interface HasInputs {
 	List<? extends ModelComponentReference<?>> getInputs();
+	Bits getInputBits();
 }

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelActionWithInputs.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelActionWithInputs.java
@@ -51,15 +51,18 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 	public static abstract class ModelAction1<I0> extends ModelActionWithInputs {
 		private final ModelComponentReference<I0> i0;
 		private final List<ModelComponentReference<I0>> inputs;
+		private final Bits inputBits;
 
 		protected ModelAction1() {
 			this.i0 = ModelComponentReference.of((Class<I0>)new TypeToken<I0>(getClass()) {}.getRawType());
 			this.inputs = ImmutableList.of(i0);
+			this.inputBits = i0.componentBits();
 		}
 
 		protected ModelAction1(ModelComponentReference<I0> i0) {
 			this.i0 = i0;
 			this.inputs = ImmutableList.of(i0);
+			this.inputBits = i0.componentBits();
 		}
 
 		@Override
@@ -72,6 +75,11 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 		@Override
 		public final List<? extends ModelComponentReference<?>> getInputs() {
 			return inputs;
+		}
+
+		@Override
+		public Bits getInputBits() {
+			return inputBits;
 		}
 	}
 
@@ -93,17 +101,20 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 		private final ModelComponentReference<I0> i0;
 		private final ModelComponentReference<I1> i1;
 		private final List<ModelComponentReference<?>> inputs;
+		private final Bits inputBits;
 
 		protected ModelAction2() {
 			this.i0 = ModelComponentReference.of((Class<I0>)new TypeToken<I0>(getClass()) {}.getRawType());
 			this.i1 = ModelComponentReference.of((Class<I1>)new TypeToken<I1>(getClass()) {}.getRawType());
 			this.inputs = ImmutableList.of(i0, i1);
+			this.inputBits = i0.componentBits().or(i1.componentBits());
 		}
 
 		protected ModelAction2(ModelComponentReference<I0> i0, ModelComponentReference<I1> i1) {
 			this.i0 = i0;
 			this.i1 = i1;
 			this.inputs = ImmutableList.of(i0, i1);
+			this.inputBits = i0.componentBits().or(i1.componentBits());
 		}
 
 		@Override
@@ -116,6 +127,11 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 		@Override
 		public final List<? extends ModelComponentReference<?>> getInputs() {
 			return inputs;
+		}
+
+		@Override
+		public Bits getInputBits() {
+			return inputBits;
 		}
 	}
 
@@ -138,12 +154,14 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 		private final ModelComponentReference<I1> i1;
 		private final ModelComponentReference<I2> i2;
 		private final List<ModelComponentReference<?>> inputs;
+		private final Bits inputBits;
 
 		protected ModelAction3() {
 			this.i0 = ModelComponentReference.of((Class<I0>)new TypeToken<I0>(getClass()) {}.getRawType());
 			this.i1 = ModelComponentReference.of((Class<I1>)new TypeToken<I1>(getClass()) {}.getRawType());
 			this.i2 = ModelComponentReference.of((Class<I2>)new TypeToken<I2>(getClass()) {}.getRawType());
 			this.inputs = ImmutableList.of(i0, i1, i2);
+			this.inputBits = i0.componentBits().or(i1.componentBits()).or(i2.componentBits());
 		}
 
 		protected ModelAction3(ModelComponentReference<I0> i0, ModelComponentReference<I1> i1, ModelComponentReference<I2> i2) {
@@ -151,6 +169,7 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 			this.i1 = i1;
 			this.i2 = i2;
 			this.inputs = ImmutableList.of(i0, i1, i2);
+			this.inputBits = i0.componentBits().or(i1.componentBits()).or(i2.componentBits());
 		}
 
 		@Override
@@ -163,6 +182,11 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 		@Override
 		public final List<? extends ModelComponentReference<?>> getInputs() {
 			return inputs;
+		}
+
+		@Override
+		public Bits getInputBits() {
+			return inputBits;
 		}
 	}
 
@@ -186,6 +210,7 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 		private final ModelComponentReference<I2> i2;
 		private final ModelComponentReference<I3> i3;
 		private final List<ModelComponentReference<?>> inputs;
+		private final Bits inputBits;
 
 		protected ModelAction4() {
 			this.i0 = ModelComponentReference.of((Class<I0>)new TypeToken<I0>(getClass()) {}.getRawType());
@@ -193,6 +218,7 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 			this.i2 = ModelComponentReference.of((Class<I2>)new TypeToken<I2>(getClass()) {}.getRawType());
 			this.i3 = ModelComponentReference.of((Class<I3>)new TypeToken<I3>(getClass()) {}.getRawType());
 			this.inputs = ImmutableList.of(i0, i1, i2, i3);
+			this.inputBits = i0.componentBits().or(i1.componentBits()).or(i2.componentBits()).or(i3.componentBits());
 		}
 
 		protected ModelAction4(ModelComponentReference<I0> i0, ModelComponentReference<I1> i1, ModelComponentReference<I2> i2, ModelComponentReference<I3> i3) {
@@ -201,6 +227,7 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 			this.i2 = i2;
 			this.i3 = i3;
 			this.inputs = ImmutableList.of(i0, i1, i2, i3);
+			this.inputBits = i0.componentBits().or(i1.componentBits()).or(i2.componentBits()).or(i3.componentBits());
 		}
 
 		@Override
@@ -213,6 +240,11 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 		@Override
 		public final List<? extends ModelComponentReference<?>> getInputs() {
 			return inputs;
+		}
+
+		@Override
+		public Bits getInputBits() {
+			return inputBits;
 		}
 	}
 
@@ -237,6 +269,7 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 		private final ModelComponentReference<I3> i3;
 		private final ModelComponentReference<I4> i4;
 		private final List<ModelComponentReference<?>> inputs;
+		private final Bits inputBits;
 
 		protected ModelAction5() {
 			this.i0 = ModelComponentReference.of((Class<I0>)new TypeToken<I0>(getClass()) {}.getRawType());
@@ -245,6 +278,7 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 			this.i3 = ModelComponentReference.of((Class<I3>)new TypeToken<I3>(getClass()) {}.getRawType());
 			this.i4 = ModelComponentReference.of((Class<I4>)new TypeToken<I4>(getClass()) {}.getRawType());
 			this.inputs = ImmutableList.of(i0, i1, i2, i3, i4);
+			this.inputBits = i0.componentBits().or(i1.componentBits()).or(i2.componentBits()).or(i3.componentBits()).or(i4.componentBits());
 		}
 
 		protected ModelAction5(ModelComponentReference<I0> i0, ModelComponentReference<I1> i1, ModelComponentReference<I2> i2, ModelComponentReference<I3> i3, ModelComponentReference<I4> i4) {
@@ -254,6 +288,7 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 			this.i3 = i3;
 			this.i4 = i4;
 			this.inputs = ImmutableList.of(i0, i1, i2, i3, i4);
+			this.inputBits = i0.componentBits().or(i1.componentBits()).or(i2.componentBits()).or(i3.componentBits()).or(i4.componentBits());
 		}
 		@Override
 		public final void execute(ModelNode node, List<?> inputs) {
@@ -265,6 +300,11 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 		@Override
 		public final List<? extends ModelComponentReference<?>> getInputs() {
 			return inputs;
+		}
+
+		@Override
+		public Bits getInputBits() {
+			return inputBits;
 		}
 	}
 }

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelActionWithInputs.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelActionWithInputs.java
@@ -24,7 +24,9 @@ import java.util.stream.Collectors;
 public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 	@Override
 	public final void execute(ModelNode node) {
-		execute(node, getInputs().stream().map(it -> it.get(node)).collect(Collectors.toList()));
+		if (node.getComponentBits().containsAll(getInputBits())) {
+			execute(node, getInputs().stream().map(it -> it.get(node)).collect(Collectors.toList()));
+		}
 	}
 
 	public abstract void execute(ModelNode node, List<?> inputs);
@@ -46,7 +48,7 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 	}
 
 	@SuppressWarnings("unchecked")
-	public static abstract class ModelAction1<I0> extends ModelActionWithInputs {
+	public static abstract class ModelAction1<I0> implements ModelAction, HasInputs {
 		private final ModelComponentReference<I0> i0;
 		private final List<ModelComponentReference<I0>> inputs;
 		private final Bits inputBits;
@@ -64,8 +66,10 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 		}
 
 		@Override
-		public final void execute(ModelNode node, List<?> inputs) {
-			execute(node, (I0) inputs.get(0));
+		public final void execute(ModelNode node) {
+			if (node.getComponentBits().containsAll(inputBits)) {
+				execute(node, i0.get(node));
+			}
 		}
 
 		protected abstract void execute(ModelNode entity, I0 i0);
@@ -95,7 +99,7 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 	}
 
 	@SuppressWarnings("unchecked")
-	public static abstract class ModelAction2<I0, I1> extends ModelActionWithInputs {
+	public static abstract class ModelAction2<I0, I1> implements ModelAction, HasInputs {
 		private final ModelComponentReference<I0> i0;
 		private final ModelComponentReference<I1> i1;
 		private final List<ModelComponentReference<?>> inputs;
@@ -116,8 +120,10 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 		}
 
 		@Override
-		public final void execute(ModelNode node, List<?> inputs) {
-			execute(node, (I0) inputs.get(0), (I1) inputs.get(1));
+		public final void execute(ModelNode node) {
+			if (node.getComponentBits().containsAll(inputBits)) {
+				execute(node, i0.get(node), i1.get(node));
+			}
 		}
 
 		protected abstract void execute(ModelNode entity, I0 i0, I1 i1);
@@ -147,7 +153,7 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 	}
 
 	@SuppressWarnings("unchecked")
-	public static abstract class ModelAction3<I0, I1, I2> extends ModelActionWithInputs {
+	public static abstract class ModelAction3<I0, I1, I2> implements ModelAction, HasInputs {
 		private final ModelComponentReference<I0> i0;
 		private final ModelComponentReference<I1> i1;
 		private final ModelComponentReference<I2> i2;
@@ -171,8 +177,10 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 		}
 
 		@Override
-		public final void execute(ModelNode node, List<?> inputs) {
-			execute(node, (I0) inputs.get(0), (I1) inputs.get(1), (I2) inputs.get(2));
+		public final void execute(ModelNode node) {
+			if (node.getComponentBits().containsAll(inputBits)) {
+				execute(node, i0.get(node), i1.get(node), i2.get(node));
+			}
 		}
 
 		protected abstract void execute(ModelNode entity, I0 i0, I1 i1, I2 i2);
@@ -202,7 +210,7 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 	}
 
 	@SuppressWarnings("unchecked")
-	public static abstract class ModelAction4<I0, I1, I2, I3> extends ModelActionWithInputs {
+	public static abstract class ModelAction4<I0, I1, I2, I3> implements ModelAction, HasInputs {
 		private final ModelComponentReference<I0> i0;
 		private final ModelComponentReference<I1> i1;
 		private final ModelComponentReference<I2> i2;
@@ -229,8 +237,10 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 		}
 
 		@Override
-		public final void execute(ModelNode node, List<?> inputs) {
-			execute(node, (I0) inputs.get(0), (I1) inputs.get(1), (I2) inputs.get(2), (I3) inputs.get(3));
+		public final void execute(ModelNode node) {
+			if (node.getComponentBits().containsAll(inputBits)) {
+				execute(node, i0.get(node), i1.get(node), i2.get(node), i3.get(node));
+			}
 		}
 
 		protected abstract void execute(ModelNode entity, I0 i0, I1 i1, I2 i2, I3 i3);
@@ -260,7 +270,7 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 	}
 
 	@SuppressWarnings("unchecked")
-	public static abstract class ModelAction5<I0, I1, I2, I3, I4> extends ModelActionWithInputs {
+	public static abstract class ModelAction5<I0, I1, I2, I3, I4> implements ModelAction, HasInputs {
 		private final ModelComponentReference<I0> i0;
 		private final ModelComponentReference<I1> i1;
 		private final ModelComponentReference<I2> i2;
@@ -289,8 +299,10 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 			this.inputBits = i0.componentBits().or(i1.componentBits()).or(i2.componentBits()).or(i3.componentBits()).or(i4.componentBits());
 		}
 		@Override
-		public final void execute(ModelNode node, List<?> inputs) {
-			execute(node, (I0) inputs.get(0), (I1) inputs.get(1), (I2) inputs.get(2), (I3) inputs.get(3), (I4) inputs.get(4));
+		public final void execute(ModelNode node) {
+			if (node.getComponentBits().containsAll(inputBits)) {
+				execute(node, i0.get(node), i1.get(node), i2.get(node), i3.get(node), i4.get(node));
+			}
 		}
 
 		protected abstract void execute(ModelNode entity, I0 i0, I1 i1, I2 i2, I3 i3, I4 i4);

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelActionWithInputs.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelActionWithInputs.java
@@ -24,9 +24,7 @@ import java.util.stream.Collectors;
 public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 	@Override
 	public final void execute(ModelNode node) {
-		if (getInputs().stream().allMatch(it -> ((ModelComponentReferenceInternal) it).isSatisfiedBy(node.getComponentTypes()))) {
-			execute(node, getInputs().stream().map(it -> it.get(node)).collect(Collectors.toList()));
-		}
+		execute(node, getInputs().stream().map(it -> it.get(node)).collect(Collectors.toList()));
 	}
 
 	public abstract void execute(ModelNode node, List<?> inputs);

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelActionWithInputs.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelActionWithInputs.java
@@ -35,16 +35,10 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 
 
 	public static <I0> ModelAction of(ModelComponentReference<I0> i0, A1<? super I0> action) {
-		return new ModelActionWithInputs() {
+		return new ModelAction1<I0>(i0) {
 			@Override
-			@SuppressWarnings("unchecked")
-			public void execute(ModelNode node, List<?> inputs) {
-				action.execute(node, (I0) inputs.get(0));
-			}
-
-			@Override
-			public List<? extends ModelComponentReference<?>> getInputs() {
-				return ImmutableList.of(i0);
+			protected void execute(ModelNode entity, I0 i0) {
+				action.execute(entity, i0);
 			}
 		};
 	}
@@ -56,13 +50,16 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 	@SuppressWarnings("unchecked")
 	public static abstract class ModelAction1<I0> extends ModelActionWithInputs {
 		private final ModelComponentReference<I0> i0;
+		private final List<ModelComponentReference<I0>> inputs;
 
 		protected ModelAction1() {
 			this.i0 = ModelComponentReference.of((Class<I0>)new TypeToken<I0>(getClass()) {}.getRawType());
+			this.inputs = ImmutableList.of(i0);
 		}
 
 		protected ModelAction1(ModelComponentReference<I0> i0) {
 			this.i0 = i0;
+			this.inputs = ImmutableList.of(i0);
 		}
 
 		@Override
@@ -74,21 +71,15 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 
 		@Override
 		public final List<? extends ModelComponentReference<?>> getInputs() {
-			return ImmutableList.of(i0);
+			return inputs;
 		}
 	}
 
 	public static <I0, I1> ModelAction of(ModelComponentReference<I0> i0, ModelComponentReference<I1> i1, A2<? super I0, ? super I1> action) {
-		return new ModelActionWithInputs() {
+		return new ModelAction2<I0, I1>(i0, i1) {
 			@Override
-			@SuppressWarnings("unchecked")
-			public void execute(ModelNode node, List<?> inputs) {
-				action.execute(node, (I0) inputs.get(0), (I1) inputs.get(1));
-			}
-
-			@Override
-			public List<? extends ModelComponentReference<?>> getInputs() {
-				return ImmutableList.of(i0, i1);
+			protected void execute(ModelNode entity, I0 i0, I1 i1) {
+				action.execute(entity, i0, i1);
 			}
 		};
 	}
@@ -101,15 +92,18 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 	public static abstract class ModelAction2<I0, I1> extends ModelActionWithInputs {
 		private final ModelComponentReference<I0> i0;
 		private final ModelComponentReference<I1> i1;
+		private final List<ModelComponentReference<?>> inputs;
 
 		protected ModelAction2() {
 			this.i0 = ModelComponentReference.of((Class<I0>)new TypeToken<I0>(getClass()) {}.getRawType());
 			this.i1 = ModelComponentReference.of((Class<I1>)new TypeToken<I1>(getClass()) {}.getRawType());
+			this.inputs = ImmutableList.of(i0, i1);
 		}
 
 		protected ModelAction2(ModelComponentReference<I0> i0, ModelComponentReference<I1> i1) {
 			this.i0 = i0;
 			this.i1 = i1;
+			this.inputs = ImmutableList.of(i0, i1);
 		}
 
 		@Override
@@ -121,21 +115,15 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 
 		@Override
 		public final List<? extends ModelComponentReference<?>> getInputs() {
-			return ImmutableList.of(i0, i1);
+			return inputs;
 		}
 	}
 
 	public static <I0, I1, I2> ModelAction of(ModelComponentReference<I0> i0, ModelComponentReference<I1> i1, ModelComponentReference<I2> i2, A3<? super I0, ? super I1, ? super I2> action) {
-		return new ModelActionWithInputs() {
+		return new ModelAction3<I0, I1, I2>(i0, i1, i2) {
 			@Override
-			@SuppressWarnings("unchecked")
-			public void execute(ModelNode node, List<?> inputs) {
-				action.execute(node, (I0) inputs.get(0), (I1) inputs.get(1), (I2) inputs.get(2));
-			}
-
-			@Override
-			public List<? extends ModelComponentReference<?>> getInputs() {
-				return ImmutableList.of(i0, i1, i2);
+			protected void execute(ModelNode entity, I0 i0, I1 i1, I2 i2) {
+				action.execute(entity, i0, i1, i2);
 			}
 		};
 	}
@@ -149,17 +137,20 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 		private final ModelComponentReference<I0> i0;
 		private final ModelComponentReference<I1> i1;
 		private final ModelComponentReference<I2> i2;
+		private final List<ModelComponentReference<?>> inputs;
 
 		protected ModelAction3() {
 			this.i0 = ModelComponentReference.of((Class<I0>)new TypeToken<I0>(getClass()) {}.getRawType());
 			this.i1 = ModelComponentReference.of((Class<I1>)new TypeToken<I1>(getClass()) {}.getRawType());
 			this.i2 = ModelComponentReference.of((Class<I2>)new TypeToken<I2>(getClass()) {}.getRawType());
+			this.inputs = ImmutableList.of(i0, i1, i2);
 		}
 
 		protected ModelAction3(ModelComponentReference<I0> i0, ModelComponentReference<I1> i1, ModelComponentReference<I2> i2) {
 			this.i0 = i0;
 			this.i1 = i1;
 			this.i2 = i2;
+			this.inputs = ImmutableList.of(i0, i1, i2);
 		}
 
 		@Override
@@ -171,21 +162,15 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 
 		@Override
 		public final List<? extends ModelComponentReference<?>> getInputs() {
-			return ImmutableList.of(i0, i1, i2);
+			return inputs;
 		}
 	}
 
 	public static <I0, I1, I2, I3> ModelAction of(ModelComponentReference<I0> i0, ModelComponentReference<I1> i1, ModelComponentReference<I2> i2, ModelComponentReference<I3> i3, A4<? super I0, ? super I1, ? super I2, ? super I3> action) {
-		return new ModelActionWithInputs() {
+		return new ModelAction4<I0, I1, I2, I3>(i0, i1, i2, i3) {
 			@Override
-			@SuppressWarnings("unchecked")
-			public void execute(ModelNode node, List<?> inputs) {
-				action.execute(node, (I0) inputs.get(0), (I1) inputs.get(1), (I2) inputs.get(2), (I3) inputs.get(3));
-			}
-
-			@Override
-			public List<? extends ModelComponentReference<?>> getInputs() {
-				return ImmutableList.of(i0, i1, i2, i3);
+			protected void execute(ModelNode entity, I0 i0, I1 i1, I2 i2, I3 i3) {
+				action.execute(entity, i0, i1, i2, i3);
 			}
 		};
 	}
@@ -200,12 +185,14 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 		private final ModelComponentReference<I1> i1;
 		private final ModelComponentReference<I2> i2;
 		private final ModelComponentReference<I3> i3;
+		private final List<ModelComponentReference<?>> inputs;
 
 		protected ModelAction4() {
 			this.i0 = ModelComponentReference.of((Class<I0>)new TypeToken<I0>(getClass()) {}.getRawType());
 			this.i1 = ModelComponentReference.of((Class<I1>)new TypeToken<I1>(getClass()) {}.getRawType());
 			this.i2 = ModelComponentReference.of((Class<I2>)new TypeToken<I2>(getClass()) {}.getRawType());
 			this.i3 = ModelComponentReference.of((Class<I3>)new TypeToken<I3>(getClass()) {}.getRawType());
+			this.inputs = ImmutableList.of(i0, i1, i2, i3);
 		}
 
 		protected ModelAction4(ModelComponentReference<I0> i0, ModelComponentReference<I1> i1, ModelComponentReference<I2> i2, ModelComponentReference<I3> i3) {
@@ -213,6 +200,7 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 			this.i1 = i1;
 			this.i2 = i2;
 			this.i3 = i3;
+			this.inputs = ImmutableList.of(i0, i1, i2, i3);
 		}
 
 		@Override
@@ -224,21 +212,15 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 
 		@Override
 		public final List<? extends ModelComponentReference<?>> getInputs() {
-			return ImmutableList.of(i0, i1, i2, i3);
+			return inputs;
 		}
 	}
 
 	public static <I0, I1, I2, I3, I4> ModelAction of(ModelComponentReference<I0> i0, ModelComponentReference<I1> i1, ModelComponentReference<I2> i2, ModelComponentReference<I3> i3, ModelComponentReference<I4> i4, A5<? super I0, ? super I1, ? super I2, ? super I3, ? super I4> action) {
-		return new ModelActionWithInputs() {
+		return new ModelAction5<I0, I1, I2, I3, I4>(i0, i1, i2, i3, i4) {
 			@Override
-			@SuppressWarnings("unchecked")
-			public void execute(ModelNode node, List<?> inputs) {
-				action.execute(node, (I0) inputs.get(0), (I1) inputs.get(1), (I2) inputs.get(2), (I3) inputs.get(3), (I4) inputs.get(4));
-			}
-
-			@Override
-			public List<? extends ModelComponentReference<?>> getInputs() {
-				return ImmutableList.of(i0, i1, i2, i3, i4);
+			protected void execute(ModelNode entity, I0 i0, I1 i1, I2 i2, I3 i3, I4 i4) {
+				action.execute(entity, i0, i1, i2, i3, i4);
 			}
 		};
 	}
@@ -254,6 +236,7 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 		private final ModelComponentReference<I2> i2;
 		private final ModelComponentReference<I3> i3;
 		private final ModelComponentReference<I4> i4;
+		private final List<ModelComponentReference<?>> inputs;
 
 		protected ModelAction5() {
 			this.i0 = ModelComponentReference.of((Class<I0>)new TypeToken<I0>(getClass()) {}.getRawType());
@@ -261,6 +244,7 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 			this.i2 = ModelComponentReference.of((Class<I2>)new TypeToken<I2>(getClass()) {}.getRawType());
 			this.i3 = ModelComponentReference.of((Class<I3>)new TypeToken<I3>(getClass()) {}.getRawType());
 			this.i4 = ModelComponentReference.of((Class<I4>)new TypeToken<I4>(getClass()) {}.getRawType());
+			this.inputs = ImmutableList.of(i0, i1, i2, i3, i4);
 		}
 
 		protected ModelAction5(ModelComponentReference<I0> i0, ModelComponentReference<I1> i1, ModelComponentReference<I2> i2, ModelComponentReference<I3> i3, ModelComponentReference<I4> i4) {
@@ -269,6 +253,7 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 			this.i2 = i2;
 			this.i3 = i3;
 			this.i4 = i4;
+			this.inputs = ImmutableList.of(i0, i1, i2, i3, i4);
 		}
 		@Override
 		public final void execute(ModelNode node, List<?> inputs) {
@@ -279,7 +264,7 @@ public abstract class ModelActionWithInputs implements ModelAction, HasInputs {
 
 		@Override
 		public final List<? extends ModelComponentReference<?>> getInputs() {
-			return ImmutableList.of(i0, i1, i2, i3, i4);
+			return inputs;
 		}
 	}
 }

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelActions.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelActions.java
@@ -64,11 +64,13 @@ public final class ModelActions {
 		private final ModelType<T> type;
 		private final Action<? super T> action;
 		private final List<ModelComponentReference<?>> inputs;
+		private final Bits inputBits;
 
 		private ExecuteUsingProjectionModelAction(ModelType<T> type, Action<? super T> action) {
 			this.type = requireNonNull(type);
 			this.action = requireNonNull(action);
 			this.inputs = ImmutableList.of(ofAny(projectionOf(type.getConcreteType())));
+			this.inputBits = inputs.stream().map(ModelComponentReference::componentBits).reduce(Bits.empty(), Bits::or);
 		}
 
 		@Override
@@ -79,6 +81,11 @@ public final class ModelActions {
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
 			return inputs;
+		}
+
+		@Override
+		public Bits getInputBits() {
+			return inputBits;
 		}
 
 		@Override
@@ -102,6 +109,7 @@ public final class ModelActions {
 		private final ModelAction action;
 		@EqualsAndHashCode.Exclude private final Set<ModelPath> alreadyExecuted = new HashSet<>();
 		private final List<ModelComponentReference<?>> inputs;
+		private final Bits inputBits;
 
 		public OnceModelAction(ModelAction action) {
 			this.action = requireNonNull(action);
@@ -111,6 +119,7 @@ public final class ModelActions {
 				builder.addAll(((HasInputs) action).getInputs());
 			}
 			this.inputs = builder.build();
+			this.inputBits = inputs.stream().map(ModelComponentReference::componentBits).reduce(Bits.empty(), Bits::or);
 		}
 
 		@Override
@@ -123,6 +132,11 @@ public final class ModelActions {
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
 			return inputs;
+		}
+
+		@Override
+		public Bits getInputBits() {
+			return inputBits;
 		}
 
 		@Override
@@ -155,10 +169,12 @@ public final class ModelActions {
 	private static final class RegisterModelAction implements ModelAction, HasInputs {
 		private final Supplier<NodeRegistration> registration;
 		private final List<ModelComponentReference<?>> inputs;
+		private final Bits inputBits;
 
 		public RegisterModelAction(Supplier<NodeRegistration> registration) {
 			this.registration = requireNonNull(registration);
 			this.inputs = ImmutableList.of(ModelComponentReference.of(RelativeRegistrationService.class));
+			this.inputBits = inputs.stream().map(ModelComponentReference::componentBits).reduce(Bits.empty(), Bits::or);
 		}
 
 		@Override
@@ -169,6 +185,11 @@ public final class ModelActions {
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
 			return inputs;
+		}
+
+		@Override
+		public Bits getInputBits() {
+			return inputBits;
 		}
 
 		@Override
@@ -193,6 +214,7 @@ public final class ModelActions {
 		private final ModelSpec spec;
 		private final ModelAction action;
 		private final List<ModelComponentReference<?>> inputs;
+		private final Bits inputBits;
 
 		public MatchingModelAction(ModelSpec spec, ModelAction action) {
 			this.spec = requireNonNull(spec);
@@ -206,6 +228,7 @@ public final class ModelActions {
 				builder.addAll(((HasInputs) action).getInputs());
 			}
 			this.inputs = builder.build();
+			this.inputBits = inputs.stream().map(ModelComponentReference::componentBits).reduce(Bits.empty(), Bits::or);
 		}
 
 		@Override
@@ -218,6 +241,11 @@ public final class ModelActions {
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
 			return inputs;
+		}
+
+		@Override
+		public Bits getInputBits() {
+			return inputBits;
 		}
 
 		@Override
@@ -244,11 +272,13 @@ public final class ModelActions {
 		private final ModelType<T> type;
 		private final Action<? super KnownDomainObject<T>> action;
 		private final List<ModelComponentReference<?>> inputs;
+		private final Bits inputBits;
 
 		public ExecuteAsKnownProjectionModelAction(ModelType<T> type, Action<? super KnownDomainObject<T>> action) {
 			this.type = requireNonNull(type);
 			this.action = requireNonNull(action);
 			this.inputs = ImmutableList.of(ofAny(projectionOf(type.getConcreteType())));
+			this.inputBits = inputs.stream().map(ModelComponentReference::componentBits).reduce(Bits.empty(), Bits::or);
 		}
 
 		@Override
@@ -259,6 +289,11 @@ public final class ModelActions {
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
 			return inputs;
+		}
+
+		@Override
+		public Bits getInputBits() {
+			return inputBits;
 		}
 
 		@Override

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelActions.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelActions.java
@@ -63,10 +63,12 @@ public final class ModelActions {
 	private static final class ExecuteUsingProjectionModelAction<T> implements ModelAction, HasInputs {
 		private final ModelType<T> type;
 		private final Action<? super T> action;
+		private final List<ModelComponentReference<?>> inputs;
 
 		private ExecuteUsingProjectionModelAction(ModelType<T> type, Action<? super T> action) {
 			this.type = requireNonNull(type);
 			this.action = requireNonNull(action);
+			this.inputs = ImmutableList.of(ofAny(projectionOf(type.getConcreteType())));
 		}
 
 		@Override
@@ -76,7 +78,7 @@ public final class ModelActions {
 
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
-			return ImmutableList.of(ofAny(projectionOf(type.getConcreteType())));
+			return inputs;
 		}
 
 		@Override
@@ -99,9 +101,16 @@ public final class ModelActions {
 	private static final class OnceModelAction implements ModelAction, HasInputs {
 		private final ModelAction action;
 		@EqualsAndHashCode.Exclude private final Set<ModelPath> alreadyExecuted = new HashSet<>();
+		private final List<ModelComponentReference<?>> inputs;
 
 		public OnceModelAction(ModelAction action) {
 			this.action = requireNonNull(action);
+			val builder = ImmutableList.<ModelComponentReference<?>>builder();
+			builder.add(ModelComponentReference.of(ModelPath.class));
+			if (action instanceof HasInputs) {
+				builder.addAll(((HasInputs) action).getInputs());
+			}
+			this.inputs = builder.build();
 		}
 
 		@Override
@@ -113,12 +122,7 @@ public final class ModelActions {
 
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
-			val builder = ImmutableList.<ModelComponentReference<?>>builder();
-			builder.add(ModelComponentReference.of(ModelPath.class));
-			if (action instanceof HasInputs) {
-				builder.addAll(((HasInputs) action).getInputs());
-			}
-			return builder.build();
+			return inputs;
 		}
 
 		@Override
@@ -150,9 +154,11 @@ public final class ModelActions {
 	@EqualsAndHashCode
 	private static final class RegisterModelAction implements ModelAction, HasInputs {
 		private final Supplier<NodeRegistration> registration;
+		private final List<ModelComponentReference<?>> inputs;
 
 		public RegisterModelAction(Supplier<NodeRegistration> registration) {
 			this.registration = requireNonNull(registration);
+			this.inputs = ImmutableList.of(ModelComponentReference.of(RelativeRegistrationService.class));
 		}
 
 		@Override
@@ -162,7 +168,7 @@ public final class ModelActions {
 
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
-			return ImmutableList.of(ModelComponentReference.of(RelativeRegistrationService.class));
+			return inputs;
 		}
 
 		@Override
@@ -186,10 +192,20 @@ public final class ModelActions {
 	private static final class MatchingModelAction implements ModelAction, HasInputs {
 		private final ModelSpec spec;
 		private final ModelAction action;
+		private final List<ModelComponentReference<?>> inputs;
 
 		public MatchingModelAction(ModelSpec spec, ModelAction action) {
 			this.spec = requireNonNull(spec);
 			this.action = requireNonNull(action);
+
+			val builder = ImmutableList.<ModelComponentReference<?>>builder();
+			if (spec instanceof HasInputs) {
+				builder.addAll(((HasInputs) spec).getInputs());
+			}
+			if (action instanceof HasInputs) {
+				builder.addAll(((HasInputs) action).getInputs());
+			}
+			this.inputs = builder.build();
 		}
 
 		@Override
@@ -201,14 +217,7 @@ public final class ModelActions {
 
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
-			val builder = ImmutableList.<ModelComponentReference<?>>builder();
-			if (spec instanceof HasInputs) {
-				builder.addAll(((HasInputs) spec).getInputs());
-			}
-			if (action instanceof HasInputs) {
-				builder.addAll(((HasInputs) action).getInputs());
-			}
-			return builder.build();
+			return inputs;
 		}
 
 		@Override
@@ -234,10 +243,12 @@ public final class ModelActions {
 	private static class ExecuteAsKnownProjectionModelAction<T> implements ModelAction, HasInputs {
 		private final ModelType<T> type;
 		private final Action<? super KnownDomainObject<T>> action;
+		private final List<ModelComponentReference<?>> inputs;
 
 		public ExecuteAsKnownProjectionModelAction(ModelType<T> type, Action<? super KnownDomainObject<T>> action) {
 			this.type = requireNonNull(type);
 			this.action = requireNonNull(action);
+			this.inputs = ImmutableList.of(ofAny(projectionOf(type.getConcreteType())));
 		}
 
 		@Override
@@ -247,7 +258,7 @@ public final class ModelActions {
 
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
-			return ImmutableList.of(ofAny(projectionOf(type.getConcreteType())));
+			return inputs;
 		}
 
 		@Override

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelActions.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelActions.java
@@ -75,7 +75,9 @@ public final class ModelActions {
 
 		@Override
 		public void execute(ModelNode node) {
-			action.execute(ModelNodeUtils.get(node, type));
+			if (node.getComponentBits().containsAll(inputBits)) {
+				action.execute(ModelNodeUtils.get(node, type));
+			}
 		}
 
 		@Override
@@ -124,8 +126,10 @@ public final class ModelActions {
 
 		@Override
 		public void execute(ModelNode node) {
-			if (alreadyExecuted.add(ModelNodeUtils.getPath(node))) {
-				action.execute(node);
+			if (node.getComponentBits().containsAll(inputBits)) {
+				if (alreadyExecuted.add(ModelNodeUtils.getPath(node))) {
+					action.execute(node);
+				}
 			}
 		}
 
@@ -179,7 +183,9 @@ public final class ModelActions {
 
 		@Override
 		public void execute(ModelNode node) {
-			ModelNodeUtils.register(node, registration.get());
+			if (node.getComponentBits().containsAll(inputBits)) {
+				ModelNodeUtils.register(node, registration.get());
+			}
 		}
 
 		@Override
@@ -233,8 +239,10 @@ public final class ModelActions {
 
 		@Override
 		public void execute(ModelNode node) {
-			if (spec.isSatisfiedBy(node)) {
-				action.execute(node);
+			if (node.getComponentBits().containsAll(inputBits)) {
+				if (spec.isSatisfiedBy(node)) {
+					action.execute(node);
+				}
 			}
 		}
 
@@ -283,7 +291,9 @@ public final class ModelActions {
 
 		@Override
 		public void execute(ModelNode node) {
-			action.execute(DefaultKnownDomainObject.of(type, node));
+			if (node.getComponentBits().containsAll(inputBits)) {
+				action.execute(DefaultKnownDomainObject.of(type, node));
+			}
 		}
 
 		@Override

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelComponentReference.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelComponentReference.java
@@ -69,6 +69,7 @@ public abstract class ModelComponentReference<T> {
 		return new OfAnyReference<>(componentType);
 	}
 
+	@EqualsAndHashCode(callSuper = false)
 	private static final class OfAnyReference<T> extends ModelComponentReference<T> implements ModelComponentReferenceInternal {
 		private final ModelComponentType<T> componentType;
 
@@ -106,6 +107,7 @@ public abstract class ModelComponentReference<T> {
 		return new OfProjectionReference<>(projectionType.getConcreteType());
 	}
 
+	@EqualsAndHashCode(callSuper = false)
 	public static abstract class ModelProjectionReference<T> extends ModelComponentReference<ModelProjection> {
 		protected final ModelComponentReference<ModelProjection> delegate;
 		private final Class<T> projectionType;

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelComponentReference.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelComponentReference.java
@@ -26,6 +26,8 @@ import org.gradle.api.provider.Provider;
 public abstract class ModelComponentReference<T> {
 	public abstract T get(ModelNode entity);
 
+	public abstract Bits componentBits();
+
 	public static <T> ModelComponentReference<T> of(Class<T> componentType) {
 		return ofInstance(ModelComponentType.componentOf(componentType));
 	}
@@ -56,6 +58,11 @@ public abstract class ModelComponentReference<T> {
 		public T get(ModelNode entity) {
 			return entity.getComponent(componentType);
 		}
+
+		@Override
+		public Bits componentBits() {
+			return componentType.bits();
+		}
 	}
 
 	public static <T> ModelComponentReference<T> ofAny(ModelComponentType<T> componentType) {
@@ -83,6 +90,11 @@ public abstract class ModelComponentReference<T> {
 		@SuppressWarnings("unchecked")
 		public T get(ModelNode entity) {
 			return (T) entity.getComponents().filter(it -> componentType.isSupertypeOf(ModelComponentType.ofInstance(it))).findFirst().orElseThrow(RuntimeException::new);
+		}
+
+		@Override
+		public Bits componentBits() {
+			return componentType.bits();
 		}
 	}
 
@@ -126,6 +138,11 @@ public abstract class ModelComponentReference<T> {
 			}
 
 			@Override
+			public Bits componentBits() {
+				return delegate.componentBits();
+			}
+
+			@Override
 			public boolean isSatisfiedBy(ModelComponentTypes componentTypes) {
 				return ((ModelComponentReferenceInternal) delegate).isSatisfiedBy(componentTypes);
 			}
@@ -140,6 +157,11 @@ public abstract class ModelComponentReference<T> {
 			@Override
 			public T get(ModelNode entity) {
 				return ModelNodeUtils.get(entity, projectionType);
+			}
+
+			@Override
+			public Bits componentBits() {
+				return delegate.componentBits();
 			}
 
 			@Override
@@ -160,6 +182,11 @@ public abstract class ModelComponentReference<T> {
 			}
 
 			@Override
+			public Bits componentBits() {
+				return delegate.componentBits();
+			}
+
+			@Override
 			public boolean isSatisfiedBy(ModelComponentTypes componentTypes) {
 				return ((ModelComponentReferenceInternal) delegate).isSatisfiedBy(componentTypes);
 			}
@@ -174,6 +201,11 @@ public abstract class ModelComponentReference<T> {
 			@Override
 			public KnownDomainObject<T> get(ModelNode entity) {
 				return DefaultKnownDomainObject.of(ModelType.of(projectionType), entity);
+			}
+
+			@Override
+			public Bits componentBits() {
+				return delegate.componentBits();
 			}
 
 			@Override
@@ -196,6 +228,11 @@ public abstract class ModelComponentReference<T> {
 		@Override
 		public ModelProjection get(ModelNode entity) {
 			return delegate.get(entity);
+		}
+
+		@Override
+		public Bits componentBits() {
+			return delegate.componentBits();
 		}
 
 		@Override

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelComponentType.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelComponentType.java
@@ -59,6 +59,8 @@ public abstract class ModelComponentType<T> {
 
 	public abstract Bits familyBits();
 
+	public abstract Bits bits();
+
 	@SuppressWarnings("unchecked")
 	public static <T> ModelComponentType<? super T> ofInstance(T component) {
 		Objects.requireNonNull(component);
@@ -96,6 +98,11 @@ public abstract class ModelComponentType<T> {
 		public Bits familyBits() {
 			return assignedComponentTypeFamilies.getUnchecked(value);
 		}
+
+		@Override
+		public Bits bits() {
+			return assignedComponentTypes.getUnchecked(value);
+		}
 	}
 
 	@Value
@@ -114,6 +121,11 @@ public abstract class ModelComponentType<T> {
 		@Override
 		public Bits familyBits() {
 			return assignedComponentTypeFamilies.getUnchecked(value).or(assignedComponentTypes.getUnchecked(ModelProjection.class));
+		}
+
+		@Override
+		public Bits bits() {
+			return assignedComponentTypes.getUnchecked(value).or(assignedComponentTypes.getUnchecked(ModelProjection.class));
 		}
 	}
 }

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelComponentType.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelComponentType.java
@@ -52,6 +52,11 @@ public abstract class ModelComponentType<T> {
 		@Override
 		public void visitType(ModelType<? super Object> type) {
 			result = result.or(assignedComponentTypes.getUnchecked(type.getType()));
+			if (type.isParameterized()) {
+				// This account for HasNativeCompileTask<CppCompileTask> && HasNativeCompileTask.
+				//    However, it won't account for HasNativeCompileTask<? extends SourceCompile> matching HasNativeCompileTask<CppCompileTask>
+				result = result.or(assignedComponentTypes.getUnchecked(type.getRawType()));
+			}
 		}
 	}
 

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelDiscoverAction.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelDiscoverAction.java
@@ -32,10 +32,12 @@ public abstract class ModelDiscoverAction implements ModelAction, HasInputs {
 
 	@Override
 	public final void execute(ModelNode node) {
-		// TODO: Should be discovered
-		if (ModelStates.getState(node).equals(ModelState.Registered)) {
-			// NOTE: The contextual node should not be accessed from the action, it's simply for contextualizing the action execution.
-			ModelNodeContext.of(node).execute(() -> execute(new Context(node)));
+		if (node.getComponentBits().containsAll(inputBits)) {
+			// TODO: Should be discovered
+			if (ModelStates.getState(node).equals(ModelState.Registered)) {
+				// NOTE: The contextual node should not be accessed from the action, it's simply for contextualizing the action execution.
+				ModelNodeContext.of(node).execute(() -> execute(new Context(node)));
+			}
 		}
 	}
 

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelDiscoverAction.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelDiscoverAction.java
@@ -27,6 +27,8 @@ import java.util.List;
 import static com.google.common.base.Preconditions.checkArgument;
 
 public abstract class ModelDiscoverAction implements ModelAction, HasInputs {
+	private final List<ModelComponentReference<?>> inputs = ImmutableList.of(ModelComponentReference.of(ModelState.class));
+
 	@Override
 	public final void execute(ModelNode node) {
 		// TODO: Should be discovered
@@ -38,7 +40,7 @@ public abstract class ModelDiscoverAction implements ModelAction, HasInputs {
 
 	@Override
 	public List<? extends ModelComponentReference<?>> getInputs() {
-		return ImmutableList.of(ModelComponentReference.of(ModelState.class));
+		return inputs;
 	}
 
 	protected abstract void execute(Context context);

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelDiscoverAction.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelDiscoverAction.java
@@ -28,6 +28,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 public abstract class ModelDiscoverAction implements ModelAction, HasInputs {
 	private final List<ModelComponentReference<?>> inputs = ImmutableList.of(ModelComponentReference.of(ModelState.class));
+	private final Bits inputBits = inputs.stream().map(ModelComponentReference::componentBits).reduce(Bits.empty(), Bits::or);
 
 	@Override
 	public final void execute(ModelNode node) {
@@ -41,6 +42,11 @@ public abstract class ModelDiscoverAction implements ModelAction, HasInputs {
 	@Override
 	public List<? extends ModelComponentReference<?>> getInputs() {
 		return inputs;
+	}
+
+	@Override
+	public Bits getInputBits() {
+		return inputBits;
 	}
 
 	protected abstract void execute(Context context);

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelElements.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelElements.java
@@ -34,19 +34,21 @@ public final class ModelElements {
 
 	private static final class WhenElementDiscoveredAction implements ModelAction, HasInputs {
 		private final ModelAction delegate;
+		private final List<ModelComponentReference<?>> inputs;
 
 		private WhenElementDiscoveredAction(ModelAction delegate) {
 			this.delegate = delegate;
-		}
-
-		@Override
-		public List<? extends ModelComponentReference<?>> getInputs() {
 			val builder = ImmutableList.<ModelComponentReference<?>>builder();
 			builder.add(ModelComponentReference.of(ModelState.IsAtLeastRegistered.class));
 			if (delegate instanceof HasInputs) {
 				builder.addAll(((HasInputs) delegate).getInputs());
 			}
-			return builder.build();
+			this.inputs = builder.build();
+		}
+
+		@Override
+		public List<? extends ModelComponentReference<?>> getInputs() {
+			return inputs;
 		}
 
 		@Override

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelElements.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelElements.java
@@ -60,7 +60,9 @@ public final class ModelElements {
 
 		@Override
 		public void execute(ModelNode node) {
-			delegate.execute(node);
+			if (node.getComponentBits().containsAll(inputBits)) {
+				delegate.execute(node);
+			}
 		}
 	}
 }

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelElements.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelElements.java
@@ -35,6 +35,7 @@ public final class ModelElements {
 	private static final class WhenElementDiscoveredAction implements ModelAction, HasInputs {
 		private final ModelAction delegate;
 		private final List<ModelComponentReference<?>> inputs;
+		private final Bits inputBits;
 
 		private WhenElementDiscoveredAction(ModelAction delegate) {
 			this.delegate = delegate;
@@ -44,11 +45,17 @@ public final class ModelElements {
 				builder.addAll(((HasInputs) delegate).getInputs());
 			}
 			this.inputs = builder.build();
+			this.inputBits = inputs.stream().map(ModelComponentReference::componentBits).reduce(Bits.empty(), Bits::or);
 		}
 
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
 			return inputs;
+		}
+
+		@Override
+		public Bits getInputBits() {
+			return inputBits;
 		}
 
 		@Override

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelInitializerAction.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelInitializerAction.java
@@ -32,9 +32,11 @@ public abstract class ModelInitializerAction implements ModelAction, HasInputs {
 
 	@Override
 	public final void execute(ModelNode node) {
-		if (ModelStates.getState(node).equals(ModelState.Created)) {
-			// NOTE: The contextual node should not be accessed from the action, it's simply for contextualizing the action execution.
-			ModelNodeContext.of(node).execute(() -> execute(new Context(node)));
+		if (node.getComponentBits().containsAll(inputBits)) {
+			if (ModelStates.getState(node).equals(ModelState.Created)) {
+				// NOTE: The contextual node should not be accessed from the action, it's simply for contextualizing the action execution.
+				ModelNodeContext.of(node).execute(() -> execute(new Context(node)));
+			}
 		}
 	}
 

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelInitializerAction.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelInitializerAction.java
@@ -28,6 +28,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 public abstract class ModelInitializerAction implements ModelAction, HasInputs {
 	private final List<ModelComponentReference<?>> inputs = ImmutableList.of(ModelComponentReference.of(ModelState.class), ModelComponentReference.of(BindManagedProjectionService.class));
+	private final Bits inputBits = inputs.stream().map(ModelComponentReference::componentBits).reduce(Bits.empty(), Bits::or);
 
 	@Override
 	public final void execute(ModelNode node) {
@@ -40,6 +41,11 @@ public abstract class ModelInitializerAction implements ModelAction, HasInputs {
 	@Override
 	public List<? extends ModelComponentReference<?>> getInputs() {
 		return inputs;
+	}
+
+	@Override
+	public Bits getInputBits() {
+		return inputBits;
 	}
 
 	public abstract void execute(Context context);

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelInitializerAction.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelInitializerAction.java
@@ -27,6 +27,8 @@ import java.util.List;
 import static com.google.common.base.Preconditions.checkArgument;
 
 public abstract class ModelInitializerAction implements ModelAction, HasInputs {
+	private final List<ModelComponentReference<?>> inputs = ImmutableList.of(ModelComponentReference.of(ModelState.class), ModelComponentReference.of(BindManagedProjectionService.class));
+
 	@Override
 	public final void execute(ModelNode node) {
 		if (ModelStates.getState(node).equals(ModelState.Created)) {
@@ -37,7 +39,7 @@ public abstract class ModelInitializerAction implements ModelAction, HasInputs {
 
 	@Override
 	public List<? extends ModelComponentReference<?>> getInputs() {
-		return ImmutableList.of(ModelComponentReference.of(ModelState.class), ModelComponentReference.of(BindManagedProjectionService.class));
+		return inputs;
 	}
 
 	public abstract void execute(Context context);

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelMutateAction.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelMutateAction.java
@@ -30,8 +30,10 @@ public abstract class ModelMutateAction implements ModelAction, HasInputs {
 
 	@Override
 	public void execute(ModelNode node) {
-		if (ModelStates.getState(node).equals(ModelState.Realized)) {
-			ModelNodeContext.of(node).execute(() -> execute(new Context(node)));
+		if (node.getComponentBits().containsAll(inputBits)) {
+			if (ModelStates.getState(node).equals(ModelState.Realized)) {
+				ModelNodeContext.of(node).execute(() -> execute(new Context(node)));
+			}
 		}
 	}
 

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelMutateAction.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelMutateAction.java
@@ -25,6 +25,8 @@ import java.util.List;
 import static com.google.common.base.Preconditions.checkArgument;
 
 public abstract class ModelMutateAction implements ModelAction, HasInputs {
+	private final List<ModelComponentReference<?>> inputs = ImmutableList.of(ModelComponentReference.of(ModelState.class));
+
 	@Override
 	public void execute(ModelNode node) {
 		if (ModelStates.getState(node).equals(ModelState.Realized)) {
@@ -34,7 +36,7 @@ public abstract class ModelMutateAction implements ModelAction, HasInputs {
 
 	@Override
 	public List<? extends ModelComponentReference<?>> getInputs() {
-		return ImmutableList.of(ModelComponentReference.of(ModelState.class));
+		return inputs;
 	}
 
 	public abstract void execute(Context context);

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelMutateAction.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelMutateAction.java
@@ -26,6 +26,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 public abstract class ModelMutateAction implements ModelAction, HasInputs {
 	private final List<ModelComponentReference<?>> inputs = ImmutableList.of(ModelComponentReference.of(ModelState.class));
+	private final Bits inputBits = inputs.stream().map(ModelComponentReference::componentBits).reduce(Bits.empty(), Bits::or);
 
 	@Override
 	public void execute(ModelNode node) {
@@ -37,6 +38,11 @@ public abstract class ModelMutateAction implements ModelAction, HasInputs {
 	@Override
 	public List<? extends ModelComponentReference<?>> getInputs() {
 		return inputs;
+	}
+
+	@Override
+	public Bits getInputBits() {
+		return inputBits;
 	}
 
 	public abstract void execute(Context context);

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelNode.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelNode.java
@@ -121,7 +121,7 @@ public final class ModelNode {
 		return components.containsKey(componentType);
 	}
 
-	public <T> void setComponent(Class<T> componentTypez, T component) {
+	public <T> void setComponent(Class<T> componentType, T component) {
 		setComponent(component);
 	}
 

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelNodes.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelNodes.java
@@ -56,10 +56,19 @@ public final class ModelNodes {
 	private static final class AndPredicate extends AbstractModelNodePredicate implements HasInputs {
 		private final Predicate<? super ModelNode> first;
 		private final Predicate<? super ModelNode> second;
+		private final List<ModelComponentReference<?>> inputs;
 
 		public AndPredicate(Predicate<? super ModelNode> first, Predicate<? super ModelNode> second) {
 			this.first = requireNonNull(first);
 			this.second = requireNonNull(second);
+			val builder = ImmutableList.<ModelComponentReference<?>>builder();
+			if (first instanceof HasInputs) {
+				builder.addAll(((HasInputs) first).getInputs());
+			}
+			if (second instanceof HasInputs) {
+				builder.addAll(((HasInputs) second).getInputs());
+			}
+			this.inputs = builder.build();
 		}
 
 		@Override
@@ -69,14 +78,7 @@ public final class ModelNodes {
 
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
-			val builder = ImmutableList.<ModelComponentReference<?>>builder();
-			if (first instanceof HasInputs) {
-				builder.addAll(((HasInputs) first).getInputs());
-			}
-			if (second instanceof HasInputs) {
-				builder.addAll(((HasInputs) second).getInputs());
-			}
-			return builder.build();
+			return inputs;
 		}
 
 		@Override
@@ -148,9 +150,11 @@ public final class ModelNodes {
 	@EqualsAndHashCode(callSuper = false)
 	private static final class WithTypePredicate extends AbstractModelNodePredicate implements HasInputs {
 		private final ModelType<?> type;
+		private final List<ModelComponentReference<?>> inputs;
 
 		private WithTypePredicate(ModelType<?> type) {
 			this.type = requireNonNull(type);
+			this.inputs = ImmutableList.of(ModelComponentReference.ofAny(projectionOf(type.getConcreteType())));
 		}
 
 		@Override
@@ -160,7 +164,7 @@ public final class ModelNodes {
 
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
-			return ImmutableList.of(ModelComponentReference.ofAny(projectionOf(type.getConcreteType())));
+			return inputs;
 		}
 
 		@Override
@@ -182,9 +186,11 @@ public final class ModelNodes {
 	@EqualsAndHashCode(callSuper = false)
 	private static final class StateAtLeastPredicate extends AbstractModelNodePredicate implements HasInputs {
 		private final ModelState state;
+		private final List<ModelComponentReference<?>> inputs;
 
 		private StateAtLeastPredicate(ModelState state) {
 			this.state = requireNonNull(state);
+			this.inputs = ImmutableList.of(ModelComponentReference.of(ModelState.class));
 		}
 
 		@Override
@@ -199,7 +205,7 @@ public final class ModelNodes {
 
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
-			return ImmutableList.of(ModelComponentReference.of(ModelState.class));
+			return inputs;
 		}
 	}
 
@@ -210,9 +216,11 @@ public final class ModelNodes {
 	@EqualsAndHashCode(callSuper = false)
 	private static final class StateOfPredicate extends AbstractModelNodePredicate implements HasInputs {
 		private final ModelState state;
+		private final List<ModelComponentReference<?>> inputs;
 
 		private StateOfPredicate(ModelState state) {
 			this.state = requireNonNull(state);
+			this.inputs = ImmutableList.of(ModelComponentReference.of(ModelState.class));
 		}
 
 		@Override
@@ -222,7 +230,7 @@ public final class ModelNodes {
 
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
-			return ImmutableList.of(ModelComponentReference.of(ModelState.class));
+			return inputs;
 		}
 
 		@Override
@@ -246,10 +254,17 @@ public final class ModelNodes {
 	private static final class SatisfiedByProjectionSpecAdapter<T> extends AbstractModelNodePredicate implements HasInputs {
 		private final ModelType<T> type;
 		private final Spec<? super T> spec;
+		private final List<ModelComponentReference<?>> inputs;
 
 		private SatisfiedByProjectionSpecAdapter(ModelType<T> type, Spec<? super T> spec) {
 			this.type = requireNonNull(type);
 			this.spec = requireNonNull(spec);
+			val builder = ImmutableList.<ModelComponentReference<?>>builder();
+			builder.add(ModelComponentReference.ofAny(projectionOf(type.getConcreteType())));
+			if (spec instanceof HasInputs) {
+				builder.addAll(((HasInputs) spec).getInputs());
+			}
+			this.inputs = builder.build();
 		}
 
 		@Override
@@ -259,12 +274,7 @@ public final class ModelNodes {
 
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
-			val builder = ImmutableList.<ModelComponentReference<?>>builder();
-			builder.add(ModelComponentReference.ofAny(projectionOf(type.getConcreteType())));
-			if (spec instanceof HasInputs) {
-				builder.addAll(((HasInputs) spec).getInputs());
-			}
-			return builder.build();
+			return inputs;
 		}
 
 		@Override
@@ -287,9 +297,11 @@ public final class ModelNodes {
 	@EqualsAndHashCode(callSuper = false)
 	private static final class WithParentPredicate extends AbstractModelNodePredicate implements HasInputs {
 		private final ModelPath parentPath;
+		private final List<ModelComponentReference<?>> inputs;
 
 		public WithParentPredicate(ModelPath parentPath) {
 			this.parentPath = requireNonNull(parentPath);
+			this.inputs = ImmutableList.of(ModelComponentReference.of(ModelPath.class));
 		}
 
 		@Override
@@ -300,7 +312,7 @@ public final class ModelNodes {
 
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
-			return ImmutableList.of(ModelComponentReference.of(ModelPath.class));
+			return inputs;
 		}
 
 		@Override
@@ -316,9 +328,11 @@ public final class ModelNodes {
 	@EqualsAndHashCode(callSuper = false)
 	private static final class DescendantOfPredicate extends AbstractModelNodePredicate implements HasInputs {
 		private final ModelPath ancestorPath;
+		private final List<ModelComponentReference<?>> inputs;
 
 		public DescendantOfPredicate(ModelPath ancestorPath) {
 			this.ancestorPath = requireNonNull(ancestorPath);
+			this.inputs = ImmutableList.of(ModelComponentReference.of(ModelPath.class));
 		}
 
 		@Override
@@ -328,7 +342,7 @@ public final class ModelNodes {
 
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
-			return ImmutableList.of(ModelComponentReference.of(ModelPath.class));
+			return inputs;
 		}
 
 		@Override
@@ -363,9 +377,11 @@ public final class ModelNodes {
 	@EqualsAndHashCode(callSuper = false)
 	private static final class WithPathPredicate extends AbstractModelNodePredicate implements HasInputs {
 		private final ModelPath path;
+		private final List<ModelComponentReference<?>> inputs;
 
 		public WithPathPredicate(ModelPath path) {
 			this.path = requireNonNull(path);
+			this.inputs = ImmutableList.of(ModelComponentReference.of(ModelPath.class));
 		}
 
 		@Override
@@ -375,7 +391,7 @@ public final class ModelNodes {
 
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
-			return ImmutableList.of(ModelComponentReference.of(ModelPath.class));
+			return inputs;
 		}
 
 		@Override

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelNodes.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelNodes.java
@@ -27,9 +27,7 @@ import org.gradle.api.specs.Spec;
 import java.util.List;
 import java.util.function.Predicate;
 
-import static dev.nokee.model.internal.core.ModelComponentType.componentOf;
 import static dev.nokee.model.internal.core.ModelComponentType.projectionOf;
-import static dev.nokee.model.internal.core.ModelComponentReference.ofInstance;
 import static dev.nokee.model.internal.state.ModelState.Realized;
 import static dev.nokee.model.internal.state.ModelState.Registered;
 import static java.util.Objects.requireNonNull;

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelNodes.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelNodes.java
@@ -56,6 +56,7 @@ public final class ModelNodes {
 	private static final class AndPredicate extends AbstractModelNodePredicate implements HasInputs {
 		private final Predicate<? super ModelNode> first;
 		private final Predicate<? super ModelNode> second;
+		private final Bits inputBits;
 		private final List<ModelComponentReference<?>> inputs;
 
 		public AndPredicate(Predicate<? super ModelNode> first, Predicate<? super ModelNode> second) {
@@ -69,6 +70,7 @@ public final class ModelNodes {
 				builder.addAll(((HasInputs) second).getInputs());
 			}
 			this.inputs = builder.build();
+			this.inputBits = inputs.stream().map(ModelComponentReference::componentBits).reduce(Bits.empty(), Bits::or);
 		}
 
 		@Override
@@ -79,6 +81,11 @@ public final class ModelNodes {
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
 			return inputs;
+		}
+
+		@Override
+		public Bits getInputBits() {
+			return inputBits;
 		}
 
 		@Override
@@ -151,10 +158,12 @@ public final class ModelNodes {
 	private static final class WithTypePredicate extends AbstractModelNodePredicate implements HasInputs {
 		private final ModelType<?> type;
 		private final List<ModelComponentReference<?>> inputs;
+		private final Bits inputBits;
 
 		private WithTypePredicate(ModelType<?> type) {
 			this.type = requireNonNull(type);
 			this.inputs = ImmutableList.of(ModelComponentReference.ofAny(projectionOf(type.getConcreteType())));
+			this.inputBits = inputs.stream().map(ModelComponentReference::componentBits).reduce(Bits.empty(), Bits::or);
 		}
 
 		@Override
@@ -165,6 +174,11 @@ public final class ModelNodes {
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
 			return inputs;
+		}
+
+		@Override
+		public Bits getInputBits() {
+			return inputBits;
 		}
 
 		@Override
@@ -187,10 +201,12 @@ public final class ModelNodes {
 	private static final class StateAtLeastPredicate extends AbstractModelNodePredicate implements HasInputs {
 		private final ModelState state;
 		private final List<ModelComponentReference<?>> inputs;
+		private final Bits inputBits;
 
 		private StateAtLeastPredicate(ModelState state) {
 			this.state = requireNonNull(state);
 			this.inputs = ImmutableList.of(ModelComponentReference.of(ModelState.class));
+			this.inputBits = inputs.stream().map(ModelComponentReference::componentBits).reduce(Bits.empty(), Bits::or);
 		}
 
 		@Override
@@ -207,6 +223,11 @@ public final class ModelNodes {
 		public List<? extends ModelComponentReference<?>> getInputs() {
 			return inputs;
 		}
+
+		@Override
+		public Bits getInputBits() {
+			return inputBits;
+		}
 	}
 
 	public static Predicate<ModelNode> stateOf(ModelState state) {
@@ -217,10 +238,12 @@ public final class ModelNodes {
 	private static final class StateOfPredicate extends AbstractModelNodePredicate implements HasInputs {
 		private final ModelState state;
 		private final List<ModelComponentReference<?>> inputs;
+		private final Bits inputBits;
 
 		private StateOfPredicate(ModelState state) {
 			this.state = requireNonNull(state);
 			this.inputs = ImmutableList.of(ModelComponentReference.of(ModelState.class));
+			this.inputBits = inputs.stream().map(ModelComponentReference::componentBits).reduce(Bits.empty(), Bits::or);
 		}
 
 		@Override
@@ -231,6 +254,11 @@ public final class ModelNodes {
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
 			return inputs;
+		}
+
+		@Override
+		public Bits getInputBits() {
+			return inputBits;
 		}
 
 		@Override
@@ -255,6 +283,7 @@ public final class ModelNodes {
 		private final ModelType<T> type;
 		private final Spec<? super T> spec;
 		private final List<ModelComponentReference<?>> inputs;
+		private final Bits inputBits;
 
 		private SatisfiedByProjectionSpecAdapter(ModelType<T> type, Spec<? super T> spec) {
 			this.type = requireNonNull(type);
@@ -265,6 +294,7 @@ public final class ModelNodes {
 				builder.addAll(((HasInputs) spec).getInputs());
 			}
 			this.inputs = builder.build();
+			this.inputBits = inputs.stream().map(ModelComponentReference::componentBits).reduce(Bits.empty(), Bits::or);
 		}
 
 		@Override
@@ -275,6 +305,11 @@ public final class ModelNodes {
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
 			return inputs;
+		}
+
+		@Override
+		public Bits getInputBits() {
+			return inputBits;
 		}
 
 		@Override
@@ -298,10 +333,12 @@ public final class ModelNodes {
 	private static final class WithParentPredicate extends AbstractModelNodePredicate implements HasInputs {
 		private final ModelPath parentPath;
 		private final List<ModelComponentReference<?>> inputs;
+		private final Bits inputBits;
 
 		public WithParentPredicate(ModelPath parentPath) {
 			this.parentPath = requireNonNull(parentPath);
 			this.inputs = ImmutableList.of(ModelComponentReference.of(ModelPath.class));
+			this.inputBits = inputs.stream().map(ModelComponentReference::componentBits).reduce(Bits.empty(), Bits::or);
 		}
 
 		@Override
@@ -313,6 +350,11 @@ public final class ModelNodes {
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
 			return inputs;
+		}
+
+		@Override
+		public Bits getInputBits() {
+			return inputBits;
 		}
 
 		@Override
@@ -329,10 +371,12 @@ public final class ModelNodes {
 	private static final class DescendantOfPredicate extends AbstractModelNodePredicate implements HasInputs {
 		private final ModelPath ancestorPath;
 		private final List<ModelComponentReference<?>> inputs;
+		private final Bits inputBits;
 
 		public DescendantOfPredicate(ModelPath ancestorPath) {
 			this.ancestorPath = requireNonNull(ancestorPath);
 			this.inputs = ImmutableList.of(ModelComponentReference.of(ModelPath.class));
+			this.inputBits = inputs.stream().map(ModelComponentReference::componentBits).reduce(Bits.empty(), Bits::or);
 		}
 
 		@Override
@@ -343,6 +387,11 @@ public final class ModelNodes {
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
 			return inputs;
+		}
+
+		@Override
+		public Bits getInputBits() {
+			return inputBits;
 		}
 
 		@Override
@@ -378,10 +427,12 @@ public final class ModelNodes {
 	private static final class WithPathPredicate extends AbstractModelNodePredicate implements HasInputs {
 		private final ModelPath path;
 		private final List<ModelComponentReference<?>> inputs;
+		private final Bits inputBits;
 
 		public WithPathPredicate(ModelPath path) {
 			this.path = requireNonNull(path);
 			this.inputs = ImmutableList.of(ModelComponentReference.of(ModelPath.class));
+			this.inputBits = inputs.stream().map(ModelComponentReference::componentBits).reduce(Bits.empty(), Bits::or);
 		}
 
 		@Override
@@ -392,6 +443,11 @@ public final class ModelNodes {
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
 			return inputs;
+		}
+
+		@Override
+		public Bits getInputBits() {
+			return inputBits;
 		}
 
 		@Override

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelSpecs.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelSpecs.java
@@ -81,6 +81,7 @@ public final class ModelSpecs {
 	private static final class OfPredicateModelSpec implements ModelSpec, HasInputs {
 		private final Predicate<? super ModelNode> predicate;
 		private final List<ModelComponentReference<?>> inputs;
+		private final Bits inputBits;
 
 		public OfPredicateModelSpec(Predicate<? super ModelNode> predicate) {
 			this.predicate = predicate;
@@ -89,6 +90,7 @@ public final class ModelSpecs {
 			} else {
 				this.inputs = ImmutableList.of();
 			}
+			this.inputBits = inputs.stream().map(ModelComponentReference::componentBits).reduce(Bits.empty(), Bits::or);
 		}
 
 		@Override
@@ -99,6 +101,11 @@ public final class ModelSpecs {
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
 			return inputs;
+		}
+
+		@Override
+		public Bits getInputBits() {
+			return inputBits;
 		}
 
 		@Override

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelSpecs.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelSpecs.java
@@ -80,9 +80,15 @@ public final class ModelSpecs {
 	@EqualsAndHashCode
 	private static final class OfPredicateModelSpec implements ModelSpec, HasInputs {
 		private final Predicate<? super ModelNode> predicate;
+		private final List<ModelComponentReference<?>> inputs;
 
 		public OfPredicateModelSpec(Predicate<? super ModelNode> predicate) {
 			this.predicate = predicate;
+			if (predicate instanceof HasInputs) {
+				this.inputs = ImmutableList.copyOf(((HasInputs) predicate).getInputs());
+			} else {
+				this.inputs = ImmutableList.of();
+			}
 		}
 
 		@Override
@@ -92,11 +98,7 @@ public final class ModelSpecs {
 
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
-			if (predicate instanceof HasInputs) {
-				return ((HasInputs) predicate).getInputs();
-			} else {
-				return ImmutableList.of();
-			}
+			return inputs;
 		}
 
 		@Override

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/NodePredicate.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/NodePredicate.java
@@ -203,6 +203,7 @@ public abstract class NodePredicate {
 		private final Predicate<? super ModelNode> matcher;
 		@EqualsAndHashCode.Exclude private final Predicate<? super ModelNode> predicate;
 		private final List<ModelComponentReference<?>> inputs;
+		private final Bits inputBits;
 
 		public BasicPredicateSpec(@Nullable ModelPath path, @Nullable ModelPath parent, @Nullable ModelPath ancestor, Predicate<? super ModelNode> matcher) {
 			this.path = path;
@@ -215,11 +216,17 @@ public abstract class NodePredicate {
 			} else {
 				this.inputs = ImmutableList.of();
 			}
+			this.inputBits = inputs.stream().map(ModelComponentReference::componentBits).reduce(Bits.empty(), Bits::or);
 		}
 
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
 			return inputs;
+		}
+
+		@Override
+		public Bits getInputBits() {
+			return inputBits;
 		}
 
 		@Override

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/NodePredicate.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/NodePredicate.java
@@ -202,6 +202,7 @@ public abstract class NodePredicate {
 		private final ModelPath ancestor;
 		private final Predicate<? super ModelNode> matcher;
 		@EqualsAndHashCode.Exclude private final Predicate<? super ModelNode> predicate;
+		private final List<ModelComponentReference<?>> inputs;
 
 		public BasicPredicateSpec(@Nullable ModelPath path, @Nullable ModelPath parent, @Nullable ModelPath ancestor, Predicate<? super ModelNode> matcher) {
 			this.path = path;
@@ -209,15 +210,16 @@ public abstract class NodePredicate {
 			this.ancestor = ancestor;
 			this.matcher = matcher;
 			this.predicate = matcher;
+			if (matcher instanceof HasInputs) {
+				this.inputs = ImmutableList.copyOf(((HasInputs) matcher).getInputs());
+			} else {
+				this.inputs = ImmutableList.of();
+			}
 		}
 
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
-			if (matcher instanceof HasInputs) {
-				return ((HasInputs) matcher).getInputs();
-			} else {
-				return ImmutableList.of();
-			}
+			return inputs;
 		}
 
 		@Override

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/registry/DefaultModelRegistry.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/registry/DefaultModelRegistry.java
@@ -146,15 +146,7 @@ public final class DefaultModelRegistry implements ModelRegistry, ModelConfigure
 		val size = entities.size();
 		for (int i = 0; i < size; i++) {
 			val node = entities.get(i);
-			if (configuration instanceof HasInputs) {
-				if (node.getComponentBits().containsAll(((HasInputs) configuration).getInputBits())) {
-					configuration.execute(node);
-				} else if (((HasInputs) configuration).getInputBits().isEmpty()) {
-					configuration.execute(node);
-				}
-			} else {
-				configuration.execute(node);
-			}
+			configuration.execute(node);
 		}
 	}
 
@@ -165,9 +157,7 @@ public final class DefaultModelRegistry implements ModelRegistry, ModelConfigure
 			for (int i = 0; i < configurations.size(); ++i) {
 				val configuration = configurations.get(i);
 				if (configuration instanceof HasInputs) {
-					if (newComponentBits.intersects(((HasInputs) configuration).getInputBits()) && node.getComponentBits().containsAll(((HasInputs) configuration).getInputBits())) {
-						configuration.execute(node);
-					} else if (((HasInputs) configuration).getInputBits().isEmpty()) {
+					if (newComponentBits.intersects(((HasInputs) configuration).getInputBits())) {
 						configuration.execute(node);
 					}
 				} else {

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/registry/DefaultModelRegistry.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/registry/DefaultModelRegistry.java
@@ -146,8 +146,12 @@ public final class DefaultModelRegistry implements ModelRegistry, ModelConfigure
 		val size = entities.size();
 		for (int i = 0; i < size; i++) {
 			val node = entities.get(i);
-			if (configuration instanceof HasInputs && node.getComponentBits().containsAll(((HasInputs) configuration).getInputBits())) {
-				configuration.execute(node);
+			if (configuration instanceof HasInputs) {
+				if (node.getComponentBits().containsAll(((HasInputs) configuration).getInputBits())) {
+					configuration.execute(node);
+				} else if (((HasInputs) configuration).getInputBits().isEmpty()) {
+					configuration.execute(node);
+				}
 			} else {
 				configuration.execute(node);
 			}
@@ -157,8 +161,7 @@ public final class DefaultModelRegistry implements ModelRegistry, ModelConfigure
 	private final class NodeStateListener implements ModelNodeListener {
 		@Override
 		public void projectionAdded(ModelNode node, Object newComponent) {
-			Bits newComponentBits = ModelComponentType.assignedComponentTypeFamilies
-				.getUnchecked(ModelType.typeOf(newComponent).getType());
+			Bits newComponentBits = ModelComponentType.ofInstance(newComponent).familyBits();
 			for (int i = 0; i < configurations.size(); ++i) {
 				val configuration = configurations.get(i);
 				if (configuration instanceof HasInputs) {

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/type/ModelTypeUtils.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/type/ModelTypeUtils.java
@@ -15,8 +15,16 @@
  */
 package dev.nokee.model.internal.type;
 
+import java.util.concurrent.ConcurrentHashMap;
+
 public final class ModelTypeUtils {
+	private static final ConcurrentHashMap<Class<?>, Class<?>> undecoratedTypes = new ConcurrentHashMap<>();
+
 	public static Class<?> toUndecoratedType(Class<?> type) {
+		return undecoratedTypes.computeIfAbsent(type, ModelTypeUtils::computeUndecoratedType);
+	}
+
+	private static Class<?> computeUndecoratedType(Class<?> type) {
 		if (type.getSimpleName().endsWith("_Decorated")) {
 			if (type.getSuperclass().equals(Object.class)) {
 				return type.getInterfaces()[0];

--- a/subprojects/core-model/src/test/groovy/dev/nokee/internal/BitOneTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/internal/BitOneTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.internal;
+
+import dev.nokee.model.internal.core.Bit;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasToString;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BitOneTest {
+	@Test
+	void hasOneDigitToString() {
+		assertThat(Bit.One, hasToString("1"));
+	}
+
+	@Test
+	void isSet() {
+		assertTrue(Bit.One.isSet());
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/internal/BitZeroTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/internal/BitZeroTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.internal;
+
+import dev.nokee.model.internal.core.Bit;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasToString;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class BitZeroTest {
+	@Test
+	void hasZeroDigitToString() {
+		assertThat(Bit.Zero, hasToString("0"));
+	}
+
+	@Test
+	void isNotSet() {
+		assertFalse(Bit.Zero.isSet());
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/internal/BitsEmptyTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/internal/BitsEmptyTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.internal;
+
+import dev.nokee.internal.testing.Assumptions;
+import dev.nokee.model.internal.core.Bits;
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.model.internal.core.Bits.empty;
+import static dev.nokee.model.internal.core.Bits.ofBits;
+import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BitsEmptyTest implements BitsTester {
+	@Override
+	public Bits subject() {
+		return empty();
+	}
+
+	@Override
+	public Bits unsetBits() {
+		return ofBits(0xB0B);
+	}
+
+	@Override
+	public Bits setBits() {
+		return Assumptions.skipCurrentTestExecution("no bits is set on empty bits");
+	}
+
+	//	@Test
+//	void canCreateEmptyBitsUsingZeroWord() {
+//		assertEquals(empty(), Bits.ofBits(0));
+//	}
+
+	@Test
+	void alwaysEmpty() {
+		assertTrue(empty().isEmpty());
+	}
+
+	@Test
+	void alwaysHasZeroLength() {
+		assertEquals(0, empty().length());
+	}
+
+//	@Test
+//	void alwaysReturnsEmptyBitsOnAndOperation() {
+//		assertAll(
+//			() -> assertEquals(empty(), empty().and(empty()), "when other is empty bits"),
+//			() -> assertEquals(empty(), empty().or(nthBit(7)), "when other is single bit bits"),
+//			() -> assertEquals(empty(), empty().or(ofBits(0b10110)), "when other is single word bits")
+//		);
+//	}
+
+//	@Test
+//	void alwaysReturnsOtherBitsOnOrOperation() {
+//		assertAll(
+//			() -> assertEquals(empty(), empty().or(empty()), "when other is empty bits"),
+//			() -> assertEquals(nthBit(9), empty().or(nthBit(9)), "when other is single bit bits"),
+//			() -> assertEquals(ofBits(0b101), empty().or(ofBits(0b101)), "when other is single word bits")
+//		);
+//	}
+//
+//	@Test
+//	void alwaysReturnsEmptyBitsOnRightShiftOperation() {
+//		assertAll(
+//			() -> assertEquals(empty(), empty().rightShift(0), "when shifting by zero bit"),
+//			() -> assertEquals(empty(), empty().rightShift(16), "when shifting by number of bit in short"),
+//			() -> assertEquals(empty(), empty().rightShift(32), "when shifting by number of bit in integer"),
+//			() -> assertEquals(empty(), empty().rightShift(64), "when shifting by number of bit in long"),
+//			() -> assertEquals(empty(), empty().rightShift(128), "when shifting by number of bit in long long"),
+//			() -> assertEquals(empty(), empty().rightShift(MAX_VALUE), "when shifting by unreasonable number of bits")
+//		);
+//	}
+//
+//	@Test
+//	void throwsExceptionOnRightShiftOfNegativeValue() {
+//		val ex = assertThrows(IllegalArgumentException.class, () -> empty().rightShift(-42));
+//		assertEquals("Bit shift 'count' (-42) must be positive.", ex.getMessage());
+//	}
+
+//	@Test
+//	void throwsExceptionWhenOtherBitsIsNullDuringAndOperation() {
+//		assertThrows(NullPointerException.class, () -> empty().and(null));
+//	}
+//
+//	@Test
+//	void throwsExceptionWhenOtherBitsIsNullDuringOrOperation() {
+//		assertThrows(NullPointerException.class, () -> empty().or(null));
+//	}
+
+	@Test
+	void returnsMeaningfulToStringRepresentation() {
+		assertEquals("empty bits", empty().toString());
+	}
+
+	@Test
+	void hasNoBits() {
+		assertIterableEquals(emptyList(), empty());
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/internal/BitsEqualityTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/internal/BitsEqualityTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.internal;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.model.internal.core.Bits.empty;
+import static dev.nokee.model.internal.core.Bits.nthBit;
+import static dev.nokee.model.internal.core.Bits.ofBits;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BitsEqualityTest {
+	@Test
+	@SuppressWarnings("UnstableApiUsage")
+	void checkEquality() {
+		new EqualsTester()
+			// No bit set
+			.addEqualityGroup(empty(), ofBits(0), ofBits(0L),
+				ofBits(0, 0, 0),
+				ofBits(0, 0, 0, 0, 0),
+				ofBits(0L, 0L),
+				ofBits(0L, 0L, 0L)
+			)
+
+			// Only least significant bit set
+			.addEqualityGroup(nthBit(0), ofBits(0b1),
+				ofBits(0, 0, 0b1),
+				ofBits(0L, 0b1L)
+			)
+
+			// Only most significant bit set of first word
+			.addEqualityGroup(nthBit(63), ofBits(0x8000000000000000L),
+				ofBits(0L, 0x8000000000000000L)
+			)
+
+			// Only most significant bit set within byte word
+			.addEqualityGroup(nthBit(3), ofBits(0b1000), ofBits(0b1000L),
+				ofBits(0, 0, 0b1000),
+				ofBits(0L, 0b1000L)
+			)
+
+			// Only most significant bit set within short word
+			.addEqualityGroup(nthBit(10), ofBits(0b10000000000), ofBits(0b10000000000L),
+				ofBits(0, 0, 0b10000000000),
+				ofBits(0L, 0b10000000000L)
+			)
+
+			// Only most significant bit set within integer word
+			.addEqualityGroup(nthBit(24), ofBits(0x1000000), ofBits(0x1000000L),
+				ofBits(0, 0, 0x1000000),
+				ofBits(0L, 0x1000000L)
+			)
+
+			// Only most significant bit set within long word
+			.addEqualityGroup(nthBit(52), ofBits(0x10000000000000L),
+				ofBits(0, 0, 0x100000, 0),
+				ofBits(0L, 0x10000000000000L)
+			)
+
+			// Only most significant bit set within long long word
+			.addEqualityGroup(nthBit(100),
+				ofBits(0b10000, 0, 0, 0),
+				ofBits(0x1000000000L, 0L)
+			)
+
+			// Bits in single words
+			.addEqualityGroup(ofBits(0xBABE), ofBits(0xBABEL))
+
+			// Bits in multiple words
+			.addEqualityGroup(
+				ofBits(0xC0FFEEL, 0xBABEL),
+				ofBits(0xC0FFEE, 0, 0xBABE)
+			)
+			.testEquals();
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/internal/BitsEqualityTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/internal/BitsEqualityTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 import static dev.nokee.model.internal.core.Bits.empty;
 import static dev.nokee.model.internal.core.Bits.nthBit;
 import static dev.nokee.model.internal.core.Bits.ofBits;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class BitsEqualityTest {
 	@Test

--- a/subprojects/core-model/src/test/groovy/dev/nokee/internal/BitsMultiWordsTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/internal/BitsMultiWordsTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.internal;
+
+import dev.nokee.model.internal.core.Bits;
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.model.internal.core.Bits.ofBits;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class BitsMultiWordsTest implements BitsTester {
+	@Override
+	public Bits subject() {
+		return ofBits(0xCAFEL, 0xD00DL);
+	}
+
+	@Override
+	public Bits unsetBits() {
+		return ofBits(0x501L, 0x0FF0L);
+	}
+
+	@Override
+	public Bits setBits() {
+		return ofBits(0xC1FEL, 0xD010L);
+	}
+
+	@Test
+	void neverEmpty() {
+		assertFalse(ofBits(0b1, 0b101, 0b11).isEmpty());
+		assertFalse(ofBits(0b11, 0, 0).isEmpty());
+		assertFalse(ofBits(0b10110L, 0b0111L).isEmpty());
+		assertFalse(ofBits(0b10110L, 0L).isEmpty());
+	}
+
+	@Test
+	void returnsPositionOfMostSignificantSetBit() {
+		assertAll(
+			() -> assertEquals(65, ofBits(0b1L, 0x42).length()),
+			() -> assertEquals(65, ofBits(0b1, 0x4, 0x2).length()),
+			() -> assertEquals(75, ofBits(0b10000110101L, 0x52).length()),
+			() -> assertEquals(129, ofBits(0b1L, 0, 0).length()),
+			() -> assertEquals(194, ofBits(0b10L, 0, 0, 0).length())
+		);
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/internal/BitsNthBitTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/internal/BitsNthBitTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.internal;
+
+import dev.nokee.model.internal.core.Bits;
+import lombok.val;
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.collect.Iterables.limit;
+import static dev.nokee.model.internal.core.Bit.One;
+import static dev.nokee.model.internal.core.Bit.Zero;
+import static dev.nokee.model.internal.core.Bits.nthBit;
+import static dev.nokee.model.internal.core.Bits.ofBits;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class BitsNthBitTest implements BitsTester {
+	@Override
+	public Bits subject() {
+		return nthBit(42);
+	}
+
+	@Override
+	public Bits unsetBits() {
+		return nthBit(32);
+	}
+
+	@Override
+	public Bits setBits() {
+		return ofBits(0x40000C00000L);
+	}
+
+	@Test
+	void alwaysShiftBitsAsUnsignedByteBits() {
+		assertEquals(ofBits(0x08), nthBit(7).rightShift(4));
+	}
+
+	@Test
+	void alwaysShiftBitsAsUnsignedShortBits() {
+		assertEquals(ofBits(0x0800), nthBit(15).rightShift(4));
+	}
+
+	@Test
+	void alwaysShiftBitsAsUnsignedIntegerBits() {
+		assertEquals(ofBits(0x08000000), nthBit(31).rightShift(4));
+	}
+
+	@Test
+	void alwaysShiftBitsAsUnsignedLongBits() {
+		assertEquals(ofBits(0x0800000000000000L), nthBit(63).rightShift(4));
+	}
+
+	@Test
+	void throwsExceptionIfBitIndexIsNegative() {
+		val ex = assertThrows(IllegalArgumentException.class, () -> nthBit(-42));
+		assertEquals("Bit 'index' (-42) must be positive.", ex.getMessage());
+	}
+
+	@Test
+	void returnsLengthInNumberOfBits() {
+		assertAll(
+			() -> assertEquals(1, nthBit(0).length()),
+			() -> assertEquals(33, nthBit(32).length()),
+			() -> assertEquals(64, nthBit(63).length()),
+			() -> assertEquals(1000, nthBit(999).length())
+		);
+	}
+
+	@Test
+	void canIterateSingleBitIndex() {
+		assertThat(nthBit(3), contains(Zero, Zero, Zero, One));
+	}
+
+	@Test
+	void hasAlwaysZeroInAllOtherPositionDuringIteration() {
+		assertThat(limit(nthBit(5), 4), everyItem(equalTo(Zero)));
+		assertThat(limit(nthBit(32), 31), everyItem(equalTo(Zero)));
+		assertThat(limit(nthBit(54), 53), everyItem(equalTo(Zero)));
+		assertThat(limit(nthBit(100), 99), everyItem(equalTo(Zero)));
+	}
+
+	@Test
+	void neverEmpty() {
+		assertFalse(nthBit(0).isEmpty());
+		assertFalse(nthBit(1).isEmpty());
+		assertFalse(nthBit(10).isEmpty());
+	}
+
+	@Test
+	void returnsMeaningfulToStringRepresentation() {
+		assertEquals("bits '10000000'", nthBit(7).toString());
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/internal/BitsNthBitTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/internal/BitsNthBitTest.java
@@ -107,6 +107,6 @@ class BitsNthBitTest implements BitsTester {
 
 	@Test
 	void returnsMeaningfulToStringRepresentation() {
-		assertEquals("bits '10000000'", nthBit(7).toString());
+		assertEquals("single bit '1 << 7'", nthBit(7).toString());
 	}
 }

--- a/subprojects/core-model/src/test/groovy/dev/nokee/internal/BitsSingleWordTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/internal/BitsSingleWordTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.internal;
+
+import dev.nokee.model.internal.core.Bits;
+import lombok.val;
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.model.internal.core.Bit.One;
+import static dev.nokee.model.internal.core.Bit.Zero;
+import static dev.nokee.model.internal.core.Bits.empty;
+import static dev.nokee.model.internal.core.Bits.ofBits;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class BitsSingleWordTest implements BitsTester {
+	@Override
+	public Bits subject() {
+		return ofBits(0xC00010FF);
+	}
+
+	@Override
+	public Bits unsetBits() {
+		return ofBits(0xEF00L);
+	}
+
+	@Override
+	public Bits setBits() {
+		return ofBits(0x800030AA);
+	}
+
+	@Test
+	void neverEmpty() {
+		assertFalse(ofBits(0b1).isEmpty());
+		assertFalse(ofBits(0b1011).isEmpty());
+		assertFalse(ofBits(0b101101).isEmpty());
+	}
+
+	@Test
+	void returnsLengthAsNumberOfBitsToStoreUpToTheMostSignificantBit() {
+		assertAll(
+			() -> assertEquals(1, ofBits(0b1).length()),
+			() -> assertEquals(3, ofBits(0b111).length()),
+			() -> assertEquals(8, ofBits(0x8F).length()),
+			() -> assertEquals(16, ofBits(0x800F).length()),
+			() -> assertEquals(32, ofBits(0x81250300).length()),
+			() -> assertEquals(64, ofBits(0x8000E40030341983L).length())
+		);
+	}
+
+//	@Test
+//	void returnsSameBitsWhenOrOperationOnSameBits() {
+//		val bits = ofBits(0b1);
+//		assertSame(bits, bits.or(bits));
+//	}
+
+	@Test
+	void returnsAllActivatedBitsFromBothBitsDuringOrOperation() {
+		assertEquals(ofBits(0b111), ofBits(0b101).or(ofBits(0b11)));
+		assertEquals(ofBits(0b111), ofBits(0b110).or(ofBits(0b11)));
+		assertEquals(ofBits(0b11111011), ofBits(0b11111011).or(ofBits(0b1000000)));
+	}
+
+//	@Test
+//	void returnsCurrentBitsOnOrOperationWithEmptyBits() {
+//		assertEquals(ofBits(0b10101), ofBits(0b10101).or(empty()));
+//	}
+//
+//	@Test
+//	void returnsSameBitsWhenAndOperationOnSameBits() {
+//		val bits = ofBits(0b1);
+//		assertEquals(bits, bits.and(bits));
+//	}
+
+	@Test
+	void returnsOnlyActivatedBitsFromBothBitsDuringAndOperation() {
+		assertEquals(ofBits(0b1), ofBits(0b101).and(ofBits(0b11)));
+		assertEquals(ofBits(0b10), ofBits(0b110).and(ofBits(0b11)));
+		assertEquals(ofBits(0b01000000), ofBits(0b11111011).and(ofBits(0b1000000)));
+	}
+
+//	@Test
+//	void returnsEmptyBitsOnAndOperationWithEmptyBits() {
+//		assertEquals(empty(), ofBits(0b101010).and(empty()));
+//	}
+
+//	@Test
+//	void throwsExceptionWhenOtherBitsIsNullDuringAndOperation() {
+//		assertThrows(NullPointerException.class, () -> ofBits(0b1).and(null));
+//	}
+//
+//	@Test
+//	void throwsExceptionWhenOtherBitsIsNullDuringOrOperation() {
+//		assertThrows(NullPointerException.class, () -> ofBits(0b1).or(null));
+//	}
+//
+//	@Test
+//	void returnsEmptyBitsWhenRightShiftLeastSignificantBitOutOfBits() {
+//		assertEquals(empty(), ofBits(0b1).rightShift(1));
+//	}
+//
+//	@Test
+//	void returnsEmptyBitsWhenRightShiftLeastSignificantBitsOutOfBits() {
+//		assertEquals(empty(), ofBits(0b1010).rightShift(4));
+//	}
+//
+//	@Test
+//	void returnsEmptyBitsWhenRightShiftMoreBitsThanAvailable() {
+//		assertEquals(empty(), ofBits(0b1010).rightShift(42));
+//	}
+
+	@Test
+	void alwaysShiftBitsAsUnsignedByteBits() {
+		assertEquals(ofBits(0x08), ofBits(0x80).rightShift(4));
+	}
+
+	@Test
+	void alwaysShiftBitsAsUnsignedShortBits() {
+		assertEquals(ofBits(0x0800), ofBits(0x8000).rightShift(4));
+	}
+
+	@Test
+	void alwaysShiftBitsAsUnsignedIntegerBits() {
+		assertEquals(ofBits(0x08000000), ofBits(0x80000000).rightShift(4));
+	}
+
+	@Test
+	void alwaysShiftBitsAsUnsignedLongBits() {
+		assertEquals(ofBits(0x0800000000000000L), ofBits(0x8000000000000000L).rightShift(4));
+	}
+
+	@Test
+	void returnsMeaningfulToStringRepresentation() {
+		assertEquals("bits '10001001'", ofBits(0b10001001).toString());
+	}
+
+	@Test
+	void hasSingleBitOnOneBit() {
+		assertIterableEquals(singletonList(One), ofBits(0b1));
+	}
+
+	@Test
+	void iterateFromLeastSignificantBit() {
+		assertIterableEquals(asList(One, One, One, Zero, Zero, One), ofBits(0b100111));
+	}
+
+	@Test
+	void stopsIterationOnMostSignificantBit() {
+		assertIterableEquals(asList(One, Zero, One), ofBits(0b000101));
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/internal/BitsTester.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/internal/BitsTester.java
@@ -288,11 +288,6 @@ public interface BitsTester {
 	}
 
 	@Test
-	default void returnsTrueOnContainsAllWithEmptyBits() {
-		assertTrue(subject().containsAll(empty()));
-	}
-
-	@Test
 	default void returnsFalseOnContainsAllWithNonOverlappingBits() {
 		assertFalse(subject().containsAll(unsetBits()));
 	}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/internal/BitsTester.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/internal/BitsTester.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.internal;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Streams;
+import dev.nokee.model.internal.core.Bit;
+import dev.nokee.model.internal.core.Bits;
+import lombok.val;
+import org.apache.commons.lang3.tuple.Pair;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.collect.Iterables.getLast;
+import static com.google.common.collect.Iterables.skip;
+import static com.google.common.collect.Streams.stream;
+import static dev.nokee.model.internal.core.Bit.One;
+import static dev.nokee.model.internal.core.Bit.Zero;
+import static dev.nokee.model.internal.core.Bits.empty;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.iterableWithSize;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public interface BitsTester {
+	Bits subject();
+
+	Bits unsetBits();
+
+	Bits setBits();
+
+	@BeforeEach
+	default void checkAssumptions() {
+		// TODO: setBits() should not be subject() but has some overlapping bits with subject()
+		assertNotEquals(subject(), setBits(), "requires a set of bits that partially overlap subject");
+		// TODO: unsetBits() should not be empty() and has no overlapping bits with subject()
+	}
+
+	@Test
+	default void alwaysReturnsEmptyBitsOnBitwiseAndOperationInvolvingEmptyBits() {
+		assertEquals(empty(), subject().and(empty()));
+		assertEquals(empty(), empty().and(subject())); // for commutativity
+	}
+
+	@Test
+	default void alwaysReturnsSelfOnBitwiseAndOperationWithSelf() {
+		assertEquals(subject(), subject().and(subject()));
+	}
+
+	@Test
+	default void alwaysReturnsSelfOnBitwiseOrOperatingWithSelf() {
+		assertEquals(subject(), subject().or(subject()));
+	}
+
+	@Test
+	default void alwaysReturnsSelfOnBitwiseOrOperatingWithEmptyBits() {
+		assertEquals(subject(), subject().or(empty()));
+		assertEquals(subject(), empty().or(subject())); // for commutativity
+	}
+
+	@Test
+	default void throwsExceptionOnRightShiftOfNegativeValue() {
+		val ex = assertThrows(IllegalArgumentException.class, () -> subject().rightShift(-42));
+		assertEquals("Bit shift 'count' (-42) must be positive.", ex.getMessage());
+	}
+
+	@Test
+	default void hasSameNumberOfBitsAsLength() {
+		assertThat(subject(), iterableWithSize(subject().length()));
+	}
+
+	@Test
+	default void throwsExceptionOnBitwiseAndOperationAgainstNull() {
+		assertThrows(NullPointerException.class, () -> subject().and(null));
+	}
+
+	@Test
+	default void throwsExceptionOnBitwiseOrOperationAgainstNull() {
+		assertThrows(NullPointerException.class, () -> subject().or(null));
+	}
+
+	@Test
+	default void alwaysReturnsEmptyBitsOnRightShiftByLength() {
+		assertEquals(empty(), subject().rightShift(subject().length()));
+	}
+
+	@Test
+	default void hasOneBitInLastIterablePositionToRepresentMostSignificantBit__AssumingNotEmptyBits() {
+		Assumptions.assumeFalse(subject().equals(empty()), "empty bits has no set bits");
+		assertEquals(One, getLast(subject()));
+	}
+
+	@Test
+	default void returnsEmptyBitsOnBitwiseAndOperationAgainstUnsetBits() {
+		assertThat(subject(), hasNoneOfTheBitsSet(unsetBits()));
+
+		assertEquals(empty(), subject().and(unsetBits()));
+		assertEquals(empty(), unsetBits().and(subject())); // for commutativity
+	}
+
+	@Test
+	default void returnsCommonBitsOnBitwiseAndOperationAgainstSetBits() {
+		assertThat(subject(), not(equalTo(setBits())));
+		assertThat(subject(), not(hasNoneOfTheBitsSet(setBits())));
+
+		assertThat(subject().and(setBits()), contains(allCommonSetBitsOf(subject(), setBits())));
+		assertThat(setBits().and(subject()), contains(allCommonSetBitsOf(subject(), setBits()))); // for commutativity
+	}
+
+	@Test
+	default void returnsCombinationOfAllSetBitsOnBitwiseOrOperationAgainstUnsetBits() {
+		assertThat(subject(), hasNoneOfTheBitsSet(unsetBits()));
+
+		assertThat(subject().or(unsetBits()), contains(allSetBitsOf(subject(), unsetBits())));
+		assertThat(unsetBits().or(subject()), contains(allSetBitsOf(subject(), unsetBits()))); // for commutativity
+	}
+
+	static Bit[] allSetBitsOf(Iterable<Bit> leftBits, Iterable<Bit> rightBits) {
+		val left = Lists.newArrayList(leftBits);
+		val right = Lists.newArrayList(rightBits);
+		val diffSize = left.size() - right.size();
+		if (diffSize > 0) {
+			for (int i = 0; i < diffSize; ++i) {
+				right.add(Zero);
+			}
+		} else {
+			for (int i = 0; i < -diffSize; ++ i) {
+				left.add(Zero);
+			}
+		}
+		return Streams.zip(left.stream(), right.stream(), (l, r) -> {
+			if (l.isSet() || r.isSet()) {
+				return One;
+			} else {
+				return Zero;
+			}
+		}).toArray(Bit[]::new);
+	}
+
+	static Bit[] allCommonSetBitsOf(Iterable<Bit> leftBits, Iterable<Bit> rightBits) {
+		val left = Lists.newArrayList(leftBits);
+		val right = Lists.newArrayList(rightBits);
+		val diffSize = left.size() - right.size();
+		if (diffSize > 0) {
+			for (int i = 0; i < diffSize; ++i) {
+				right.add(Zero);
+			}
+		} else {
+			for (int i = 0; i < -diffSize; ++ i) {
+				left.add(Zero);
+			}
+		}
+		return Streams.zip(left.stream(), right.stream(), (l, r) -> {
+			if (l.isSet() && r.isSet()) {
+				return One;
+			} else {
+				return Zero;
+			}
+		}).toArray(Bit[]::new);
+	}
+
+	@Test
+	default void alwaysReturnsSelfOnRightShiftOfZeroBit() {
+		assertEquals(subject(), subject().rightShift(0));
+	}
+
+	@Test
+	default void canShiftOneBitsToTheRight() {
+		Assumptions.assumeTrue(subject().length() > 1);
+		assertThat(subject().rightShift(1), contains(stream(skip(subject(), 1)).toArray(Bit[]::new)));
+	}
+
+	@Test
+	default void canShiftThreeBitsToTheRight() {
+		Assumptions.assumeTrue(subject().length() > 3);
+		assertThat(subject().rightShift(3), contains(stream(skip(subject(), 3)).toArray(Bit[]::new)));
+	}
+
+	@Test
+	default void canShiftTwentyBitsToTheRight() {
+		Assumptions.assumeTrue(subject().length() > 20);
+		assertThat(subject().rightShift(20), contains(stream(skip(subject(), 20)).toArray(Bit[]::new)));
+	}
+
+	@Test // TODO: Move to big word test
+	default void canShiftByAtLeastOneWordOfBitsToTheRight() {
+		Assumptions.assumeTrue(subject().length() > 70);
+		assertThat(subject().rightShift(70), contains(stream(skip(subject(), 70)).toArray(Bit[]::new)));
+	}
+
+	@Test // TODO: Move to big word test
+	default void canShiftByMultipleWordOfBitsToTheRight() {
+		Assumptions.assumeTrue(subject().length() > 180);
+		assertThat(subject().rightShift(180), contains(stream(skip(subject(), 180)).toArray(Bit[]::new)));
+	}
+
+	@Test
+	default void isNotEmptyWhenLengthIsNonZero() {
+		Assumptions.assumeTrue(subject().length() > 0);
+		assertFalse(subject().isEmpty());
+	}
+
+	@Test
+	default void isEmptyWhenLengthIsZero() {
+		Assumptions.assumeTrue(subject().length() == 0);
+		assertTrue(subject().isEmpty());
+	}
+
+	static Matcher<Iterable<Bit>> hasNoneOfTheBitsSet(Iterable<Bit> unsetBits) {
+		return new TypeSafeMatcher<Iterable<Bit>>() {
+			@Override
+			protected boolean matchesSafely(Iterable<Bit> item) {
+				return Streams.zip(stream(item), stream(unsetBits), Pair::of).noneMatch(it -> {
+					return it.getLeft().equals(it.getRight()) && it.getLeft().isSet();
+				});
+			}
+
+			@Override
+			public void describeTo(Description description) {
+
+			}
+		};
+	}
+
+	@Test
+	default void throwsExceptionOnIntersectsAgainstNull() {
+		assertThrows(NullPointerException.class, () -> subject().intersects(null));
+	}
+
+	@Test
+	default void alwaysReturnsTrueOnIntersectsWithSelf__AssumingNotEmptyBits() {
+		Assumptions.assumeFalse(subject().isEmpty());
+		assertTrue(subject().intersects(subject()));
+	}
+
+	@Test
+	default void alwaysReturnsFalseOnIntersectsWithEmptyBits() {
+		assertFalse(subject().intersects(empty()));
+	}
+
+	@Test
+	default void returnsTrueOnIntersectsWithOverlappingBits() {
+		assertTrue(subject().intersects(setBits()));
+	}
+
+	@Test
+	default void returnsFalseOnIntersectsWithNonOverlappingBits() {
+		assertFalse(subject().intersects(unsetBits()));
+	}
+
+	@Test
+	default void throwsExceptionOnContainsAllAgainstNull() {
+		assertThrows(NullPointerException.class, () -> subject().containsAll(null));
+	}
+
+	@Test
+	default void alwaysReturnsTrueOnContainsAllWithSelf__AssumingNotEmptyBits() {
+		Assumptions.assumeFalse(subject().isEmpty());
+		assertTrue(subject().containsAll(subject()));
+	}
+
+	@Test
+	default void alwaysReturnsTrueOnContainsAllWithEmptyBits() {
+		assertTrue(subject().containsAll(empty()));
+	}
+
+	@Test
+	default void returnsTrueOnContainsAllWithEmptyBits() {
+		assertTrue(subject().containsAll(empty()));
+	}
+
+	@Test
+	default void returnsFalseOnContainsAllWithNonOverlappingBits() {
+		assertFalse(subject().containsAll(unsetBits()));
+	}
+
+	@Test
+	default void returnsFalseOnContainsAllWithPartiallyOverlappingBits() {
+		assertFalse(subject().containsAll(setBits()));
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/ModeNodeComponentBitsTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/ModeNodeComponentBitsTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.core;
+
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ModeNodeComponentBitsTest {
+	private final ModelNode subject = new ModelNode();
+
+	@Test
+	void hasNoComponentBitsOnNewEntity() {
+		assertEquals(Bits.empty(), subject.getComponentBits());
+	}
+
+	@Test
+	void hasBitsOfAddedComponent() {
+		subject.addComponent(objectFactory().newInstance(MyBaseComponent.class));
+		assertEquals(ModelComponentType.assignedComponentTypes.getUnchecked(MyBaseComponent.class),
+			subject.getComponentBits());
+	}
+
+	@Test
+	void hasBitsOfAddedComponentFamily() {
+		subject.addComponent(objectFactory().newInstance(MyComponent.class));
+		assertEquals(ModelComponentType.assignedComponentTypeFamilies.getUnchecked(MyComponent.class),
+			subject.getComponentBits());
+	}
+
+	@Test
+	void hasBitsOfAllComponentFamilies() {
+		subject.addComponent(objectFactory().newInstance(MyComponent.class));
+		subject.addComponent(objectFactory().newInstance(MyOtherComponent.class));
+		assertEquals(ModelComponentType.assignedComponentTypeFamilies.getUnchecked(MyComponent.class)
+				.or(ModelComponentType.assignedComponentTypeFamilies.getUnchecked(MyOtherComponent.class)),
+			subject.getComponentBits());
+	}
+
+	interface MyBaseComponent {}
+	interface MyComponent extends MyBaseComponent {}
+	interface MyOtherComponent {}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/ModeNodeComponentBitsTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/ModeNodeComponentBitsTest.java
@@ -31,14 +31,14 @@ class ModeNodeComponentBitsTest {
 	@Test
 	void hasBitsOfAddedComponent() {
 		subject.addComponent(objectFactory().newInstance(MyBaseComponent.class));
-		assertEquals(ModelComponentType.assignedComponentTypes.getUnchecked(MyBaseComponent.class),
+		assertEquals(ModelComponentType.componentBits(MyBaseComponent.class),
 			subject.getComponentBits());
 	}
 
 	@Test
 	void hasBitsOfAddedComponentFamily() {
 		subject.addComponent(objectFactory().newInstance(MyComponent.class));
-		assertEquals(ModelComponentType.assignedComponentTypeFamilies.getUnchecked(MyComponent.class),
+		assertEquals(ModelComponentType.componentFamilyBits(MyComponent.class),
 			subject.getComponentBits());
 	}
 
@@ -46,8 +46,8 @@ class ModeNodeComponentBitsTest {
 	void hasBitsOfAllComponentFamilies() {
 		subject.addComponent(objectFactory().newInstance(MyComponent.class));
 		subject.addComponent(objectFactory().newInstance(MyOtherComponent.class));
-		assertEquals(ModelComponentType.assignedComponentTypeFamilies.getUnchecked(MyComponent.class)
-				.or(ModelComponentType.assignedComponentTypeFamilies.getUnchecked(MyOtherComponent.class)),
+		assertEquals(ModelComponentType.componentFamilyBits(MyComponent.class)
+				.or(ModelComponentType.componentFamilyBits(MyOtherComponent.class)),
 			subject.getComponentBits());
 	}
 

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/ModelActions_ExecuteAsKnownProjectionTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/ModelActions_ExecuteAsKnownProjectionTest.java
@@ -31,8 +31,11 @@ import static dev.nokee.utils.ActionUtils.doNothing;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasToString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 class ModelActions_ExecuteAsKnownProjectionTest {
 	@Test
@@ -59,9 +62,9 @@ class ModelActions_ExecuteAsKnownProjectionTest {
 	}
 
 	@Test
-	void throwExceptionWhenProjectionIsUnknown() {
+	void doesNotExecuteActionWhenProjectionIsUnknown() {
 		Action<KnownDomainObject<WrongType>> action = Cast.uncheckedCast(mock(Action.class));
-		assertThrows(IllegalArgumentException.class, () -> executeAsKnownProjection(of(WrongType.class), action).execute(node(projectionOf(MyType.class))));
+		assertDoesNotThrow(() -> executeAsKnownProjection(of(WrongType.class), action).execute(node(projectionOf(MyType.class))));
 		verify(action, never()).execute(any());
 	}
 

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/ModelActions_ExecuteUsingProjectionTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/ModelActions_ExecuteUsingProjectionTest.java
@@ -28,9 +28,12 @@ import static dev.nokee.utils.ActionUtils.doNothing;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasToString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 class ModelActions_ExecuteUsingProjectionTest {
 	@Test
@@ -56,9 +59,9 @@ class ModelActions_ExecuteUsingProjectionTest {
 	}
 
 	@Test
-	void throwExceptionWhenProjectionIsUnavailable() {
+	void doesNotExecuteActionWhenProjectionIsUnavailable() {
 		Action<WrongType> action = Cast.uncheckedCast(mock(Action.class));
-		assertThrows(IllegalStateException.class, () -> executeUsingProjection(of(WrongType.class), action).execute(node(projectionOf(MyType.class))));
+		assertDoesNotThrow(() -> executeUsingProjection(of(WrongType.class), action).execute(node(projectionOf(MyType.class))));
 		verify(action, never()).execute(any());
 	}
 

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/ModelTestActions.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/ModelTestActions.java
@@ -117,6 +117,11 @@ public final class ModelTestActions {
 
 	public static class CaptureNodeTransitionAction extends ModelActionWithInputs {
 		private final List<NodeStateTransition> values = new ArrayList<>();
+		private final List<ModelComponentReference<?>> inputs;
+
+		public CaptureNodeTransitionAction() {
+			this.inputs = ImmutableList.of(ModelComponentReference.of(ModelPath.class), ModelComponentReference.of(ModelState.class));
+		}
 
 		public List<NodeStateTransition> getAllTransitions() {
 			return values;
@@ -129,7 +134,7 @@ public final class ModelTestActions {
 
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
-			return ImmutableList.of(ModelComponentReference.of(ModelPath.class), ModelComponentReference.of(ModelState.class));
+			return inputs;
 		}
 
 		public static CaptureNodeTransitionAction.NodeStateTransition realized(Object path) {

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/ModelTestActions.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/ModelTestActions.java
@@ -118,9 +118,11 @@ public final class ModelTestActions {
 	public static class CaptureNodeTransitionAction extends ModelActionWithInputs {
 		private final List<NodeStateTransition> values = new ArrayList<>();
 		private final List<ModelComponentReference<?>> inputs;
+		private final Bits inputBits;
 
 		public CaptureNodeTransitionAction() {
 			this.inputs = ImmutableList.of(ModelComponentReference.of(ModelPath.class), ModelComponentReference.of(ModelState.class));
+			this.inputBits = inputs.stream().map(ModelComponentReference::componentBits).reduce(Bits.empty(), Bits::or);
 		}
 
 		public List<NodeStateTransition> getAllTransitions() {
@@ -135,6 +137,11 @@ public final class ModelTestActions {
 		@Override
 		public List<? extends ModelComponentReference<?>> getInputs() {
 			return inputs;
+		}
+
+		@Override
+		public Bits getInputBits() {
+			return inputBits;
 		}
 
 		public static CaptureNodeTransitionAction.NodeStateTransition realized(Object path) {


### PR DESCRIPTION
When we migrated the platform JNI project to the universal model, there was quite a big performance regression. This PR fixes about 90% of it. The last 10% requires a reordering of the configuration logic.