### PR TITLE
Output JNI JARs in libs/<componentName> to avoid some colision

### DIFF
--- a/subprojects/platform-jni/src/functionalTest/groovy/dev/nokee/platform/jni/AbstractJavaJniLibraryIncrementalFunctionalTest.groovy
+++ b/subprojects/platform-jni/src/functionalTest/groovy/dev/nokee/platform/jni/AbstractJavaJniLibraryIncrementalFunctionalTest.groovy
@@ -76,7 +76,7 @@ abstract class AbstractJavaJniLibraryIncrementalFunctionalTest extends AbstractI
 		result.assertTaskNotSkipped(':jar')
 		result.assertTaskNotSkipped(":jar${currentOsFamilyName.capitalize()}")
 		jar("build/libs/jni-greeter.jar").hasDescendants('com/example/greeter/Greeter.class', 'com/example/greeter/NativeLoader.class')
-		jar("build/libs/jni-greeter-${currentOsFamilyName}.jar").hasDescendants(sharedLibraryName("com/example/greeter/${currentOsFamilyName}/jni-greeter"))
+		jar("build/libs/main/jni-greeter-${currentOsFamilyName}.jar").hasDescendants(sharedLibraryName("com/example/greeter/${currentOsFamilyName}/jni-greeter"))
 	}
 
 	def "skips JAR when dimension does not change (e.g. target machine)"() {

--- a/subprojects/platform-jni/src/functionalTest/groovy/dev/nokee/platform/jni/JniLibraryTargetMachinesFunctionalTest.groovy
+++ b/subprojects/platform-jni/src/functionalTest/groovy/dev/nokee/platform/jni/JniLibraryTargetMachinesFunctionalTest.groovy
@@ -57,7 +57,7 @@ class JniLibraryTargetMachinesFunctionalTest extends AbstractTargetMachinesFunct
 			jar("build/libs/jni-greeter.jar").hasDescendants('com/example/greeter/Greeter.class', 'com/example/greeter/NativeLoader.class', sharedLibraryName('jni-greeter'))
 		} else {
 			jar("build/libs/jni-greeter.jar").hasDescendants('com/example/greeter/Greeter.class', 'com/example/greeter/NativeLoader.class')
-			jar("build/libs/jni-greeter-${variant}.jar").hasDescendants(sharedLibraryName("${variant}/jni-greeter"))
+			jar("build/libs/main/jni-greeter-${variant}.jar").hasDescendants(sharedLibraryName("${variant}/jni-greeter"))
 		}
 	}
 
@@ -77,7 +77,7 @@ class JniLibraryTargetMachinesFunctionalTest extends AbstractTargetMachinesFunct
 		expect:
 		succeeds 'assemble'
 		jar("build/libs/jni-greeter.jar").hasDescendants('com/example/greeter/Greeter.class', 'com/example/greeter/NativeLoader.class')
-		jar("build/libs/jni-greeter-${currentOsFamilyName}.jar").hasDescendants(sharedLibraryName("com/example/greeter/${currentOsFamilyName}/jni-greeter"))
+		jar("build/libs/main/jni-greeter-${currentOsFamilyName}.jar").hasDescendants(sharedLibraryName("com/example/greeter/${currentOsFamilyName}/jni-greeter"))
 	}
 
 	def "can configure the resource path for each variant from target machine"() {
@@ -119,7 +119,7 @@ class JniLibraryTargetMachinesFunctionalTest extends AbstractTargetMachinesFunct
 		expect:
 		succeeds 'assemble'
 		jar("build/libs/jni-greeter.jar").hasDescendants('com/example/greeter/Greeter.class', 'com/example/greeter/NativeLoader.class')
-		jar("build/libs/jni-greeter-${currentOsFamilyName}.jar").hasDescendants(sharedLibraryName("com/example/foobar/${currentArchitecture}-${currentOsFamilyName}/jni-greeter"))
+		jar("build/libs/main/jni-greeter-${currentOsFamilyName}.jar").hasDescendants(sharedLibraryName("com/example/foobar/${currentArchitecture}-${currentOsFamilyName}/jni-greeter"))
 	}
 
 	def "variants have the right platform type"() {
@@ -173,7 +173,7 @@ class JniLibraryTargetMachinesFunctionalTest extends AbstractTargetMachinesFunct
 		result.assertTasksExecutedAndNotSkipped(':cpp-library:compileDebugX86-64Cpp', ':cpp-library:linkDebugX86-64',
 			":compileX86-64Cpp", ":linkX86-64",
 			':compileJava', ':jarX86-64')
-		jar('build/libs/jni-greeter-x86-64.jar').hasDescendants(sharedLibraryName('x86-64/cpp-library'), sharedLibraryName('x86-64/jni-greeter'))
+		jar('build/libs/main/jni-greeter-x86-64.jar').hasDescendants(sharedLibraryName('x86-64/cpp-library'), sharedLibraryName('x86-64/jni-greeter'))
 
 		when:
 		succeeds(':jar')

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JavaNativeInterfaceLibraryComponentRegistrationFactory.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JavaNativeInterfaceLibraryComponentRegistrationFactory.java
@@ -316,6 +316,15 @@ public final class JavaNativeInterfaceLibraryComponentRegistrationFactory {
 						val variant = project.getExtensions().getByType(ModelRegistry.class).register(variantFactory.create(variantIdentifier));
 						variant.configure(JniLibrary.class, it -> it.getBaseName().convention(ModelProperties.getProperty(entity, "baseName").as(String.class).asProvider()));
 
+						// See https://github.com/nokeedev/gradle-native/issues/543
+						if (component.getBuildVariants().get().size() > 1) {
+							variant.configure(JniLibrary.class, it -> {
+								it.getJavaNativeInterfaceJar().getJarTask().configure(task -> {
+									task.getDestinationDirectory().set(project.getLayout().getBuildDirectory().dir("libs/" + identifier.getName()));
+								});
+							});
+						}
+
 						variants.put(buildVariant, ModelNodes.of(variant));
 					});
 					entity.addComponent(new Variants(variants.build()));

--- a/subprojects/platform-jni/src/test/groovy/dev/nokee/platform/jni/JavaNativeInterfaceLibraryComponentIntegrationTest.java
+++ b/subprojects/platform-jni/src/test/groovy/dev/nokee/platform/jni/JavaNativeInterfaceLibraryComponentIntegrationTest.java
@@ -49,6 +49,7 @@ import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.provider.Provider;
+import org.gradle.jvm.tasks.Jar;
 import org.gradle.language.cpp.CppBinary;
 import org.gradle.nativeplatform.toolchain.NativeToolChainRegistry;
 import org.gradle.nativeplatform.toolchain.internal.gcc.AbstractGccCompatibleToolChain;
@@ -59,7 +60,9 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static dev.nokee.internal.testing.ConfigurationMatchers.*;
+import static dev.nokee.internal.testing.FileSystemMatchers.aFile;
 import static dev.nokee.internal.testing.FileSystemMatchers.aFileBaseNamed;
+import static dev.nokee.internal.testing.FileSystemMatchers.withAbsolutePath;
 import static dev.nokee.internal.testing.GradleNamedMatchers.named;
 import static dev.nokee.internal.testing.GradleProviderMatchers.providerOf;
 import static dev.nokee.internal.testing.TaskMatchers.dependsOn;
@@ -599,6 +602,12 @@ class JavaNativeInterfaceLibraryComponentIntegrationTest extends AbstractPluginT
 			assertThat(subject().getBaseName(), providerOf("jaru"));
 		}
 
+		@Test
+		void putsJniJarDirectlyInLibsDirectory() {
+			assertThat(subject().getJavaNativeInterfaceJar().getJarTask().flatMap(Jar::getDestinationDirectory),
+				providerOf(aFile(withAbsolutePath(endsWith("/build/libs")))));
+		}
+
 		abstract class ResolvableConfigurationAttributeTester {
 			public abstract Configuration subject();
 
@@ -793,6 +802,12 @@ class JavaNativeInterfaceLibraryComponentIntegrationTest extends AbstractPluginT
 			}
 
 			@Test
+			void putsJniJarInComponentNamedFolderInsideLibsDirectory() {
+				assertThat(subject().getJavaNativeInterfaceJar().getJarTask().flatMap(Jar::getDestinationDirectory),
+					providerOf(aFile(withAbsolutePath(endsWith("/build/libs/quzu")))));
+			}
+
+			@Test
 			void nativeImplementationExtendsFromMatchingParentConfiguration() {
 				assertThat(project().getConfigurations().getByName("quzuWindowsX64NativeImplementation"),
 					extendsFrom(hasItem(named("quzuNativeImplementation"))));
@@ -971,6 +986,12 @@ class JavaNativeInterfaceLibraryComponentIntegrationTest extends AbstractPluginT
 				subject.getBaseName().set("cebo");
 				subject().getBaseName().set((String) null);
 				assertThat(subject().getBaseName(), providerOf("cebo"));
+			}
+
+			@Test
+			void putsJniJarInComponentNamedFolderInsideLibsDirectory() {
+				assertThat(subject().getJavaNativeInterfaceJar().getJarTask().flatMap(Jar::getDestinationDirectory),
+					providerOf(aFile(withAbsolutePath(endsWith("/build/libs/quzu")))));
 			}
 
 			@Test


### PR DESCRIPTION
Note that only JNI JARs are affected, dual JNI/JVM JARs are still in
libs directory.

Fixes https://github.com/nokeedev/gradle-native/issues/543