### PR TITLE
Split ModelAction between System and Gradle Action bridge

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,4 @@ mockitoVersion=4.3.1
 hamcrestVersion=2.2
 hamcrestOptionalVersion=1.2.0
 autoFactoryVersion=1.0.1
+equalsverifierVersion=3.9

--- a/subprojects/core-model/core-model.gradle
+++ b/subprojects/core-model/core-model.gradle
@@ -16,6 +16,7 @@ dependencies {
 
 	testImplementation gradleApi(minimumGradleVersion)
 	testImplementation "dev.gradleplugins:gradle-fixtures-well-behaving-plugins:latest.release"
+	testImplementation "nl.jqno.equalsverifier:equalsverifier:${equalsverifierVersion}"
 	testImplementation gradleTestKit()
 	testImplementation(testFixtures(project(':coreUtils')))
 

--- a/subprojects/core-model/src/integrationTest/java/dev/nokee/model/ModelActionByAncestorsIntegrationTest.java
+++ b/subprojects/core-model/src/integrationTest/java/dev/nokee/model/ModelActionByAncestorsIntegrationTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model;
+
+import dev.nokee.model.internal.actions.ModelSpec;
+import dev.nokee.model.internal.core.ModelNode;
+import dev.nokee.model.internal.core.ModelRegistration;
+import dev.nokee.model.internal.core.ParentComponent;
+import org.junit.jupiter.api.BeforeEach;
+
+import static dev.nokee.model.internal.actions.ModelSpec.descendantOf;
+import static dev.nokee.model.internal.core.ModelRegistration.builder;
+
+class ModelActionByAncestorsIntegrationTest extends ModelActionIntegrationTester {
+	private final ModelNode ancestor = new ModelNode();
+	private final ModelNode parent = new ModelNode();
+	private final ModelNode unrelated = new ModelNode();
+
+	@BeforeEach
+	void createEntities() {
+		parent.addComponent(new ParentComponent(ancestor));
+	}
+
+	@Override
+	public ModelSpec spec() {
+		return descendantOf(ancestor.getId());
+	}
+
+	@Override
+	public ModelRegistration newEntityMatchingSpec() {
+		return builder().withComponent(new ParentComponent(parent)).build();
+	}
+
+	@Override
+	public ModelRegistration newEntityNotMatchingSpec() {
+		return builder().withComponent(new ParentComponent(unrelated)).build();
+	}
+}

--- a/subprojects/core-model/src/integrationTest/java/dev/nokee/model/ModelActionByElementNameIntegrationTest.java
+++ b/subprojects/core-model/src/integrationTest/java/dev/nokee/model/ModelActionByElementNameIntegrationTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model;
+
+import dev.nokee.model.internal.ElementName;
+import dev.nokee.model.internal.ElementNameComponent;
+import dev.nokee.model.internal.actions.ModelSpec;
+import dev.nokee.model.internal.core.ModelRegistration;
+import org.junit.jupiter.api.BeforeAll;
+
+import static dev.nokee.model.internal.actions.ModelSpec.named;
+import static dev.nokee.model.internal.core.ModelRegistration.builder;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class ModelActionByElementNameIntegrationTest extends ModelActionIntegrationTester {
+	private static final ElementName NAME = ElementName.of("lpoe");
+	private static final ElementName OTHER_NAME = ElementName.of("kjge");
+
+	@BeforeAll
+	static void verifyElementNameExpectation() {
+		assertNotEquals(NAME, OTHER_NAME);
+	}
+
+	@Override
+	public ModelSpec spec() {
+		return named(NAME);
+	}
+
+	@Override
+	public ModelRegistration newEntityMatchingSpec() {
+		return builder().withComponent(new ElementNameComponent(NAME)).build();
+	}
+
+	@Override
+	public ModelRegistration newEntityNotMatchingSpec() {
+		return builder().withComponent(new ElementNameComponent(OTHER_NAME)).build();
+	}
+}

--- a/subprojects/core-model/src/integrationTest/java/dev/nokee/model/ModelActionByFullyQualifiedNameIntegrationTest.java
+++ b/subprojects/core-model/src/integrationTest/java/dev/nokee/model/ModelActionByFullyQualifiedNameIntegrationTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model;
+
+import dev.nokee.model.internal.FullyQualifiedName;
+import dev.nokee.model.internal.FullyQualifiedNameComponent;
+import dev.nokee.model.internal.actions.ModelSpec;
+import dev.nokee.model.internal.core.ModelRegistration;
+import org.junit.jupiter.api.BeforeAll;
+
+import static dev.nokee.model.internal.actions.ModelSpec.named;
+import static dev.nokee.model.internal.core.ModelRegistration.builder;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class ModelActionByFullyQualifiedNameIntegrationTest extends ModelActionIntegrationTester {
+	private static final FullyQualifiedName NAME = FullyQualifiedName.of("pete");
+	private static final FullyQualifiedName OTHER_NAME = FullyQualifiedName.of("kdel");
+
+	@BeforeAll
+	static void verifyFullyQualifiedNameExpectation() {
+		assertNotEquals(NAME, OTHER_NAME);
+	}
+
+	@Override
+	public ModelSpec spec() {
+		return named(NAME);
+	}
+
+	@Override
+	public ModelRegistration newEntityMatchingSpec() {
+		return builder().withComponent(new FullyQualifiedNameComponent(NAME)).build();
+	}
+
+	@Override
+	public ModelRegistration newEntityNotMatchingSpec() {
+		return builder().withComponent(new FullyQualifiedNameComponent(OTHER_NAME)).build();
+	}
+}

--- a/subprojects/core-model/src/integrationTest/java/dev/nokee/model/ModelActionByOwnerIntegrationTest.java
+++ b/subprojects/core-model/src/integrationTest/java/dev/nokee/model/ModelActionByOwnerIntegrationTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model;
+
+import dev.nokee.model.internal.actions.ModelSpec;
+import dev.nokee.model.internal.core.ModelNode;
+import dev.nokee.model.internal.core.ModelRegistration;
+import dev.nokee.model.internal.core.ParentComponent;
+
+import static dev.nokee.model.internal.actions.ModelSpec.ownedBy;
+import static dev.nokee.model.internal.core.ModelRegistration.builder;
+
+class ModelActionByOwnerIntegrationTest extends ModelActionIntegrationTester {
+	private final ModelNode owner = new ModelNode();
+	private final ModelNode unrelated = new ModelNode();
+
+	@Override
+	public ModelSpec spec() {
+		return ownedBy(owner.getId());
+	}
+
+	@Override
+	public ModelRegistration newEntityMatchingSpec() {
+		return builder().withComponent(new ParentComponent(owner)).build();
+	}
+
+	@Override
+	public ModelRegistration newEntityNotMatchingSpec() {
+		return builder().withComponent(new ParentComponent(unrelated)).build();
+	}
+}

--- a/subprojects/core-model/src/integrationTest/java/dev/nokee/model/ModelActionByStateIntegrationTest.java
+++ b/subprojects/core-model/src/integrationTest/java/dev/nokee/model/ModelActionByStateIntegrationTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model;
+
+import dev.nokee.model.internal.actions.ModelSpec;
+import dev.nokee.model.internal.core.ModelRegistration;
+import dev.nokee.model.internal.state.ModelState;
+
+import static dev.nokee.model.internal.actions.ModelSpec.stateAtLeast;
+import static dev.nokee.model.internal.core.ModelRegistration.builder;
+
+class ModelActionByStateIntegrationTest extends ModelActionIntegrationTester {
+	@Override
+	public ModelSpec spec() {
+		return stateAtLeast(ModelState.Realized);
+	}
+
+	@Override
+	public ModelRegistration newEntityMatchingSpec() {
+		return builder().withComponent(ModelState.Realized).build();
+	}
+
+	@Override
+	public ModelRegistration newEntityNotMatchingSpec() {
+		return builder().withComponent(ModelState.Created).build();
+	}
+}

--- a/subprojects/core-model/src/integrationTest/java/dev/nokee/model/ModelActionByTypeIntegrationTest.java
+++ b/subprojects/core-model/src/integrationTest/java/dev/nokee/model/ModelActionByTypeIntegrationTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model;
+
+import dev.nokee.model.internal.actions.ModelSpec;
+import dev.nokee.model.internal.core.ModelRegistration;
+
+import static dev.nokee.model.internal.actions.ModelSpec.subtypeOf;
+import static dev.nokee.model.internal.core.ModelProjections.managed;
+import static dev.nokee.model.internal.core.ModelRegistration.builder;
+import static dev.nokee.model.internal.type.ModelType.of;
+
+class ModelActionByTypeIntegrationTest extends ModelActionIntegrationTester {
+	@Override
+	public ModelSpec spec() {
+		return subtypeOf(of(MyType.class));
+	}
+
+	@Override
+	public ModelRegistration newEntityMatchingSpec() {
+		return builder().withComponent(managed(of(MyType.class))).build();
+	}
+
+	@Override
+	public ModelRegistration newEntityNotMatchingSpec() {
+		return builder().withComponent(managed(of(MyOtherType.class))).build();
+	}
+
+	private interface MyType {}
+	private interface MyOtherType {}
+}

--- a/subprojects/core-model/src/integrationTest/java/dev/nokee/model/ModelActionIntegrationTester.java
+++ b/subprojects/core-model/src/integrationTest/java/dev/nokee/model/ModelActionIntegrationTester.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model;
+
+import dev.nokee.internal.Factories;
+import dev.nokee.internal.testing.util.ProjectTestUtils;
+import dev.nokee.model.internal.ElementName;
+import dev.nokee.model.internal.ElementNameComponent;
+import dev.nokee.model.internal.FullyQualifiedName;
+import dev.nokee.model.internal.FullyQualifiedNameComponent;
+import dev.nokee.model.internal.actions.ModelAction;
+import dev.nokee.model.internal.actions.ModelSpec;
+import dev.nokee.model.internal.core.ModelNode;
+import dev.nokee.model.internal.core.ModelRegistration;
+import dev.nokee.model.internal.core.ParentComponent;
+import dev.nokee.model.internal.plugins.ModelBasePlugin;
+import dev.nokee.model.internal.registry.ModelRegistry;
+import dev.nokee.model.internal.state.ModelState;
+import lombok.val;
+import org.gradle.api.Project;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static dev.nokee.model.internal.actions.ModelAction.configureMatching;
+import static dev.nokee.model.internal.core.ModelProjections.createdUsing;
+import static dev.nokee.model.internal.core.ModelRegistration.builder;
+import static dev.nokee.model.internal.type.ModelType.of;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+abstract class ModelActionIntegrationTester {
+	@Mock private ModelAction firstAction;
+	private final Project project = ProjectTestUtils.rootProject();
+	private ModelRegistry registry;
+
+	public abstract ModelSpec spec();
+	public abstract ModelRegistration newEntityMatchingSpec();
+	public abstract ModelRegistration newEntityNotMatchingSpec();
+
+	@BeforeEach
+	void setUp() {
+		project.getPluginManager().apply(ModelBasePlugin.class);
+		registry = project.getExtensions().getByType(ModelRegistry.class);
+		registry.instantiate(builder().build()); // empty, non-matching, entity
+		registry.instantiate(configureMatching(spec(), firstAction));
+	}
+
+	@Test
+	void doesNotExecuteActionWhenNoEntityMatch() {
+		verify(firstAction, never()).execute(any());
+	}
+
+	@Test
+	void doesNotExecuteActionWhenEntityHasCompatibleIdentityWithSpecButDoesNotMatchSpec() {
+		registry.instantiate(newEntityNotMatchingSpec());
+		verify(firstAction, never()).execute(any());
+	}
+
+	@Nested
+	class OnMatchingEntityTest {
+		@Mock private ModelAction secondAction;
+		private ModelNode entity;
+
+		@BeforeEach
+		void createMatchingEntity() {
+			entity = registry.instantiate(newEntityMatchingSpec());
+		}
+
+		@Test
+		void executesActionForEntity() {
+			verify(firstAction).execute(entity);
+		}
+
+		@Test
+		void executesNewActionForEntity() {
+			registry.instantiate(configureMatching(spec(), secondAction));
+			verify(secondAction).execute(entity);
+		}
+
+		@Test
+		void doesNotExecuteCurrentActionAfterFirstExecution() {
+			reset(firstAction); // ignore expected callback
+
+			// force the modification of the entity identity with no-op selector
+			entity.addComponent(createdUsing(of(MyOtherType.class), Factories.alwaysThrow()));
+
+			// should not call back again as it should already have called back
+			verify(firstAction, never()).execute(any());
+		}
+
+		@Test
+		void doesNotExecuteNewActionAfterFirstExecution() {
+			registry.instantiate(configureMatching(spec(), secondAction));
+			reset(secondAction); // ignore expected callback
+
+			// force the modification of the entity identity with no-op selector
+			entity.addComponent(createdUsing(of(MyOtherType.class), Factories.alwaysThrow()));
+
+			// should not call back again as it should already have called back
+			verify(secondAction, never()).execute(any());
+		}
+	}
+
+	@ParameterizedTest
+	@EnumSource(B.class)
+	void throwsExceptionIfEntityChangeWhileExecutingAction(B provider) {
+		doAnswer(args -> {
+			args.getArgument(0, ModelNode.class).addComponent(provider.g());
+			return null;
+		}).when(firstAction).execute(any());
+		Assertions.assertThrows(IllegalStateException.class, () -> registry.instantiate(newEntityMatchingSpec()));
+	}
+
+	enum B {
+		PROJECTION {
+			@Override
+			public Object g() {
+				return createdUsing(of(MyOtherType.class), Factories.alwaysThrow());
+			}
+		},
+		OWNER {
+			@Override
+			public Object g() {
+				return new ParentComponent(new ModelNode());
+			}
+		},
+		STATE {
+			@Override
+			public Object g() {
+				return ModelState.Registered;
+			}
+		},
+		ANCESTOR {
+			@Override
+			public Object g() {
+				val g = new ModelNode();
+				g.addComponent(new ParentComponent(new ModelNode()));
+				return new ParentComponent(g);
+			}
+		},
+		ELEMENT_NAME {
+			@Override
+			public Object g() {
+				return new ElementNameComponent(ElementName.of("lkew"));
+			}
+		},
+		FULLY_QUALIFIED_NAME {
+			@Override
+			public Object g() {
+				return new FullyQualifiedNameComponent(FullyQualifiedName.of("peor"));
+			}
+		}
+		;
+
+		public abstract Object g();
+	}
+
+	@Test
+	void executeSelfMutatingActionAfterCurrentActions() {
+		val secondAction = Mockito.mock(ModelAction.class, "secondAction");
+		val thirdAction = Mockito.mock(ModelAction.class, "thirdAction");
+		registry.instantiate(configureMatching(spec(), secondAction));
+		doAnswer(args -> {
+			registry.instantiate(configureMatching(spec(), thirdAction));
+			return null;
+		}).when(firstAction).execute(any());
+
+		val entity = registry.instantiate(newEntityMatchingSpec());
+		val inOrder = Mockito.inOrder(firstAction, secondAction, thirdAction);
+		inOrder.verify(firstAction).execute(entity);
+		inOrder.verify(secondAction).execute(entity);
+		inOrder.verify(thirdAction).execute(entity);
+	}
+
+
+	private interface MyOtherType {}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/ElementName.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/ElementName.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.nokee.model.internal.core;
+package dev.nokee.model.internal;
 
 import lombok.EqualsAndHashCode;
 

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/ElementNameComponent.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/ElementNameComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.nokee.model.internal.core;
+package dev.nokee.model.internal;
+
+import dev.nokee.model.internal.core.ModelComponent;
 
 public final class ElementNameComponent implements ModelComponent {
 	private final ElementName value;

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/FullyQualifiedName.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/FullyQualifiedName.java
@@ -30,7 +30,7 @@ package dev.nokee.model.internal;
 public final class FullyQualifiedName {
 	private final String name;
 
-	public FullyQualifiedName(String name) {
+	private FullyQualifiedName(String name) {
 		this.name = name;
 	}
 
@@ -41,5 +41,9 @@ public final class FullyQualifiedName {
 	@Override
 	public String toString() {
 		return name;
+	}
+
+	public static FullyQualifiedName of(String name) {
+		return new FullyQualifiedName(name);
 	}
 }

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/FullyQualifiedName.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/FullyQualifiedName.java
@@ -15,6 +15,18 @@
  */
 package dev.nokee.model.internal;
 
+/**
+ * A fully qualified name represent a unique name of a domain object which include the name of the domain object as well as all of its owners.
+ * Although the name typically represent the domain object's ownership hierarchy, users should not use it as such.
+ * Typically, Gradle uses the fully qualified name in the {@link org.gradle.api.Named} interface.
+ * The Nokee plugins always return the fully qualified name when implementing the {@link org.gradle.api.Named} interface.
+ *
+ * It's important to make a distinction between the fully qualified name, the partially qualified name, and the element name.
+ * The fully qualified name is unique among domain objects with the same base type.
+ * The partially qualified name is not unique and includes the domain object's ownership hierarchy from an arbitrary ancestor.
+ * The element name is not unique and represent only the domain object's name, without any ownership.
+ * Note that a partially qualified name using the domain object as the base ancestor will be the same as the element name.
+ */
 public final class FullyQualifiedName {
 	private final String name;
 

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/FullyQualifiedName.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/FullyQualifiedName.java
@@ -34,10 +34,6 @@ public final class FullyQualifiedName {
 		this.name = name;
 	}
 
-	public String get() {
-		return name;
-	}
-
 	@Override
 	public String toString() {
 		return name;

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/FullyQualifiedName.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/FullyQualifiedName.java
@@ -15,6 +15,8 @@
  */
 package dev.nokee.model.internal;
 
+import lombok.EqualsAndHashCode;
+
 /**
  * A fully qualified name represent a unique name of a domain object which include the name of the domain object as well as all of its owners.
  * Although the name typically represent the domain object's ownership hierarchy, users should not use it as such.
@@ -27,6 +29,7 @@ package dev.nokee.model.internal;
  * The element name is not unique and represent only the domain object's name, without any ownership.
  * Note that a partially qualified name using the domain object as the base ancestor will be the same as the element name.
  */
+@EqualsAndHashCode
 public final class FullyQualifiedName {
 	private final String name;
 

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/FullyQualifiedNameComponent.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/FullyQualifiedNameComponent.java
@@ -21,7 +21,7 @@ public final class FullyQualifiedNameComponent implements Supplier<FullyQualifie
 	private final FullyQualifiedName value;
 
 	public FullyQualifiedNameComponent(String value) {
-		this.value = new FullyQualifiedName(value);
+		this.value = FullyQualifiedName.of(value);
 	}
 
 	public FullyQualifiedNameComponent(FullyQualifiedName value) {

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/ModelElementFactory.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/ModelElementFactory.java
@@ -70,7 +70,7 @@ public final class ModelElementFactory {
 		val namedStrategy = new NamedStrategy() {
 			@Override
 			public String getAsString() {
-				return entity.getComponent(ElementNameComponent.class).get();
+				return entity.getComponent(ElementNameComponent.class).get().toString();
 			}
 		};
 		val castableStrategy = new ModelBackedModelCastableStrategy(entity, this);
@@ -136,7 +136,7 @@ public final class ModelElementFactory {
 		val namedStrategy = new NamedStrategy() {
 			@Override
 			public String getAsString() {
-				return entity.getComponent(ElementNameComponent.class).get();
+				return entity.getComponent(ElementNameComponent.class).get().toString();
 			}
 		};
 		val castableStrategy = new ModelBackedModelCastableStrategy(entity, this);
@@ -259,7 +259,7 @@ public final class ModelElementFactory {
 		val namedStrategy = new NamedStrategy() {
 			@Override
 			public String getAsString() {
-				return entity.getComponent(ElementNameComponent.class).get();
+				return entity.getComponent(ElementNameComponent.class).get().toString();
 			}
 		};
 		val castableStrategy = new ModelBackedModelCastableStrategy(entity, this);

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/ActionSelectorComponent.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/ActionSelectorComponent.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import dev.nokee.model.internal.core.ModelComponent;
+
+final class ActionSelectorComponent implements ModelComponent {
+	private final DomainObjectIdentity identity;
+
+	public ActionSelectorComponent(DomainObjectIdentity identity) {
+		this.identity = identity;
+	}
+
+	public DomainObjectIdentity get() {
+		return identity;
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/AncestorSpec.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/AncestorSpec.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import com.google.common.collect.Iterables;
+import dev.nokee.model.internal.core.ModelEntityId;
+import lombok.EqualsAndHashCode;
+import org.gradle.api.specs.Spec;
+
+/**
+ * @see ModelSpec#descendantOf(ModelEntityId)
+ */
+@EqualsAndHashCode
+final class AncestorSpec implements Spec<DomainObjectIdentity>, ModelSpec {
+	private final ModelEntityId ancestorRef;
+
+	public AncestorSpec(ModelEntityId ancestorRef) {
+		this.ancestorRef = ancestorRef;
+	}
+
+	@Override
+	public boolean isSatisfiedBy(DomainObjectIdentity identity) {
+		return identity.get(Ancestors.class).map(it -> Iterables.contains(it, ancestorRef)).orElse(false);
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/Ancestors.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/Ancestors.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import dev.nokee.model.internal.core.ModelEntityId;
+
+import java.util.Iterator;
+import java.util.Set;
+
+final class Ancestors implements Iterable<ModelEntityId> {
+	private final Set<ModelEntityId> values;
+
+	public Ancestors(Set<ModelEntityId> values) {
+		this.values = values;
+	}
+
+	@Override
+	public Iterator<ModelEntityId> iterator() {
+		return values.iterator();
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/AndSpec.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/AndSpec.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import com.google.common.collect.ImmutableSet;
+import lombok.EqualsAndHashCode;
+import lombok.val;
+import org.gradle.api.specs.Spec;
+
+import java.util.Set;
+
+@EqualsAndHashCode
+final class AndSpec implements Spec<DomainObjectIdentity>, ModelSpec {
+	@EqualsAndHashCode.Include private final Set<ModelSpec> specs;
+
+	public AndSpec(ModelSpec first, ModelSpec second) {
+		this(consolidate(first, second));
+	}
+
+	public AndSpec(Set<ModelSpec> specs) {
+		this.specs = specs;
+	}
+
+	@Override
+	public ModelSpec and(ModelSpec other) {
+		return new AndSpec(consolidate(this, other));
+	}
+
+	private static Set<ModelSpec> consolidate(ModelSpec first, ModelSpec second) {
+		val builder = ImmutableSet.<ModelSpec>builder();
+		if (first instanceof AndSpec) {
+			builder.addAll(((AndSpec) first).specs);
+		} else {
+			builder.add(first);
+		}
+
+		if (second instanceof AndSpec) {
+			builder.addAll(((AndSpec) second).specs);
+		} else {
+			builder.add(second);
+		}
+
+		return builder.build();
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public boolean isSatisfiedBy(DomainObjectIdentity element) {
+		return specs.stream().allMatch(it -> ((Spec<DomainObjectIdentity>) it).isSatisfiedBy(element));
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/DirectDescendantSpec.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/DirectDescendantSpec.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import dev.nokee.model.internal.core.ModelEntityId;
+import lombok.EqualsAndHashCode;
+import org.gradle.api.specs.Spec;
+
+/**
+ * @see ModelSpec#ownedBy(ModelEntityId)
+ */
+@EqualsAndHashCode
+final class DirectDescendantSpec implements Spec<DomainObjectIdentity>, ModelSpec {
+	private final ParentRef parentRef;
+
+	public DirectDescendantSpec(ModelEntityId entityId) {
+		this.parentRef = new ParentRef(entityId);
+	}
+
+	@Override
+	public boolean isSatisfiedBy(DomainObjectIdentity identity) {
+		return identity.get(ParentRef.class).map(parentRef::equals).orElse(false);
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/DomainObjectIdentity.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/DomainObjectIdentity.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import com.google.common.collect.ImmutableMap;
+import lombok.val;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Represent what an entity is all about in terms of projection actions
+ */
+final class DomainObjectIdentity {
+	private final Map<Class<?>, Object> values;
+
+	private DomainObjectIdentity(Map<Class<?>, Object> values) {
+		this.values = values;
+	}
+
+	public static DomainObjectIdentity of(Object value) {
+		return new DomainObjectIdentity(ImmutableMap.of(value.getClass(), value));
+	}
+
+	public <T> Optional<T> get(Class<T> type) {
+		Objects.requireNonNull(type);
+		@SuppressWarnings("unchecked")
+		T value = (T) values.get(type);
+		return Optional.ofNullable(value);
+	}
+
+	public <T> DomainObjectIdentity with(T value) {
+		Objects.requireNonNull(value);
+		val result = new HashMap<>(values);
+		result.put(value.getClass(), value);
+		return new DomainObjectIdentity(ImmutableMap.copyOf(result));
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/ExecutedActionComponent.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/ExecutedActionComponent.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import dev.nokee.model.internal.core.ModelComponent;
+import dev.nokee.model.internal.core.ModelEntityId;
+
+import java.util.Set;
+
+final class ExecutedActionComponent implements ModelComponent {
+	private final Set<ModelEntityId> ids;
+
+	public ExecutedActionComponent(Set<ModelEntityId> ids) {
+		this.ids = ids;
+	}
+
+	public Set<ModelEntityId> get() {
+		return ids;
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/IterableOnce.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/IterableOnce.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import java.util.Iterator;
+
+final class IterableOnce<T> implements Iterable<T> {
+	private Iterator<T> iterator;
+
+	public IterableOnce(Iterator<T> iterator) {
+		this.iterator = iterator;
+	}
+
+	@Override
+	public Iterator<T> iterator() {
+		if (iterator == null) {
+			throw new IllegalStateException("Already iterated a one-pass iterable");
+		}
+		final Iterator<T> result = iterator;
+		iterator = null;
+		return result;
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/ModelAction.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/ModelAction.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import dev.nokee.model.KnownDomainObject;
+import dev.nokee.model.internal.FullyQualifiedName;
+import dev.nokee.model.internal.core.ModelNode;
+import dev.nokee.model.internal.core.ModelRegistration;
+import dev.nokee.model.internal.state.ModelState;
+import org.gradle.api.Action;
+
+import static dev.nokee.model.internal.actions.ModelSpec.named;
+import static dev.nokee.model.internal.actions.ModelSpec.stateAtLeast;
+import static dev.nokee.model.internal.actions.ModelSpec.subtypeOf;
+import static dev.nokee.model.internal.type.ModelType.of;
+
+/**
+ * Represent an action to execute against a projection of the entity.
+ */
+public interface ModelAction {
+	/**
+	 * Performs this action against given entity.
+	 *
+	 * @param entity  the entity to perform the action on, never null
+	 */
+	void execute(ModelNode entity);
+
+	/**
+	 * Creates action registration that configures each entity using the projection of the specified type.
+	 * The model action assume a state of at least {@link ModelState#Realized}.
+	 *
+	 * @param type  the projection type to perform the action on, must not be null
+	 * @param action  the action to perform, must not be null
+	 * @param <T>  the projection type
+	 * @return a registration for model action, never null
+	 */
+	static <T> ModelRegistration configureEach(Class<T> type, Action<? super T> action) {
+		return configureMatching(subtypeOf(of(type)).and(stateAtLeast(ModelState.Realized)),
+			new ModelActionAdapter<>(of(type), action));
+	}
+
+	/**
+	 * Creates action registration that configures each entity matching the specified spec using the projection of the specified type.
+	 * The model action assume a state of at least {@link ModelState#Realized}.
+	 *
+	 * @param spec  a specification to satisfied, must not be null
+	 * @param type  the projection type to perform the action on, must not be null
+	 * @param action  the action to perform, must not be null
+	 * @param <T>  the projection type
+	 * @return a registration for model action, never null
+	 */
+	static <T> ModelRegistration configureEach(ModelSpec spec, Class<T> type, Action<? super T> action) {
+		return configureMatching(subtypeOf(of(type)).and(stateAtLeast(ModelState.Realized)).and(spec),
+			new ModelActionAdapter<>(of(type), action));
+	}
+
+	/**
+	 * Creates action registration that configures each entity when the projection of the specified type is known.
+	 * The model action assume a state of at least {@link ModelState#Registered}.
+	 *
+	 * @param type  the projection type to perform the action when known, must not be null
+	 * @param action  the action to perform, must not be null
+	 * @param <T>  the projection type
+	 * @return a registration for model action, never null
+	 */
+	static <T> ModelRegistration whenElementKnown(Class<T> type, Action<? super KnownDomainObject<T>> action) {
+		return configureMatching(subtypeOf(of(type)).and(stateAtLeast(ModelState.Registered)),
+			new ModelActionKnownDomainObjectAdapter<>(of(type), action));
+	}
+
+	/**
+	 * Creates action registration that configures each entity matching the specified spec and when the projection of the specified type is known.
+	 * The model action assume a state of at least {@link ModelState#Registered}.
+	 *
+	 * @param type  the projection type to perform the action when known, must not be null
+	 * @param action  the action to perform, must not be null
+	 * @param <T>  the projection type
+	 * @return a registration for model action, never null
+	 */
+	static <T> ModelRegistration whenElementKnown(ModelSpec spec, Class<T> type, Action<? super KnownDomainObject<T>> action) {
+		return configureMatching(subtypeOf(of(type)).and(stateAtLeast(ModelState.Registered)).and(spec),
+			new ModelActionKnownDomainObjectAdapter<>(of(type), action));
+	}
+
+	/**
+	 * Creates a registration to configure the specified fully qualified domain object with the specified projection type.
+	 * The model action assume a state of at least {@link ModelState#Realized}.
+	 *
+	 * @param name  the fully qualified name of the domain object to configure, must not be null
+	 * @param type  the projection type to perform the action, must not be null
+	 * @param action  the action to perform, must not be null
+	 * @param <T>  the projection type
+	 * @return a registration for model action, never null
+	 */
+	static <T> ModelRegistration configure(String name, Class<T> type, Action<? super T> action) {
+		return configureMatching(subtypeOf(of(type)).and(stateAtLeast(ModelState.Realized)).and(named(FullyQualifiedName.of(name))),
+			new ModelActionAdapter<>(of(type), action));
+	}
+
+	/**
+	 * Creates a registration to configure the entity matching the specified spec using the specified action.
+	 *
+	 * @param spec  the spec to satisfy, must not be null
+	 * @param action  the action to perform, must not be null
+	 * @return a registration for model action, never null
+	 */
+	static ModelRegistration configureMatching(ModelSpec spec, ModelAction action) {
+		return ModelRegistration.builder()
+			.withComponent(new ModelSpecComponent(spec))
+			.withComponent(new ModelActionComponent(action))
+			.withComponent(ModelActionTag.tag())
+			.build();
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/ModelActionAdapter.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/ModelActionAdapter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import dev.nokee.model.internal.core.ModelNode;
+import dev.nokee.model.internal.core.ModelNodeUtils;
+import dev.nokee.model.internal.type.ModelType;
+import lombok.EqualsAndHashCode;
+import org.gradle.api.Action;
+
+@EqualsAndHashCode
+final class ModelActionAdapter<T> implements ModelAction {
+	private final ModelType<T> type;
+	private final Action<? super T> action;
+
+	public ModelActionAdapter(ModelType<T> type, Action<? super T> action) {
+		this.type = type;
+		this.action = action;
+	}
+
+	@Override
+	public void execute(ModelNode entity) {
+		action.execute(ModelNodeUtils.get(entity, type));
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/ModelActionComponent.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/ModelActionComponent.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import dev.nokee.model.internal.core.ModelComponent;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode
+final class ModelActionComponent implements ModelComponent {
+	private final ModelAction action;
+
+	public ModelActionComponent(ModelAction action) {
+		this.action = action;
+	}
+
+	public ModelAction get() {
+		return action;
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/ModelActionKnownDomainObjectAdapter.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/ModelActionKnownDomainObjectAdapter.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import dev.nokee.model.KnownDomainObject;
+import dev.nokee.model.internal.DefaultKnownDomainObject;
+import dev.nokee.model.internal.core.ModelNode;
+import dev.nokee.model.internal.type.ModelType;
+import lombok.EqualsAndHashCode;
+import org.gradle.api.Action;
+
+@EqualsAndHashCode
+final class ModelActionKnownDomainObjectAdapter<T> implements ModelAction {
+	@EqualsAndHashCode.Include private final ModelType<T> type;
+	@EqualsAndHashCode.Include private final Action<? super KnownDomainObject<T>> action;
+
+	public ModelActionKnownDomainObjectAdapter(ModelType<T> type, Action<? super KnownDomainObject<T>> action) {
+		this.type = type;
+		this.action = action;
+	}
+
+	@Override
+	public void execute(ModelNode entity) {
+		action.execute(DefaultKnownDomainObject.of(type, entity));
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/ModelActionSystem.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/ModelActionSystem.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import dev.nokee.model.internal.FullyQualifiedNameComponent;
+import dev.nokee.model.internal.ElementNameComponent;
+import dev.nokee.model.internal.core.ModelActionWithInputs;
+import dev.nokee.model.internal.core.ModelComponentReference;
+import dev.nokee.model.internal.core.ModelEntityId;
+import dev.nokee.model.internal.core.ModelNode;
+import dev.nokee.model.internal.core.ModelProjection;
+import dev.nokee.model.internal.core.ParentComponent;
+import dev.nokee.model.internal.registry.ModelConfigurer;
+import dev.nokee.model.internal.registry.ModelLookup;
+import dev.nokee.model.internal.state.ModelState;
+import lombok.val;
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.specs.Spec;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+import static dev.nokee.model.internal.core.ModelComponentType.componentOf;
+
+@SuppressWarnings("unchecked")
+public final class ModelActionSystem implements Action<Project> {
+	private final ReentrantAvoidance reentrant = new ReentrantAvoidance();
+	private final ModelLookup lookup;
+
+	public ModelActionSystem(ModelLookup lookup) {
+		this.lookup = lookup;
+	}
+
+	@Override
+	public void execute(Project project) {
+		val configurer = project.getExtensions().getByType(ModelConfigurer.class);
+
+		// Rules to execute actions
+		configurer.configure(ModelActionWithInputs.of(ModelComponentReference.of(ActionSelectorComponent.class), this::onIdentityChanged));
+		configurer.configure(ModelActionWithInputs.of(ModelComponentReference.of(ModelSpecComponent.class), ModelComponentReference.of(ModelActionComponent.class), this::onActionAdded));
+
+		// Rules to keep identity up-to-date
+		configurer.configure(ModelActionWithInputs.of(ModelComponentReference.ofAny(componentOf(ModelProjection.class)), this::updateSelectorForProjection));
+		configurer.configure(ModelActionWithInputs.of(ModelComponentReference.of(ElementNameComponent.class), this::updateSelectorForElementName));
+		configurer.configure(ModelActionWithInputs.of(ModelComponentReference.of(FullyQualifiedNameComponent.class), this::updateSelectorForFullyQualifiedName));
+		configurer.configure(ModelActionWithInputs.of(ModelComponentReference.of(ParentComponent.class), this::updateSelectorForParent));
+		configurer.configure(ModelActionWithInputs.of(ModelComponentReference.of(ModelState.class), this::updateSelectorForState));
+		configurer.configure(ModelActionWithInputs.of(ModelComponentReference.of(ParentComponent.class), this::updateSelectorForAncestors));
+	}
+
+	// ComponentFromEntity<MatchingSpecificationComponent> (readonly) all
+	// ComponentFromEntity<ActionComponent> (readonly) all
+	// ComponentFromEntity<ExecutedActionComponent> (read-write) self
+	private void onIdentityChanged(ModelNode entity, ActionSelectorComponent component) {
+		allActions(lookup, reentrant.andDeferredActions(entity, filter(actionMatching(component),
+			whileIgnoringExecuted(entity, executeAction(entity)))));
+	}
+
+	private static Consumer<ModelNode> executeAction(ModelNode entity) {
+		return it -> it.getComponent(componentOf(ModelActionComponent.class)).get().execute(entity);
+	}
+
+	private static void allActions(ModelLookup lookup, Consumer<? super Iterable<ModelNode>> action) {
+		action.accept(lookup.query(it -> it.hasComponent(componentOf(ModelActionTag.class))).get());
+	}
+
+	private static Consumer<Iterable<ModelNode>> filter(Predicate<? super ModelNode> filter, Consumer<? super Iterable<ModelNode>> action) {
+		return it -> action.accept(Iterables.filter(it, filter::test));
+	}
+
+	//region Sync ExecutedActionComponent
+	private static Consumer<Iterable<ModelNode>> whileIgnoringExecuted(ModelNode entity, Consumer<? super ModelNode> action) {
+		return actionEntities -> {
+			// Retrieve all previously executed actions
+			val ids = new HashSet<>(executedActions(entity));
+
+			// Pass only action entities that were not previously executed
+			for (ModelNode actionEntity : actionEntities) {
+				if (ids.add(actionEntity.getId())) {
+					action.accept(actionEntity);
+				}
+			}
+
+			// Saves executed action list
+			entity.addComponent(new ExecutedActionComponent(ids));
+		};
+	}
+
+	private static Consumer<ModelNode> updateExecutedAfter(ModelNode actionEntity, Consumer<? super ModelNode> action) {
+		return entity -> {
+			// Execute action
+			action.accept(entity);
+
+			// Update executed actions
+			entity.addComponent(new ExecutedActionComponent(ImmutableSet.<ModelEntityId>builder().addAll(executedActions(entity)).add(actionEntity.getId()).build()));
+		};
+	}
+
+	private static Set<ModelEntityId> executedActions(ModelNode entity) {
+		return entity.findComponent(ExecutedActionComponent.class).map(ExecutedActionComponent::get).orElse(Collections.emptySet());
+	}
+	//endregion
+
+	private static Predicate<ModelNode> actionMatching(ActionSelectorComponent component) {
+		return it -> {
+			val identity = it.findComponent(componentOf(ModelSpecComponent.class));
+			return identity.map(actionIdentityComponent -> ((Spec<DomainObjectIdentity>) actionIdentityComponent.get()).isSatisfiedBy(component.get())).orElse(false);
+		};
+	}
+
+	// ComponentFromEntity<ActionSelectorComponent> read-write self
+	private void updateSelectorForElementName(ModelNode entity, ElementNameComponent elementName) {
+		entity.addComponent(new ActionSelectorComponent(entity.findComponent(componentOf(ActionSelectorComponent.class))
+			.map(ActionSelectorComponent::get)
+			.map(it -> it.with(elementName.get()))
+			.orElseGet(() -> DomainObjectIdentity.of(elementName.get()))));
+	}
+
+	// ComponentFromEntity<ActionSelectorComponent> read-write self
+	private void updateSelectorForFullyQualifiedName(ModelNode entity, FullyQualifiedNameComponent fullyQualifiedName) {
+		entity.addComponent(new ActionSelectorComponent(entity.findComponent(componentOf(ActionSelectorComponent.class))
+			.map(ActionSelectorComponent::get)
+			.map(it -> it.with(fullyQualifiedName.get()))
+			.orElseGet(() -> DomainObjectIdentity.of(fullyQualifiedName.get()))));
+	}
+
+	// ComponentFromEntity<ActionSelectorComponent> read-write self
+	private void updateSelectorForState(ModelNode entity, ModelState state) {
+		entity.addComponent(new ActionSelectorComponent(entity.findComponent(componentOf(ActionSelectorComponent.class))
+			.map(ActionSelectorComponent::get)
+			.map(it -> it.with(state))
+			.orElseGet(() -> DomainObjectIdentity.of(state))));
+	}
+
+	// ComponentFromEntity<ActionSelectorComponent> read-write self
+	private void updateSelectorForParent(ModelNode entity, ParentComponent parent) {
+		entity.addComponent(new ActionSelectorComponent(entity.findComponent(componentOf(ActionSelectorComponent.class))
+			.map(ActionSelectorComponent::get)
+			.map(it -> it.with(new ParentRef(parent.get().getId())))
+			.orElseGet(() -> DomainObjectIdentity.of(new ParentRef(parent.get().getId())))));
+	}
+
+	// ComponentFromEntity<ActionSelectorComponent> read-write self
+	private void updateSelectorForProjection(ModelNode entity, ModelProjection projection) {
+		entity.addComponent(new ActionSelectorComponent(entity.findComponent(componentOf(ActionSelectorComponent.class))
+			.map(ActionSelectorComponent::get)
+			.map(it -> it.with(it.get(ProjectionTypes.class).map(t -> t.plus(projection.getType())).orElseGet(() -> ProjectionTypes.of(projection.getType()))))
+			.orElseGet(() -> DomainObjectIdentity.of(ProjectionTypes.of(projection.getType())))));
+	}
+
+	// ComponentFromEntity<ParentComponent> read-only all
+	// ComponentFromEntity<ActionSelectorComponent> read-write self
+	private void updateSelectorForAncestors(ModelNode entity, ParentComponent parent) {
+		val ancestors = ImmutableSet.<ModelEntityId>builder();
+		Optional<ParentComponent> parentComponent = Optional.of(parent);
+		while(parentComponent.isPresent()) {
+			ancestors.add(parentComponent.get().get().getId());
+			parentComponent = parentComponent.flatMap(it -> it.get().findComponent(componentOf(ParentComponent.class)));
+		}
+
+		entity.addComponent(new ActionSelectorComponent(entity.findComponent(componentOf(ActionSelectorComponent.class))
+			.map(ActionSelectorComponent::get)
+			.map(it -> it.with(new Ancestors(ancestors.build())))
+			.orElseGet(() -> DomainObjectIdentity.of(new Ancestors(ancestors.build())))));
+	}
+
+	// ComponentFromEntity<ActionSelectorComponent> (readonly) all
+	// ComponentFromEntity<ExecutedActionComponent> (read-write) all
+	private void onActionAdded(ModelNode entity, ModelSpecComponent identity, ModelActionComponent component) {
+		allEntities(lookup, filter(onlyMatching(identity),
+			it -> it.forEach(reentrant.ifPossible(entity, updateExecutedAfter(entity, executeAction(component))))));
+	}
+
+	private static Consumer<ModelNode> executeAction(ModelActionComponent component) {
+		return it -> component.get().execute(it);
+	}
+
+	private static void allEntities(ModelLookup lookup, Consumer<? super Iterable<ModelNode>> action) {
+		action.accept(lookup.query(it -> it.hasComponent(componentOf(ActionSelectorComponent.class))).get());
+	}
+
+	private static Predicate<ModelNode> onlyMatching(ModelSpecComponent component) {
+		return entity -> {
+			val selector = entity.findComponent(componentOf(ActionSelectorComponent.class));
+			return selector.map(t -> ((Spec<DomainObjectIdentity>) component.get()).isSatisfiedBy(t.get())).orElse(false);
+		};
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/ModelActionTag.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/ModelActionTag.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+final class ModelActionTag {
+	private static final ModelActionTag INSTANCE = new ModelActionTag();
+
+	private ModelActionTag() {}
+
+	public static ModelActionTag tag() {
+		return INSTANCE;
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/ModelSpec.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/ModelSpec.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import dev.nokee.model.internal.core.ModelEntityId;
+import dev.nokee.model.internal.state.ModelState;
+import dev.nokee.model.internal.type.ModelType;
+
+import java.util.Objects;
+
+/**
+ * A model specification represent a smart query to match entities scoped by the {@link ModelAction}.
+ *
+ * <b>Note:</b> This interface is not intended for implementation by build script or plugin authors.
+ * Use one of the factory methods available.
+ */
+public interface ModelSpec {
+	/**
+	 * Creates a new intersecting specification where both this and the specified specification needs to be satisfied.
+	 *
+	 * @param other  the other specification to satisfy, must not be null
+	 * @return a new intersecting specification, never null
+	 */
+	default ModelSpec and(ModelSpec other) {
+		return new AndSpec(this, other);
+	}
+
+	/**
+	 * Creates a specification that match for the specified name.
+	 * You can use any name object, e.g. {@link dev.nokee.model.internal.FullyQualifiedName}, {@link dev.nokee.model.internal.ElementName}, etc.
+	 * Although, the method can accept a {@code String} name, it would almost certainly be wrong as names are represented by custom type relative to their function.
+	 *
+	 * @param name  the entity name to satisfy, must not be null
+	 * @return a new specification matching the specified name, never null
+	 */
+	static ModelSpec named(Object name) {
+		return new NamedSpec(Objects.requireNonNull(name));
+	}
+
+	/**
+	 * Creates a specification that match for the specified base type.
+	 *
+	 * @param type  a base type to match entity projections, must not be null
+	 * @return a new specification matching the specified base type, never null
+	 */
+	static ModelSpec subtypeOf(ModelType<?> type) {
+		return new WithTypeSpec(Objects.requireNonNull(type));
+	}
+
+	/**
+	 * Creates a specification that match at least the specified state.
+	 *
+	 * @param state  the minimum entity state to satisfy, must not be null
+	 * @return a new specification matching the specified entity state, never null
+	 */
+	static ModelSpec stateAtLeast(ModelState state) {
+		return new StateAtLeastSpec(Objects.requireNonNull(state));
+	}
+
+	/**
+	 * Creates a specification that match the direct parent of an entity.
+	 *
+	 * @param entityRef  the parent entity reference to satisfy, must not be null
+	 * @return a new specification matching the specified parent entity, never null
+	 */
+	static ModelSpec ownedBy(ModelEntityId entityRef) {
+		return new DirectDescendantSpec(Objects.requireNonNull(entityRef));
+	}
+
+	/**
+	 * Creates a specification that match any ancestors of an entity.
+	 *
+	 * @param entityRef  a ancestor entity reference to satisfy, must not be null
+	 * @return a new specification matching the specified ancestor entity, never null
+	 */
+	static ModelSpec descendantOf(ModelEntityId entityRef) {
+		return new AncestorSpec(Objects.requireNonNull(entityRef));
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/ModelSpecComponent.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/ModelSpecComponent.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import dev.nokee.model.internal.core.ModelComponent;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode
+final class ModelSpecComponent implements ModelComponent {
+	private final ModelSpec spec;
+
+	public ModelSpecComponent(ModelSpec spec) {
+		this.spec = spec;
+	}
+
+	public ModelSpec get() {
+		return spec;
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/NamedSpec.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/NamedSpec.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import lombok.EqualsAndHashCode;
+import org.gradle.api.specs.Spec;
+
+/**
+ * @see ModelSpec#named(Object)
+ */
+@EqualsAndHashCode
+final class NamedSpec implements Spec<DomainObjectIdentity>, ModelSpec {
+	private final Object name;
+
+	public NamedSpec(Object name) {
+		this.name = name;
+	}
+
+	@Override
+	public boolean isSatisfiedBy(DomainObjectIdentity identity) {
+		return identity.get(name.getClass()).map(name::equals).orElse(false);
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/ParentRef.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/ParentRef.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import dev.nokee.model.internal.core.ModelEntityId;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode
+final class ParentRef {
+	private final ModelEntityId entityRef;
+
+	public ParentRef(ModelEntityId entityRef) {
+		this.entityRef = entityRef;
+	}
+
+	public ModelEntityId get() {
+		return entityRef;
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/ProjectionTypes.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/ProjectionTypes.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import com.google.common.collect.ImmutableSet;
+import dev.nokee.model.internal.type.ModelType;
+
+import java.util.Iterator;
+import java.util.Set;
+import java.util.stream.Stream;
+
+final class ProjectionTypes implements Iterable<ModelType<?>> {
+	private final Set<ModelType<?>> values;
+
+	public ProjectionTypes(Set<ModelType<?>> values) {
+		this.values = values;
+	}
+
+	public ProjectionTypes plus(ModelType<?> element) {
+		return new ProjectionTypes(ImmutableSet.<ModelType<?>>builder().addAll(values).add(element).build());
+	}
+
+	public Stream<ModelType<?>> stream() {
+		return values.stream();
+	}
+
+	@Override
+	public Iterator<ModelType<?>> iterator() {
+		return values.iterator();
+	}
+
+	public static ProjectionTypes of(ModelType<?> first, ModelType<?>... others) {
+		return new ProjectionTypes(ImmutableSet.<ModelType<?>>builder().add(first).add(others).build());
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/ReentrantAvoidance.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/ReentrantAvoidance.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import com.google.common.collect.Iterables;
+import dev.nokee.model.internal.core.ModelEntityId;
+import dev.nokee.model.internal.core.ModelNode;
+import lombok.val;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.function.Consumer;
+
+final class ReentrantAvoidance {
+	private final Map<ModelEntityId, Deque<ModelNode>> scope = new HashMap<>();
+
+	public Consumer<Iterable<ModelNode>> andDeferredActions(ModelNode entity, Consumer<? super Iterable<ModelNode>> action) {
+		return actionEntities -> {
+			if (scope.containsKey(entity.getId())) {
+				throw new IllegalStateException();
+			}
+			val leftovers = new ArrayDeque<ModelNode>();
+			scope.put(entity.getId(), leftovers);
+
+			action.accept(Iterables.concat(actionEntities, new IterableOnce<>(new RemoveFirstIterator<>(leftovers))));
+
+			scope.remove(entity.getId());
+		};
+	}
+
+	public Consumer<ModelNode> ifPossible(ModelNode actionEntity, Consumer<ModelNode> action) {
+		return entity -> {
+			if (scope.containsKey(entity.getId())) {
+				scope.get(entity.getId()).add(actionEntity);
+			} else {
+				action.accept(entity);
+			}
+		};
+	}
+
+	private static final class RemoveFirstIterator<T> implements Iterator<T> {
+		private final Deque<T> values;
+
+		private RemoveFirstIterator(Deque<T> values) {
+			this.values = values;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return !values.isEmpty();
+		}
+
+		@Override
+		public T next() {
+			return values.removeFirst();
+		}
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/StateAtLeastSpec.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/StateAtLeastSpec.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import dev.nokee.model.internal.state.ModelState;
+import lombok.EqualsAndHashCode;
+import org.gradle.api.specs.Spec;
+
+/**
+ * @see ModelSpec#stateAtLeast(ModelState)
+ */
+@EqualsAndHashCode
+final class StateAtLeastSpec implements Spec<DomainObjectIdentity>, ModelSpec {
+	private final ModelState state;
+
+	public StateAtLeastSpec(ModelState state) {
+		this.state = state;
+	}
+
+	@Override
+	public boolean isSatisfiedBy(DomainObjectIdentity identity) {
+		return identity.get(ModelState.class).map(it -> it.isAtLeast(state)).orElse(false);
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/WithTypeSpec.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/actions/WithTypeSpec.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import dev.nokee.model.internal.type.ModelType;
+import lombok.EqualsAndHashCode;
+import org.gradle.api.specs.Spec;
+
+/**
+ * @see ModelSpec#subtypeOf(ModelType) to create new instance
+ */
+@EqualsAndHashCode
+final class WithTypeSpec implements Spec<DomainObjectIdentity>, ModelSpec {
+	private final ModelType<?> type;
+
+	public WithTypeSpec(ModelType<?> type) {
+		this.type = type;
+	}
+
+	@Override
+	public boolean isSatisfiedBy(DomainObjectIdentity identity) {
+		return identity.get(ProjectionTypes.class).map(it -> it.stream().anyMatch(type::isSupertypeOf)).orElse(false);
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ElementName.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ElementName.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.core;
+
+import lombok.EqualsAndHashCode;
+
+/**
+ * An element name represent the name of a domain object regardless of its owners.
+ * The name is non-unique across all domain objects of a project.
+ * For example, the element name of a task that assemble the output of a component is {@literal assemble}.
+ * However, it's fully qualified name may be {@literal assembleFoo} for the {@literal foo} component.
+ * In some cases, the element name may be the same as the fully qualified name such as the assemble task of the {@literal main} component.
+ * It's important to keep in mind that both name represent different things.
+ */
+@EqualsAndHashCode
+public final class ElementName {
+	private final String name;
+
+	private ElementName(String name) {
+		this.name = name;
+	}
+
+	@Override
+	public String toString() {
+		return name;
+	}
+
+	public static ElementName of(String name) {
+		return new ElementName(name);
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ElementNameComponent.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ElementNameComponent.java
@@ -15,22 +15,18 @@
  */
 package dev.nokee.model.internal.core;
 
-import java.util.function.Supplier;
-
-public final class ElementNameComponent implements Supplier<String>, ModelComponent {
-	private final String value;
+public final class ElementNameComponent implements ModelComponent {
+	private final ElementName value;
 
 	public ElementNameComponent(String value) {
+		this.value = ElementName.of(value);
+	}
+
+	public ElementNameComponent(ElementName value) {
 		this.value = value;
 	}
 
-	@Override
-	public String get() {
-		return value;
-	}
-
-	@Override
-	public String toString() {
+	public ElementName get() {
 		return value;
 	}
 }

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelBackedModelElementLookupStrategy.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelBackedModelElementLookupStrategy.java
@@ -32,13 +32,13 @@ public final class ModelBackedModelElementLookupStrategy implements ModelElement
 	@Override
 	public ModelElement get(String name) {
 		assert name != null;
-		return elementFactory.createElement(ModelNodeUtils.getDirectDescendants(entity).stream().filter(it -> it.getComponent(ElementNameComponent.class).get().equals(name)).collect(MoreCollectors.onlyElement()));
+		return elementFactory.createElement(ModelNodeUtils.getDirectDescendants(entity).stream().filter(it -> it.getComponent(ElementNameComponent.class).get().toString().equals(name)).collect(MoreCollectors.onlyElement()));
 	}
 
 	@Override
 	public <S> DomainObjectProvider<S> get(String name, ModelType<S> type) {
 		assert name != null;
 		assert type != null;
-		return elementFactory.createObject(ModelNodeUtils.getDirectDescendants(entity).stream().filter(it -> it.getComponent(ElementNameComponent.class).get().equals(name) && ModelNodeUtils.canBeViewedAs(it, type)).collect(MoreCollectors.onlyElement()), type);
+		return elementFactory.createObject(ModelNodeUtils.getDirectDescendants(entity).stream().filter(it -> it.getComponent(ElementNameComponent.class).get().toString().equals(name) && ModelNodeUtils.canBeViewedAs(it, type)).collect(MoreCollectors.onlyElement()), type);
 	}
 }

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelBackedModelElementLookupStrategy.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelBackedModelElementLookupStrategy.java
@@ -17,6 +17,7 @@ package dev.nokee.model.internal.core;
 
 import com.google.common.collect.MoreCollectors;
 import dev.nokee.model.DomainObjectProvider;
+import dev.nokee.model.internal.ElementNameComponent;
 import dev.nokee.model.internal.ModelElementFactory;
 import dev.nokee.model.internal.type.ModelType;
 

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelComponentReference.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelComponentReference.java
@@ -90,7 +90,11 @@ public abstract class ModelComponentReference<T> {
 		@Override
 		@SuppressWarnings("unchecked")
 		public T get(ModelNode entity) {
-			return (T) entity.getComponents().filter(it -> componentType.isSupertypeOf(ModelComponentType.ofInstance(it))).findFirst().orElseThrow(RuntimeException::new);
+			if (componentType.equals(ModelComponentType.componentOf(ModelProjection.class))) {
+				return (T) entity.getComponents().filter(it -> componentType.isSupertypeOf(ModelComponentType.ofInstance(it))).reduce((a, b) -> b).orElseThrow(RuntimeException::new);
+			} else {
+				return (T) entity.getComponents().filter(it -> componentType.isSupertypeOf(ModelComponentType.ofInstance(it))).findFirst().orElseThrow(RuntimeException::new);
+			}
 		}
 
 		@Override

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelComponentType.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelComponentType.java
@@ -94,7 +94,9 @@ public abstract class ModelComponentType<T> {
 
 		@Override
 		public boolean isSupertypeOf(ModelComponentType<?> componentType) {
-			if (componentType instanceof ComponentType) {
+			if (value.equals(ModelProjection.class) && componentType instanceof ProjectionType) {
+				return true;
+			} else if (componentType instanceof ComponentType) {
 				return value.isAssignableFrom(((ComponentType<?>) componentType).getValue());
 			}
 			return false;

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelNode.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelNode.java
@@ -17,6 +17,7 @@ package dev.nokee.model.internal.core;
 
 import dev.nokee.internal.reflect.Instantiator;
 import dev.nokee.model.DomainObjectProvider;
+import dev.nokee.model.internal.ElementNameComponent;
 import dev.nokee.model.internal.registry.ModelConfigurer;
 import dev.nokee.model.internal.registry.ModelLookup;
 import dev.nokee.model.internal.registry.ModelRegistry;

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/plugins/ModelBasePlugin.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/plugins/ModelBasePlugin.java
@@ -19,6 +19,7 @@ import dev.nokee.model.internal.DomainObjectEventPublisher;
 import dev.nokee.model.internal.DomainObjectEventPublisherImpl;
 import dev.nokee.model.internal.RealizableDomainObjectRealizer;
 import dev.nokee.model.internal.RealizableDomainObjectRealizerImpl;
+import dev.nokee.model.internal.actions.ModelActionSystem;
 import dev.nokee.model.internal.core.ModelPropertyRegistrationFactory;
 import dev.nokee.model.internal.registry.DefaultModelRegistry;
 import dev.nokee.model.internal.registry.ModelConfigurer;
@@ -49,5 +50,6 @@ public class ModelBasePlugin implements Plugin<Project> {
 
 		modelRegistry.configure(new AttachDisplayNameToGradleProperty());
 		modelRegistry.configure(new UseModelPropertyIdentifierAsDisplayName());
+		new ModelActionSystem(modelRegistry).execute(project);
 	}
 }

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/registry/DefaultModelRegistry.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/registry/DefaultModelRegistry.java
@@ -23,7 +23,7 @@ import dev.nokee.model.internal.core.BindManagedProjectionService;
 import dev.nokee.model.internal.core.Bits;
 import dev.nokee.model.internal.core.DescendantNodes;
 import dev.nokee.model.internal.core.DisplayNameComponent;
-import dev.nokee.model.internal.core.ElementNameComponent;
+import dev.nokee.model.internal.ElementNameComponent;
 import dev.nokee.model.internal.core.HasInputs;
 import dev.nokee.model.internal.core.ModelAction;
 import dev.nokee.model.internal.core.ModelActionWithInputs;

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/ElementNameTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/ElementNameTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal;
+
+import dev.nokee.model.internal.core.ElementName;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasToString;
+
+class ElementNameTest {
+	@Test
+	void checkEquals() {
+		EqualsVerifier.forClass(ElementName.class)
+			.verify();
+	}
+
+	@Test
+	void canConvertToString() {
+		assertThat(ElementName.of("taqe"), hasToString("taqe"));
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/ElementNameTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/ElementNameTest.java
@@ -15,7 +15,6 @@
  */
 package dev.nokee.model.internal;
 
-import dev.nokee.model.internal.core.ElementName;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/FullyQualifiedNameTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/FullyQualifiedNameTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasToString;
+
+class FullyQualifiedNameTest {
+	@Test
+	void canConvertToString() {
+		assertThat(FullyQualifiedName.of("leqe"), hasToString("leqe"));
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/FullyQualifiedNameTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/FullyQualifiedNameTest.java
@@ -15,12 +15,19 @@
  */
 package dev.nokee.model.internal;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasToString;
 
 class FullyQualifiedNameTest {
+	@Test
+	void checkEquals() {
+		EqualsVerifier.forClass(FullyQualifiedName.class)
+			.verify();
+	}
+
 	@Test
 	void canConvertToString() {
 		assertThat(FullyQualifiedName.of("leqe"), hasToString("leqe"));

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/DomainObjectIdentityTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/DomainObjectIdentityTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import com.google.common.testing.NullPointerTester;
+import dev.nokee.model.internal.actions.DomainObjectIdentity;
+import org.junit.jupiter.api.Test;
+
+import static com.spotify.hamcrest.optional.OptionalMatchers.emptyOptional;
+import static com.spotify.hamcrest.optional.OptionalMatchers.optionalWithValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class DomainObjectIdentityTest {
+	private static final MyValue VALUE = new MyValue();
+	private static final MyValue ALTERNATE_VALUE = new MyValue();
+	private static final MyOtherValue OTHER_VALUE = new MyOtherValue();
+	private final DomainObjectIdentity subject = DomainObjectIdentity.of(VALUE);
+
+	@Test
+	void returnsCurrentValueWhenExist() {
+		assertThat(subject.get(MyValue.class), optionalWithValue(equalTo(VALUE)));
+	}
+
+	@Test
+	void returnsEmptyWhenValueDoesNotExists() {
+		assertThat(subject.get(MyOtherValue.class), emptyOptional());
+	}
+
+	@Test
+	void canReplaceCurrentValue() {
+		assertThat(subject.with(ALTERNATE_VALUE).get(MyValue.class), optionalWithValue(equalTo(ALTERNATE_VALUE)));
+	}
+
+	@Test
+	@SuppressWarnings("UnstableApiUsage")
+	void checkNullsOnPublicMethods() {
+		new NullPointerTester().testAllPublicInstanceMethods(subject);
+	}
+
+	@Test
+	@SuppressWarnings("UnstableApiUsage")
+	void checkNullsOnPublicStaticMethods() {
+		new NullPointerTester().testAllPublicStaticMethods(DomainObjectIdentity.class);
+	}
+
+	@Test
+	void canSetNonExistentValue() {
+		assertThat(subject.with(OTHER_VALUE).get(MyOtherValue.class), optionalWithValue(equalTo(OTHER_VALUE)));
+	}
+
+	@Test
+	void doesNotChangeOriginalSubject() {
+		subject.with(ALTERNATE_VALUE);
+		assertThat(subject.get(MyValue.class), optionalWithValue(equalTo(VALUE)));
+	}
+
+	private static final class MyValue {}
+	private static final class MyOtherValue {}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/ModelActionComponentTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/ModelActionComponentTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class ModelActionComponentTest {
+	@Test
+	void checkEquals() {
+		EqualsVerifier.forClass(ModelActionComponent.class).verify();
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/ModelActionTester.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/ModelActionTester.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import dev.nokee.model.internal.core.ModelRegistration;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.isA;
+
+interface ModelActionTester {
+	ModelRegistration subject();
+
+	@Test
+	default void hasSelectorComponent() {
+		assertThat(subject().getComponents(), hasItem(isA(ModelSpecComponent.class)));
+	}
+
+	@Test
+	default void hasModelActionComponent() {
+		assertThat(subject().getComponents(), hasItem(isA(ModelActionComponent.class)));
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/ModelAction_ConfigureEachTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/ModelAction_ConfigureEachTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import dev.nokee.model.internal.core.ModelRegistration;
+import dev.nokee.model.internal.state.ModelState;
+import org.gradle.api.Action;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static dev.nokee.model.internal.actions.ModelSpec.stateAtLeast;
+import static dev.nokee.model.internal.actions.ModelSpec.subtypeOf;
+import static dev.nokee.model.internal.type.ModelType.of;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+
+@ExtendWith(MockitoExtension.class)
+class ModelAction_ConfigureEachTest {
+	@Nested
+	class ByTypeOnlyTest implements ModelActionTester {
+		@Mock private Action<MyType> action;
+		private ModelRegistration subject;
+
+		@BeforeEach
+		void createSubject() {
+			subject = ModelAction.configureEach(MyType.class, action);
+		}
+
+		@Override
+		public ModelRegistration subject() {
+			return subject;
+		}
+
+		@Test
+		void usesIntersectionOfSpecifiedTypeAndStateInComponent() {
+			assertThat(subject.getComponents(), hasItem(new ModelSpecComponent(subtypeOf(of(MyType.class)).and(stateAtLeast(ModelState.Realized)))));
+		}
+
+		@Test
+		void usesSpecifiedActionInComponent() {
+			assertThat(subject.getComponents(), hasItem(new ModelActionComponent(new ModelActionAdapter<>(of(MyType.class), action))));
+		}
+	}
+
+	@Nested
+	class BySpecAndTypeTest implements ModelActionTester {
+		@Mock private ModelSpec spec;
+		@Mock private Action<MyType> action;
+		private ModelRegistration subject;
+
+		@BeforeEach
+		void createSubject() {
+			subject = ModelAction.configureEach(spec, MyType.class, action);
+		}
+
+		@Override
+		public ModelRegistration subject() {
+			return subject;
+		}
+
+		@Test
+		void usesIntersectionOfSpecifiedSpec_Type_AndStateInComponent() {
+			assertThat(subject.getComponents(), hasItem(new ModelSpecComponent(subtypeOf(of(MyType.class)).and(stateAtLeast(ModelState.Realized)).and(spec))));
+		}
+
+		@Test
+		void usesSpecifiedActionInComponent() {
+			assertThat(subject.getComponents(), hasItem(new ModelActionComponent(new ModelActionAdapter<>(of(MyType.class), action))));
+		}
+	}
+
+	private interface MyType {}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/ModelAction_ConfigureMatchingTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/ModelAction_ConfigureMatchingTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import dev.nokee.model.internal.core.ModelRegistration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+
+@ExtendWith(MockitoExtension.class)
+class ModelAction_ConfigureMatchingTest implements ModelActionTester {
+	@Mock private ModelSpec spec;
+	@Mock private ModelAction action;
+	private ModelRegistration subject;
+
+	@BeforeEach
+	void createSubject() {
+		subject = ModelAction.configureMatching(spec, action);
+	}
+
+	@Override
+	public ModelRegistration subject() {
+		return subject;
+	}
+
+	@Test
+	void usesSpecifiedSpecInComponent() {
+		assertThat(subject.getComponents(), hasItem(new ModelSpecComponent(spec)));
+	}
+
+	@Test
+	void usesSpecifiedActionInComponent() {
+		assertThat(subject.getComponents(), hasItem(new ModelActionComponent(action)));
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/ModelAction_ConfigureTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/ModelAction_ConfigureTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import dev.nokee.model.internal.core.ModelRegistration;
+import org.gradle.api.Action;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ModelAction_ConfigureTest implements ModelActionTester {
+	@Mock private Action<MyType> action;
+	private ModelRegistration subject;
+
+	@BeforeEach
+	void createSubject() {
+		subject = ModelAction.configure("kdel", MyType.class, action);
+	}
+
+	@Override
+	public ModelRegistration subject() {
+		return subject;
+	}
+
+	private interface MyType {}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/ModelAction_WhenElementKnownTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/ModelAction_WhenElementKnownTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import dev.nokee.model.KnownDomainObject;
+import dev.nokee.model.internal.core.ModelRegistration;
+import dev.nokee.model.internal.state.ModelState;
+import org.gradle.api.Action;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static dev.nokee.model.internal.actions.ModelSpec.stateAtLeast;
+import static dev.nokee.model.internal.actions.ModelSpec.subtypeOf;
+import static dev.nokee.model.internal.type.ModelType.of;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+
+@ExtendWith(MockitoExtension.class)
+class ModelAction_WhenElementKnownTest {
+	@Nested
+	class ByTypeOnlyTest implements ModelActionTester {
+		@Mock private Action<KnownDomainObject<MyType>> action;
+		private ModelRegistration subject;
+
+		@BeforeEach
+		void createSubject() {
+			subject = ModelAction.whenElementKnown(MyType.class, action);
+		}
+
+		@Override
+		public ModelRegistration subject() {
+			return subject;
+		}
+
+		@Test
+		void usesIntersectionOfSpecifiedSpec_Type_AndStateInComponent() {
+			assertThat(subject.getComponents(), hasItem(new ModelSpecComponent(subtypeOf(of(MyType.class)).and(stateAtLeast(ModelState.Registered)))));
+		}
+
+		@Test
+		void usesSpecifiedActionInComponent() {
+			assertThat(subject.getComponents(), hasItem(new ModelActionComponent(new ModelActionKnownDomainObjectAdapter<>(of(MyType.class), action))));
+		}
+	}
+
+	@Nested
+	class BySpecAndTypeTest implements ModelActionTester {
+		@Mock private ModelSpec spec;
+		@Mock private Action<KnownDomainObject<MyType>> action;
+		private ModelRegistration subject;
+
+		@BeforeEach
+		void createSubject() {
+			subject = ModelAction.whenElementKnown(spec, MyType.class, action);
+		}
+
+		@Override
+		public ModelRegistration subject() {
+			return subject;
+		}
+
+		@Test
+		void usesIntersectionOfSpecifiedSpecAndTypeAndStateInComponent() {
+			assertThat(subject.getComponents(), hasItem(new ModelSpecComponent(subtypeOf(of(MyType.class)).and(stateAtLeast(ModelState.Registered)).and(spec))));
+		}
+
+		@Test
+		void usesSpecifiedActionInComponent() {
+			assertThat(subject.getComponents(), hasItem(new ModelActionComponent(new ModelActionKnownDomainObjectAdapter<>(of(MyType.class), action))));
+		}
+	}
+
+	private interface MyType {}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/ModelSpecAndEqualityTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/ModelSpecAndEqualityTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ModelSpecAndEqualityTest {
+	@Mock private ModelSpec spec0;
+	@Mock private ModelSpec spec1;
+	@Mock private ModelSpec spec2;
+	@Mock private ModelSpec spec3;
+
+	@Test
+	@SuppressWarnings("UnstableApiUsage")
+	void anyIntersectSpecTreeOfSameSpecsOrder() {
+		new EqualsTester()
+			.addEqualityGroup(
+				new AndSpec(spec0, spec1).and(spec2).and(spec3),
+				new AndSpec(spec0, spec1).and(new AndSpec(spec2, spec3)),
+				new AndSpec(spec0, new AndSpec(spec1, spec2)).and(spec3),
+				new AndSpec(spec0, new AndSpec(spec1, spec2).and(spec3))
+			)
+			.testEquals();
+	}
+
+	@Test
+	@SuppressWarnings("UnstableApiUsage")
+	void inAnyOrders() {
+		new EqualsTester()
+			.addEqualityGroup(
+				new AndSpec(spec0, spec1).and(spec2).and(spec3),
+				new AndSpec(spec3, spec1).and(spec0).and(spec2),
+				new AndSpec(spec1, spec3).and(new AndSpec(spec2, spec0))
+			)
+			.testEquals();
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/ModelSpecComponentTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/ModelSpecComponentTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class ModelSpecComponentTest {
+	@Test
+	void checkEquals() {
+		EqualsVerifier.forClass(ModelSpecComponent.class).verify();
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/ModelSpecNullTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/ModelSpecNullTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import com.google.common.testing.NullPointerTester;
+import org.junit.jupiter.api.Test;
+
+class ModelSpecNullTest {
+	@Test
+	@SuppressWarnings("UnstableApiUsage")
+	void checkNullsOnAllPublicStaticMethods() {
+		new NullPointerTester().testAllPublicStaticMethods(ModelSpec.class);
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/ModelSpecTester.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/ModelSpecTester.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import com.google.common.reflect.TypeToken;
+import com.google.common.testing.NullPointerTester;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.gradle.api.specs.Spec;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.model.internal.actions.ModelSpecTester.TestSpec.SATISFY_ALL;
+import static dev.nokee.model.internal.actions.ModelSpecTester.TestSpec.SATISFY_NONE;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+interface ModelSpecTester<T extends ModelSpec & Spec<DomainObjectIdentity>> {
+	T subject();
+
+	DomainObjectIdentity satisfyingInput();
+	DomainObjectIdentity notSatisfyingInput();
+
+	@BeforeEach
+	default void verifyInvariance() {
+		assertTrue(subject().isSatisfiedBy(satisfyingInput()));
+		assertFalse(subject().isSatisfiedBy(notSatisfyingInput()));
+	}
+
+	@Test
+	default void checkEquals() {
+		EqualsVerifier.forClass(specClass()).verify();
+	}
+
+	@Test
+	@SuppressWarnings("UnstableApiUsage")
+	default void checkNullsOnAllPublicMethods() {
+		new NullPointerTester().testAllPublicInstanceMethods(subject());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	default void canCombineWithSatisfyNoneSpec() {
+		assertFalse(((Spec<DomainObjectIdentity>) subject().and(SATISFY_NONE)).isSatisfiedBy(satisfyingInput()));
+		assertFalse(((Spec<DomainObjectIdentity>) subject().and(SATISFY_NONE)).isSatisfiedBy(notSatisfyingInput()));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	default void canCombineWithSatisfyAllSpec() {
+		assertTrue(((Spec<DomainObjectIdentity>) subject().and(SATISFY_ALL)).isSatisfiedBy(satisfyingInput()));
+		assertFalse(((Spec<DomainObjectIdentity>) subject().and(SATISFY_ALL)).isSatisfiedBy(notSatisfyingInput()));
+	}
+
+	@SuppressWarnings({"unchecked", "UnstableApiUsage"})
+	default Class<T> specClass() {
+		return (Class<T>) new TypeToken<T>(getClass()) {}.getRawType();
+	}
+
+	default DomainObjectIdentity emptyIdentity() {
+		return DomainObjectIdentity.of(new Object());
+	}
+
+	enum TestSpec implements Spec<DomainObjectIdentity>, ModelSpec {
+		SATISFY_NONE {
+			@Override
+			public boolean isSatisfiedBy(DomainObjectIdentity domainObjectIdentity) {
+				return false;
+			}
+		},
+		SATISFY_ALL {
+			@Override
+			public boolean isSatisfiedBy(DomainObjectIdentity domainObjectIdentity) {
+				return true;
+			}
+		}
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/ModelSpec_AncestorTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/ModelSpec_AncestorTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.model.internal.actions.ModelSpec.descendantOf;
+import static dev.nokee.model.internal.core.ModelEntityId.ofId;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class ModelSpec_AncestorTest implements ModelSpecTester<AncestorSpec> {
+	@Override
+	public AncestorSpec subject() {
+		return new AncestorSpec(ofId(32));
+	}
+
+	@Override
+	public DomainObjectIdentity satisfyingInput() {
+		return DomainObjectIdentity.of(new Ancestors(ImmutableSet.of(ofId(12), ofId(32))));
+	}
+
+	@Override
+	public DomainObjectIdentity notSatisfyingInput() {
+		return DomainObjectIdentity.of(new Ancestors(ImmutableSet.of(ofId(12))));
+	}
+
+	@Test
+	void doesNotSatisfyOnEmptyIdentity() {
+		assertFalse(subject().isSatisfiedBy(emptyIdentity()));
+	}
+
+	@Test
+	void canCreateSpecUsingFactoryMethod() {
+		assertEquals(new AncestorSpec(ofId(987)), descendantOf(ofId(987)));
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/ModelSpec_DirectDescendantTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/ModelSpec_DirectDescendantTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.model.internal.actions.ModelSpec.ownedBy;
+import static dev.nokee.model.internal.core.ModelEntityId.ofId;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class ModelSpec_DirectDescendantTest implements ModelSpecTester<DirectDescendantSpec> {
+	@Override
+	public DirectDescendantSpec subject() {
+		return new DirectDescendantSpec(ofId(32));
+	}
+
+	@Override
+	public DomainObjectIdentity satisfyingInput() {
+		return DomainObjectIdentity.of(new ParentRef(ofId(32)));
+	}
+
+	@Override
+	public DomainObjectIdentity notSatisfyingInput() {
+		return DomainObjectIdentity.of(new ParentRef(ofId(54)));
+	}
+
+	@Test
+	void doesNotSatisfyOnEmptyIdentity() {
+		assertFalse(subject().isSatisfiedBy(emptyIdentity()));
+	}
+
+	@Test
+	void canCreateSpecUsingFactoryMethod() {
+		assertEquals(new DirectDescendantSpec(ofId(675)), ownedBy(ofId(675)));
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/ModelSpec_NamedTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/ModelSpec_NamedTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.model.internal.actions.ModelSpec.named;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class ModelSpec_NamedTest implements ModelSpecTester<NamedSpec> {
+	@Override
+	public NamedSpec subject() {
+		return new NamedSpec("ldok");
+	}
+
+	@Override
+	public DomainObjectIdentity satisfyingInput() {
+		return DomainObjectIdentity.of("ldok");
+	}
+
+	@Override
+	public DomainObjectIdentity notSatisfyingInput() {
+		return DomainObjectIdentity.of("nope");
+	}
+
+	@Test
+	void doesNotSatisfyOnEmptyIdentity() {
+		assertFalse(subject().isSatisfiedBy(emptyIdentity()));
+	}
+
+	@Test
+	void canCreateSpecUsingFactoryMethod() {
+		assertEquals(new NamedSpec("same"), named("same"));
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/ModelSpec_StateAtLeastTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/ModelSpec_StateAtLeastTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import dev.nokee.model.internal.state.ModelState;
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.model.internal.actions.ModelSpec.stateAtLeast;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class ModelSpec_StateAtLeastTest implements ModelSpecTester<StateAtLeastSpec> {
+	@Override
+	public StateAtLeastSpec subject() {
+		return new StateAtLeastSpec(ModelState.Realized);
+	}
+
+	@Override
+	public DomainObjectIdentity satisfyingInput() {
+		return DomainObjectIdentity.of(ModelState.Realized);
+	}
+
+	@Override
+	public DomainObjectIdentity notSatisfyingInput() {
+		return DomainObjectIdentity.of(ModelState.Created);
+	}
+
+	@Test
+	void doesNotSatisfyOnEmptyIdentity() {
+		assertFalse(subject().isSatisfiedBy(emptyIdentity()));
+	}
+
+	@Test
+	void canCreateSpecUsingFactoryMethod() {
+		assertEquals(new StateAtLeastSpec(ModelState.Created), stateAtLeast(ModelState.Created));
+	}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/ModelSpec_WithTypeTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/actions/ModelSpec_WithTypeTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.actions;
+
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.model.internal.actions.ModelSpec.subtypeOf;
+import static dev.nokee.model.internal.type.ModelType.of;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class ModelSpec_WithTypeTest implements ModelSpecTester<WithTypeSpec> {
+	@Override
+	public WithTypeSpec subject() {
+		return new WithTypeSpec(of(MyType.class));
+	}
+
+	@Override
+	public DomainObjectIdentity satisfyingInput() {
+		return DomainObjectIdentity.of(ProjectionTypes.of(of(MyType.class)));
+	}
+
+	@Override
+	public DomainObjectIdentity notSatisfyingInput() {
+		return DomainObjectIdentity.of(ProjectionTypes.of(of(WrongType.class)));
+	}
+
+	@Test
+	void doesNotSatisfyOnEmptyIdentity() {
+		assertFalse(subject().isSatisfiedBy(emptyIdentity()));
+	}
+
+	@Test
+	void canCreateSpecUsingFactoryMethod() {
+		assertEquals(new WithTypeSpec(of(MyType.class)), subtypeOf(of(MyType.class)));
+	}
+
+	private interface MyType {}
+	private interface WrongType {}
+}

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/DefaultModelElementBackedByModelEntityIntegrationTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/DefaultModelElementBackedByModelEntityIntegrationTest.java
@@ -17,6 +17,7 @@ package dev.nokee.model.internal.core;
 
 import dev.nokee.model.DomainObjectIdentifier;
 import dev.nokee.model.DomainObjectProvider;
+import dev.nokee.model.internal.ElementNameComponent;
 import dev.nokee.model.internal.ModelElementFactory;
 import dev.nokee.model.internal.ModelObjectTester;
 import dev.nokee.model.internal.registry.ModelConfigurer;

--- a/subprojects/internal-testing/internal-testing.gradle
+++ b/subprojects/internal-testing/internal-testing.gradle
@@ -26,7 +26,7 @@ dependencies {
 	api "com.google.guava:guava:${guavaVersion}"
 	api "com.google.guava:guava-testlib:${guavaVersion}"
 	api "nl.jqno.equalsverifier:equalsverifier:${equalsverifierVersion}"
-	implementation 'org.apache.commons:commons-lang3:3.12.0'
+	implementation "org.apache.commons:commons-lang3:${commonsLangVersion}"
 	implementation testFixtures(gradleRunnerKit())
 	api gradleRunnerKit()
 	implementation gradleApi(minimumGradleVersion)

--- a/subprojects/internal-testing/internal-testing.gradle
+++ b/subprojects/internal-testing/internal-testing.gradle
@@ -24,6 +24,7 @@ dependencies {
 	api "commons-io:commons-io:${commonsIoVersion}"
 	api "com.google.guava:guava:${guavaVersion}"
 	api "com.google.guava:guava-testlib:${guavaVersion}"
+	api "nl.jqno.equalsverifier:equalsverifier:${equalsverifierVersion}"
 	implementation 'org.apache.commons:commons-lang3:3.12.0'
 	implementation testFixtures(gradleRunnerKit())
 	api gradleRunnerKit()

--- a/subprojects/internal-testing/internal-testing.gradle
+++ b/subprojects/internal-testing/internal-testing.gradle
@@ -16,6 +16,7 @@ dependencies {
 
 	// Mockito
 	api "org.mockito:mockito-core:${mockitoVersion}"
+	api "org.mockito:mockito-junit-jupiter:${mockitoVersion}"
 
 	// Support libraries
 	api "org.hamcrest:hamcrest:${hamcrestVersion}"

--- a/subprojects/internal-testing/internal-testing.gradle
+++ b/subprojects/internal-testing/internal-testing.gradle
@@ -25,7 +25,6 @@ dependencies {
 	api "commons-io:commons-io:${commonsIoVersion}"
 	api "com.google.guava:guava:${guavaVersion}"
 	api "com.google.guava:guava-testlib:${guavaVersion}"
-	api "nl.jqno.equalsverifier:equalsverifier:${equalsverifierVersion}"
 	implementation "org.apache.commons:commons-lang3:${commonsLangVersion}"
 	implementation testFixtures(gradleRunnerKit())
 	api gradleRunnerKit()

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/TaskRegistrationFactory.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/TaskRegistrationFactory.java
@@ -46,7 +46,7 @@ public final class TaskRegistrationFactory {
 	}
 
 	public <T extends Task> ModelRegistration.Builder create(TaskIdentifier<?> identifier, Class<T> type) {
-		val name = new FullyQualifiedName(taskNamer.determineName(identifier));
+		val name = FullyQualifiedName.of(taskNamer.determineName(identifier));
 		val taskProvider = (TaskProvider<T>) taskRegistry.registerIfAbsent(name.toString(), type);
 		return ModelRegistration.builder()
 			.withComponent(DomainObjectIdentifierUtils.toPath(identifier))


### PR DESCRIPTION
Previous ModelAction will evolve into ModelSystem while the new ModelAction will evolve into all configuration executed at the projection (domain object) level.