### PR TITLE
Generate the ModelPath from DomainObjectIdentifier

### DIFF
--- a/subprojects/core-model/core-model.gradle
+++ b/subprojects/core-model/core-model.gradle
@@ -41,3 +41,9 @@ gradlePlugin {
 		}
 	}
 }
+
+integrationTest {
+	dependencies {
+		implementation testFixtures(project)
+	}
+}

--- a/subprojects/core-model/src/integrationTest/java/dev/nokee/model/ModelActionIntegrationTester.java
+++ b/subprojects/core-model/src/integrationTest/java/dev/nokee/model/ModelActionIntegrationTester.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -158,7 +159,7 @@ abstract class ModelActionIntegrationTester {
 		ANCESTOR {
 			@Override
 			public Object g() {
-				val g = new ModelNode();
+				final ModelNode g = new ModelNode();
 				g.addComponent(new ParentComponent(new ModelNode()));
 				return new ParentComponent(g);
 			}
@@ -182,16 +183,16 @@ abstract class ModelActionIntegrationTester {
 
 	@Test
 	void executeSelfMutatingActionAfterCurrentActions() {
-		val secondAction = Mockito.mock(ModelAction.class, "secondAction");
-		val thirdAction = Mockito.mock(ModelAction.class, "thirdAction");
+		final ModelAction secondAction = Mockito.mock(ModelAction.class, "secondAction");
+		final ModelAction thirdAction = Mockito.mock(ModelAction.class, "thirdAction");
 		registry.instantiate(configureMatching(spec(), secondAction));
 		doAnswer(args -> {
 			registry.instantiate(configureMatching(spec(), thirdAction));
 			return null;
 		}).when(firstAction).execute(any());
 
-		val entity = registry.instantiate(newEntityMatchingSpec());
-		val inOrder = Mockito.inOrder(firstAction, secondAction, thirdAction);
+		final ModelNode entity = registry.instantiate(newEntityMatchingSpec());
+		final InOrder inOrder = Mockito.inOrder(firstAction, secondAction, thirdAction);
 		inOrder.verify(firstAction).execute(entity);
 		inOrder.verify(secondAction).execute(entity);
 		inOrder.verify(thirdAction).execute(entity);

--- a/subprojects/core-model/src/integrationTest/java/dev/nokee/model/ModelPathFromDomainObjectIdentifierIntegrationTest.java
+++ b/subprojects/core-model/src/integrationTest/java/dev/nokee/model/ModelPathFromDomainObjectIdentifierIntegrationTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model;
+
+import dev.nokee.internal.testing.util.ProjectTestUtils;
+import dev.nokee.model.internal.core.ModelComponentType;
+import dev.nokee.model.internal.core.ModelNode;
+import dev.nokee.model.internal.core.ModelNodes;
+import dev.nokee.model.internal.core.ModelPath;
+import dev.nokee.model.internal.plugins.ModelBasePlugin;
+import dev.nokee.model.internal.registry.ModelRegistry;
+import org.gradle.api.Project;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.model.fixtures.ModelRegistryTestUtils.identifier;
+import static dev.nokee.model.internal.core.ModelRegistration.builder;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class ModelPathFromDomainObjectIdentifierIntegrationTest {
+	private final Project project = ProjectTestUtils.rootProject();
+	private ModelNode subject;
+
+	@BeforeEach
+	void setUp() {
+		project.getPluginManager().apply(ModelBasePlugin.class);
+		subject = ModelNodes.of(project.getExtensions().getByType(ModelRegistry.class).instantiate(builder()
+			.withComponent(identifier("peow.keju.ewol"))
+			.build()));
+	}
+
+	@Test
+	void hasModelPath() {
+		assertThat(subject.getComponent(ModelComponentType.componentOf(ModelPath.class)),
+			equalTo(ModelPath.path("peow.keju.ewol")));
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelPropertyRegistrationFactory.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelPropertyRegistrationFactory.java
@@ -50,7 +50,6 @@ public final class ModelPropertyRegistrationFactory {
 		val path = toPath(identifier);
 		return ModelRegistration.builder()
 			.withComponent(identifier)
-			.withComponent(path)
 			.action(ModelActionWithInputs.of(ModelComponentReference.of(ModelPropertyIdentifier.class), ModelComponentReference.of(ModelState.IsAtLeastRealized.class), (e, id, ignored) -> {
 				// When property is realized... realize the source entity
 				if (id.equals(identifier)) {
@@ -87,7 +86,6 @@ public final class ModelPropertyRegistrationFactory {
 		val property = objects.property(type);
 		return ModelRegistration.builder()
 			.withComponent(identifier)
-			.withComponent(path)
 			.withComponent(ModelPropertyTag.instance())
 			.withComponent(new ModelPropertyTypeComponent(of(type)))
 			.withComponent(new GradlePropertyComponent(property))
@@ -99,7 +97,6 @@ public final class ModelPropertyRegistrationFactory {
 		val property = objects.fileCollection();
 		return ModelRegistration.builder()
 			.withComponent(identifier)
-			.withComponent(path)
 			.withComponent(ModelPropertyTag.instance())
 			.withComponent(new ModelPropertyTypeComponent(set(of(File.class))))
 			.withComponent(new GradlePropertyComponent(property))

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelRegistration.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/core/ModelRegistration.java
@@ -49,7 +49,6 @@ public final class ModelRegistration {
 	public static Builder managedBuilder(DomainObjectIdentifier identifier, Class<?> type) {
 		return builder()
 			.withComponent(identifier)
-			.withComponent(DomainObjectIdentifierUtils.toPath(identifier))
 			.withComponent(ModelProjections.managed(ModelType.of(type)));
 	}
 

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/plugins/GenerateModelPathFromIdentifier.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/plugins/GenerateModelPathFromIdentifier.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.model.internal.plugins;
+
+import dev.nokee.model.DomainObjectIdentifier;
+import dev.nokee.model.internal.DomainObjectIdentifierUtils;
+import dev.nokee.model.internal.core.ModelActionWithInputs;
+import dev.nokee.model.internal.core.ModelComponentReference;
+import dev.nokee.model.internal.core.ModelComponentType;
+import dev.nokee.model.internal.core.ModelNode;
+
+final class GenerateModelPathFromIdentifier extends ModelActionWithInputs.ModelAction1<DomainObjectIdentifier> {
+	public GenerateModelPathFromIdentifier() {
+		super(ModelComponentReference.ofAny(ModelComponentType.componentOf(DomainObjectIdentifier.class)));
+	}
+
+	@Override
+	protected void execute(ModelNode entity, DomainObjectIdentifier identifier) {
+		entity.addComponent(DomainObjectIdentifierUtils.toPath(identifier));
+	}
+}

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/plugins/ModelBasePlugin.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/plugins/ModelBasePlugin.java
@@ -51,5 +51,6 @@ public class ModelBasePlugin implements Plugin<Project> {
 		modelRegistry.configure(new AttachDisplayNameToGradleProperty());
 		modelRegistry.configure(new UseModelPropertyIdentifierAsDisplayName());
 		new ModelActionSystem(modelRegistry).execute(project);
+		modelRegistry.configure(new GenerateModelPathFromIdentifier());
 	}
 }

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/registry/DefaultModelRegistry.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/registry/DefaultModelRegistry.java
@@ -53,6 +53,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+import static dev.nokee.model.internal.core.ModelComponentType.componentOf;
+
 public final class DefaultModelRegistry implements ModelRegistry, ModelConfigurer, ModelLookup {
 	private final Instantiator instantiator;
 	private final List<ModelNode> entities = new ArrayList<>();
@@ -81,7 +83,9 @@ public final class DefaultModelRegistry implements ModelRegistry, ModelConfigure
 					node.addComponent(new ParentComponent(this.get(parentPath)));
 				});
 				node.addComponent(new ElementNameComponent(path.getName()));
-				node.addComponent(new DisplayNameComponent(path.toString()));
+				if (!node.hasComponent(componentOf(DisplayNameComponent.class))) {
+					node.addComponent(new DisplayNameComponent(path.toString()));
+				}
 			} else if (state.equals(ModelState.Registered)) {
 				assert !nodes.values().contains(node) : "duplicated registered notification";
 				nodes.put(path, node);

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelObjectElementQueryIntegrationTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/DefaultModelObjectElementQueryIntegrationTest.java
@@ -26,28 +26,29 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
-import static dev.nokee.model.internal.core.ModelPath.path;
+import static dev.nokee.model.fixtures.ModelRegistryTestUtils.identifier;
 import static dev.nokee.model.internal.core.ModelProjections.createdUsing;
 import static dev.nokee.model.internal.core.ModelProjections.ofInstance;
 import static dev.nokee.model.internal.core.ModelRegistration.builder;
 import static dev.nokee.model.internal.type.ModelType.of;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @PluginRequirement.Require(id = "dev.nokee.model-base")
 class DefaultModelObjectElementQueryIntegrationTest extends AbstractPluginTest {
-	private final DomainObjectIdentifier i0 = mock(DomainObjectIdentifier.class);
-	private final DomainObjectIdentifier i1 = mock(DomainObjectIdentifier.class);
-	private final DomainObjectIdentifier i2 = mock(DomainObjectIdentifier.class);
+	private final DomainObjectIdentifier i0 = identifier("a.b");
+	private final DomainObjectIdentifier i1 = identifier("a.b");
+	private final DomainObjectIdentifier i2 = identifier("a.c");
 	private DomainObjectProvider<Object> object;
 
 	@BeforeEach
 	void createObject() {
 		val registry = project.getExtensions().getByType(ModelRegistry.class);
-		object = registry.register(builder().withComponent(path("a")).withComponent(ofInstance(new Object())).build()).as(Object.class);
-		registry.register(builder().withComponent(path("a.b")).withComponent(i0).withComponent(ofInstance("peda")).build());
-		registry.register(builder().withComponent(path("a.b")).withComponent(i1).withComponent(createdUsing(of(MyType.class), () -> objectFactory().newInstance(MyType.class))).build());
-		registry.register(builder().withComponent(path("a.c")).withComponent(i2).withComponent(ofInstance(Boolean.TRUE)).build());
+		object = registry.register(builder().withComponent(identifier("a")).withComponent(ofInstance(new Object())).build()).as(Object.class);
+		registry.register(builder().withComponent(i0).withComponent(ofInstance("peda")).build());
+		registry.register(builder().withComponent(i1).withComponent(createdUsing(of(MyType.class), () -> objectFactory().newInstance(MyType.class))).build());
+		registry.register(builder().withComponent(i2).withComponent(ofInstance(Boolean.TRUE)).build());
 	}
 
 	@Nested
@@ -115,7 +116,7 @@ class DefaultModelObjectElementQueryIntegrationTest extends AbstractPluginTest {
 		@BeforeEach
 		void createConflictingElement() {
 			val registry = project.getExtensions().getByType(ModelRegistry.class);
-			registry.register(builder().withComponent(path("a.b")).withComponent(mock(DomainObjectIdentifier.class)).withComponent(ofInstance("vequ")).build());
+			registry.register(builder().withComponent(identifier("a.b")).withComponent(ofInstance("vequ")).build());
 		}
 
 		@Test

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/DefaultModelElementElementQueryIntegrationTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/core/DefaultModelElementElementQueryIntegrationTest.java
@@ -26,28 +26,29 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
-import static dev.nokee.model.internal.core.ModelPath.path;
+import static dev.nokee.model.fixtures.ModelRegistryTestUtils.identifier;
 import static dev.nokee.model.internal.core.ModelProjections.createdUsing;
 import static dev.nokee.model.internal.core.ModelProjections.ofInstance;
 import static dev.nokee.model.internal.core.ModelRegistration.builder;
 import static dev.nokee.model.internal.type.ModelType.of;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @PluginRequirement.Require(id = "dev.nokee.model-base")
 class DefaultModelElementElementQueryIntegrationTest extends AbstractPluginTest {
-	private final DomainObjectIdentifier i0 = mock(DomainObjectIdentifier.class);
-	private final DomainObjectIdentifier i1 = mock(DomainObjectIdentifier.class);
-	private final DomainObjectIdentifier i2 = mock(DomainObjectIdentifier.class);
+	private final DomainObjectIdentifier i0 = identifier("a.b");
+	private final DomainObjectIdentifier i1 = identifier("a.b");
+	private final DomainObjectIdentifier i2 = identifier("a.c");
 	private ModelElement element;
 
 	@BeforeEach
 	void createObject() {
 		val registry = project.getExtensions().getByType(ModelRegistry.class);
-		element = registry.register(builder().withComponent(path("a")).withComponent(ofInstance(new Object())).build());
-		registry.register(builder().withComponent(path("a.b")).withComponent(i0).withComponent(createdUsing(of(MyType.class), () -> objectFactory().newInstance(MyType.class))).build());
-		registry.register(builder().withComponent(path("a.b")).withComponent(i1).withComponent(ofInstance("dalo")).build());
-		registry.register(builder().withComponent(path("a.c")).withComponent(i2).withComponent(ofInstance(Boolean.TRUE)).build());
+		element = registry.register(builder().withComponent(identifier("a")).withComponent(ofInstance(new Object())).build());
+		registry.register(builder().withComponent(i0).withComponent(createdUsing(of(MyType.class), () -> objectFactory().newInstance(MyType.class))).build());
+		registry.register(builder().withComponent(i1).withComponent(ofInstance("dalo")).build());
+		registry.register(builder().withComponent(i2).withComponent(ofInstance(Boolean.TRUE)).build());
 	}
 
 	@Nested
@@ -115,7 +116,7 @@ class DefaultModelElementElementQueryIntegrationTest extends AbstractPluginTest 
 		@BeforeEach
 		void createConflictingElement() {
 			val registry = project.getExtensions().getByType(ModelRegistry.class);
-			registry.register(builder().withComponent(path("a.b")).withComponent(mock(DomainObjectIdentifier.class)).withComponent(ofInstance("cere")).build());
+			registry.register(builder().withComponent(identifier("a.b")).withComponent(ofInstance("cere")).build());
 		}
 
 		@Test

--- a/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/fixtures/ModelRegistryTestUtils.java
+++ b/subprojects/core-model/src/testFixtures/groovy/dev/nokee/model/fixtures/ModelRegistryTestUtils.java
@@ -15,15 +15,22 @@
  */
 package dev.nokee.model.fixtures;
 
+import com.google.common.collect.Streams;
 import dev.nokee.internal.testing.util.ProjectTestUtils;
+import dev.nokee.model.DomainObjectIdentifier;
+import dev.nokee.model.HasName;
 import dev.nokee.model.internal.core.ModelElement;
 import dev.nokee.model.internal.core.ModelNodeUtils;
+import dev.nokee.model.internal.core.ModelPath;
 import dev.nokee.model.internal.core.ModelRegistration;
 import dev.nokee.model.internal.core.NodeRegistration;
 import dev.nokee.model.internal.registry.DefaultModelRegistry;
+import lombok.EqualsAndHashCode;
 import org.gradle.api.model.ObjectFactory;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.Iterator;
 
 import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
 import static dev.nokee.model.internal.core.ModelPath.path;
@@ -48,6 +55,38 @@ public class ModelRegistryTestUtils {
 
 	public static DefaultModelRegistry registry(ObjectFactory objectFactory) {
 		return new DefaultModelRegistry(objectFactory::newInstance);
+	}
+
+	public static DomainObjectIdentifier identifier(String path) {
+		return new Identifier(Streams.stream(ModelPath.path(path)).map(Identity::new).toArray(Object[]::new));
+	}
+
+	@EqualsAndHashCode
+	private static final class Identifier implements DomainObjectIdentifier {
+		@EqualsAndHashCode.Include private final Iterable<Object> identities;
+
+		public Identifier(Object... identities) {
+			this.identities = Arrays.asList(identities);
+		}
+
+		@Override
+		public Iterator<Object> iterator() {
+			return identities.iterator();
+		}
+	}
+
+	@EqualsAndHashCode
+	private static final class Identity implements HasName {
+		@EqualsAndHashCode.Include private final String name;
+
+		public Identity(String name) {
+			this.name = name;
+		}
+
+		@Override
+		public Object getName() {
+			return name;
+		}
 	}
 
 	interface TestHolder {}

--- a/subprojects/language-base/src/main/java/dev/nokee/language/base/internal/HasConfigurableSourceMixInRule.java
+++ b/subprojects/language-base/src/main/java/dev/nokee/language/base/internal/HasConfigurableSourceMixInRule.java
@@ -45,7 +45,6 @@ public final class HasConfigurableSourceMixInRule extends ModelActionWithInputs.
 	protected void execute(ModelNode entity, KnownDomainObject<HasConfigurableSourceMixIn> knownObject, IsLanguageSourceSet ignored) {
 		val propertyIdentifier = ModelPropertyIdentifier.of(knownObject.getIdentifier(), "source");
 		val element = registry.register(ModelRegistration.builder()
-			.withComponent(DomainObjectIdentifierUtils.toPath(propertyIdentifier))
 			.withComponent(propertyIdentifier)
 			.withComponent(ModelPropertyTag.instance())
 			.withComponent(new ModelPropertyTypeComponent(set(ModelType.of(File.class))))

--- a/subprojects/language-base/src/main/java/dev/nokee/language/base/internal/LanguageSourceSetRegistrationFactory.java
+++ b/subprojects/language-base/src/main/java/dev/nokee/language/base/internal/LanguageSourceSetRegistrationFactory.java
@@ -53,7 +53,6 @@ public final class LanguageSourceSetRegistrationFactory {
 	private ModelRegistration.Builder create(LanguageSourceSetIdentifier identifier, ModelAction sourcePropertyAction) {
 		return ModelRegistration.builder()
 			.withComponent(identifier)
-			.withComponent(toPath(identifier))
 			.action(sourcePropertyAction);
 	}
 }

--- a/subprojects/language-base/src/main/java/dev/nokee/language/base/internal/SourcePropertyRegistrationAction.java
+++ b/subprojects/language-base/src/main/java/dev/nokee/language/base/internal/SourcePropertyRegistrationAction.java
@@ -50,7 +50,6 @@ public final class SourcePropertyRegistrationAction extends ModelActionWithInput
 		if (identifier.equals(this.identifier)) {
 			val propertyIdentifier = ModelPropertyIdentifier.of(identifier, "source");
 			val element = registry.register(ModelRegistration.builder()
-				.withComponent(DomainObjectIdentifierUtils.toPath(propertyIdentifier))
 				.withComponent(propertyIdentifier)
 				.withComponent(ModelPropertyTag.instance())
 				.withComponent(new ModelPropertyTypeComponent(set(ModelType.of(File.class))))

--- a/subprojects/language-native/src/main/java/dev/nokee/language/nativebase/internal/HasConfigurableHeadersMixInRule.java
+++ b/subprojects/language-native/src/main/java/dev/nokee/language/nativebase/internal/HasConfigurableHeadersMixInRule.java
@@ -47,7 +47,6 @@ public final class HasConfigurableHeadersMixInRule extends ModelActionWithInputs
 	protected void execute(ModelNode entity, KnownDomainObject<HasConfigurableHeadersMixIn> knownObject, IsLanguageSourceSet ignored) {
 		val propertyIdentifier = ModelPropertyIdentifier.of(knownObject.getIdentifier(), "headers");
 		val element = registry.register(ModelRegistration.builder()
-			.withComponent(DomainObjectIdentifierUtils.toPath(propertyIdentifier))
 			.withComponent(propertyIdentifier)
 			.withComponent(ModelPropertyTag.instance())
 			.withComponent(new ModelPropertyTypeComponent(set(ModelType.of(File.class))))

--- a/subprojects/platform-base/src/integrationTest/java/dev/nokee/platform/base/VariantAwareComponentDimensionsIntegrationTest.java
+++ b/subprojects/platform-base/src/integrationTest/java/dev/nokee/platform/base/VariantAwareComponentDimensionsIntegrationTest.java
@@ -41,7 +41,6 @@ class VariantAwareComponentDimensionsIntegrationTest extends VariantDimensionsIn
 		project.getPluginManager().apply(ComponentModelBasePlugin.class);
 		subject = project.getExtensions().getByType(ModelRegistry.class).register(ModelRegistration.builder()
 			.withComponent(ofMain(ProjectIdentifier.of(project)))
-			.withComponent(DomainObjectIdentifierUtils.toPath(ofMain(ProjectIdentifier.of(project))))
 			.withComponent(ModelProjections.managed(of(MyComponent.class))).build()).as(MyComponent.class).get();
 	}
 

--- a/subprojects/platform-base/src/integrationTest/java/dev/nokee/platform/base/VariantAwareComponentDimensionsValueOrderingIntegrationTest.java
+++ b/subprojects/platform-base/src/integrationTest/java/dev/nokee/platform/base/VariantAwareComponentDimensionsValueOrderingIntegrationTest.java
@@ -47,7 +47,6 @@ class VariantAwareComponentDimensionsValueOrderingIntegrationTest {
 		project.getPluginManager().apply(ComponentModelBasePlugin.class);
 		subject = project.getExtensions().getByType(ModelRegistry.class).register(ModelRegistration.builder()
 			.withComponent(ofMain(ProjectIdentifier.of(project)))
-			.withComponent(DomainObjectIdentifierUtils.toPath(ofMain(ProjectIdentifier.of(project))))
 			.withComponent(ModelProjections.managed(of(MyComponent.class))).build()).as(MyComponent.class).get();
 		subject.getDimensions().newAxis(OSFamily.class).value(asList(new OSFamily("windows"), new OSFamily("macOS"), new OSFamily("linux")));
 		subject.getDimensions().newAxis(MyAxis.class, it -> it.onlyIf(OSFamily.class, (a, b) -> !a.isPresent() || b.isWindows())).value(asList(new MyAxis("first"), new MyAxis("second")));

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ComponentBinariesPropertyRegistrationFactory.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ComponentBinariesPropertyRegistrationFactory.java
@@ -60,7 +60,6 @@ public final class ComponentBinariesPropertyRegistrationFactory {
 		assert path.getParent().isPresent();
 		val ownerPath = path.getParent().get();
 		return ModelRegistration.builder()
-			.withComponent(path)
 			.withComponent(identifier)
 			.withComponent(ModelPropertyTag.instance())
 			.withComponent(new ModelPropertyTypeComponent(map(of(String.class), of(Binary.class))))

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ComponentDependenciesPropertyRegistrationFactory.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ComponentDependenciesPropertyRegistrationFactory.java
@@ -55,7 +55,6 @@ public final class ComponentDependenciesPropertyRegistrationFactory {
 		assert path.getParent().isPresent();
 		val ownerPath = path.getParent().get();
 		return ModelRegistration.builder()
-			.withComponent(path)
 			.withComponent(identifier)
 			.withComponent(ModelPropertyTag.instance())
 			.withComponent(new ModelPropertyTypeComponent(map(of(String.class), of(DependencyBucket.class))))

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ComponentSourcesPropertyRegistrationFactory.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ComponentSourcesPropertyRegistrationFactory.java
@@ -66,7 +66,6 @@ public final class ComponentSourcesPropertyRegistrationFactory {
 		assert path.getParent().isPresent();
 		val ownerPath = path.getParent().get();
 		return ModelRegistration.builder()
-			.withComponent(path)
 			.withComponent(identifier)
 			.withComponent(ModelPropertyTag.instance())
 			.withComponent(new ModelPropertyTypeComponent(map(of(String.class), of(LanguageSourceSet.class))))
@@ -95,7 +94,6 @@ public final class ComponentSourcesPropertyRegistrationFactory {
 		assert path.getParent().isPresent();
 		val ownerPath = path.getParent().get();
 		return ModelRegistration.builder()
-			.withComponent(path)
 			.withComponent(identifier)
 			.withComponent(ModelPropertyTag.instance())
 			.withComponent(new ModelPropertyTypeComponent(map(of(String.class), of(LanguageSourceSet.class))))
@@ -123,7 +121,6 @@ public final class ComponentSourcesPropertyRegistrationFactory {
 		assert path.getParent().isPresent();
 		val ownerPath = path.getParent().get();
 		return ModelRegistration.builder()
-			.withComponent(path)
 			.withComponent(identifier)
 			.withComponent(ModelPropertyTag.instance())
 			.withComponent(new ModelPropertyTypeComponent(map(of(String.class), of(LanguageSourceSet.class))))

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ComponentTasksPropertyRegistrationFactory.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ComponentTasksPropertyRegistrationFactory.java
@@ -60,7 +60,6 @@ public final class ComponentTasksPropertyRegistrationFactory {
 		assert path.getParent().isPresent();
 		val ownerPath = path.getParent().get();
 		return ModelRegistration.builder()
-			.withComponent(path)
 			.withComponent(identifier)
 			.withComponent(ModelPropertyTag.instance())
 			.withComponent(new ModelPropertyTypeComponent(map(of(String.class), of(Task.class))))
@@ -89,7 +88,6 @@ public final class ComponentTasksPropertyRegistrationFactory {
 		assert path.getParent().isPresent();
 		val ownerPath = path.getParent().get();
 		return ModelRegistration.builder()
-			.withComponent(path)
 			.withComponent(identifier)
 			.withComponent(ModelPropertyTag.instance())
 			.withComponent(new ModelPropertyTypeComponent(map(of(String.class), of(elementType))))

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ComponentVariantsPropertyRegistrationFactory.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ComponentVariantsPropertyRegistrationFactory.java
@@ -52,7 +52,6 @@ public final class ComponentVariantsPropertyRegistrationFactory {
 		assert path.getParent().isPresent();
 		val ownerPath = path.getParent().get();
 		return ModelRegistration.builder()
-			.withComponent(path)
 			.withComponent(identifier)
 			.withComponent(ModelPropertyTag.instance())
 			.withComponent(new ModelPropertyTypeComponent(map(of(String.class), of(elementType))))

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/DimensionPropertyRegistrationFactory.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/DimensionPropertyRegistrationFactory.java
@@ -140,7 +140,7 @@ public final class DimensionPropertyRegistrationFactory {
 			val result = ModelRegistration.builder();
 
 			if (identifier != null) {
-				result.withComponent(toPath(identifier)).withComponent(identifier);
+				result.withComponent(identifier);
 			}
 
 			result
@@ -172,7 +172,6 @@ public final class DimensionPropertyRegistrationFactory {
 		property.finalizeValueOnRead();
 		property.disallowChanges();
 		return ModelRegistration.builder()
-			.withComponent(toPath(identifier))
 			.withComponent(identifier)
 			.withComponent(ModelPropertyTag.instance())
 			.withComponent(new ModelPropertyTypeComponent(set(of(BuildVariant.class))))

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ModelBackedVariantDimensions.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ModelBackedVariantDimensions.java
@@ -53,7 +53,6 @@ public final class ModelBackedVariantDimensions implements VariantDimensions {
 	public <T> SetProperty<T> newAxis(Class<T> axisType) {
 		val identifier = ModelPropertyIdentifier.of(owner, StringUtils.uncapitalize(axisType.getSimpleName()));
 		val result = registry.register(ModelRegistration.builder()
-			.withComponent(toPath(identifier))
 			.withComponent(identifier)
 			.mergeFrom(dimensionsPropertyFactory.newAxisProperty(CoordinateAxis.of(axisType)))
 			.build());
@@ -66,7 +65,6 @@ public final class ModelBackedVariantDimensions implements VariantDimensions {
 		Objects.requireNonNull(action);
 		val identifier = ModelPropertyIdentifier.of(owner, StringUtils.uncapitalize(axisType.getSimpleName()));
 		val builder = ModelRegistration.builder()
-			.withComponent(toPath(identifier))
 			.withComponent(identifier);
 		val axisBuilder = dimensionsPropertyFactory.newAxisProperty();
 		axisBuilder.axis(CoordinateAxis.of(axisType));

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/TaskRegistrationFactory.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/TaskRegistrationFactory.java
@@ -49,7 +49,6 @@ public final class TaskRegistrationFactory {
 		val name = FullyQualifiedName.of(taskNamer.determineName(identifier));
 		val taskProvider = (TaskProvider<T>) taskRegistry.registerIfAbsent(name.toString(), type);
 		return ModelRegistration.builder()
-			.withComponent(DomainObjectIdentifierUtils.toPath(identifier))
 			.withComponent(identifier)
 			.withComponent(IsTask.tag())
 			.withComponent(new ModelElementProviderSourceComponent(taskProvider))

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/ConsumableDependencyBucketRegistrationFactory.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/ConsumableDependencyBucketRegistrationFactory.java
@@ -77,7 +77,6 @@ public final class ConsumableDependencyBucketRegistrationFactory {
 		configurationProvider.configure(attachOutgoingArtifactToConfiguration(outgoing));
 		val entityPath = toPath(identifier);
 		return ModelRegistration.builder()
-			.withComponent(entityPath)
 			.withComponent(identifier)
 			.withComponent(IsDependencyBucket.tag())
 			.withComponent(new FullyQualifiedNameComponent(namer.determineName(identifier)))

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/DeclarableDependencyBucketRegistrationFactory.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/DeclarableDependencyBucketRegistrationFactory.java
@@ -67,7 +67,6 @@ public final class DeclarableDependencyBucketRegistrationFactory {
 		});
 		val entityPath = toPath(identifier);
 		return ModelRegistration.builder()
-			.withComponent(entityPath)
 			.withComponent(identifier)
 			.withComponent(IsDependencyBucket.tag())
 			.withComponent(new FullyQualifiedNameComponent(namer.determineName(identifier)))

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/ResolvableDependencyBucketRegistrationFactory.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/ResolvableDependencyBucketRegistrationFactory.java
@@ -70,7 +70,6 @@ public final class ResolvableDependencyBucketRegistrationFactory {
 		});
 		val entityPath = toPath(identifier);
 		return ModelRegistration.builder()
-			.withComponent(entityPath)
 			.withComponent(identifier)
 			.withComponent(IsDependencyBucket.tag())
 			.withComponent(new FullyQualifiedNameComponent(namer.determineName(identifier)))

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/IosApplicationComponentModelRegistrationFactory.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/IosApplicationComponentModelRegistrationFactory.java
@@ -253,7 +253,6 @@ public final class IosApplicationComponentModelRegistrationFactory {
 
 				val executableIdentifier = BinaryIdentifier.of(BinaryName.of("executable"), ExecutableBinaryInternal.class, identifier);
 				val executable = registry.register(ModelRegistration.builder()
-					.withComponent(path.child("executable"))
 					.withComponent(IsBinary.tag())
 					.withComponent(executableIdentifier)
 					.withComponent(new FullyQualifiedNameComponent(BinaryNamer.INSTANCE.determineName(executableIdentifier)))
@@ -265,7 +264,6 @@ public final class IosApplicationComponentModelRegistrationFactory {
 
 				val applicationBundleIdentifier = BinaryIdentifier.of(BinaryName.of("applicationBundle"), IosApplicationBundleInternal.class, identifier);
 				val applicationBundle = registry.register(ModelRegistration.builder()
-					.withComponent(path.child("applicationBundle"))
 					.withComponent(IsBinary.tag())
 					.withComponent(applicationBundleIdentifier)
 					.withComponent(new FullyQualifiedNameComponent(BinaryNamer.INSTANCE.determineName(applicationBundleIdentifier)))
@@ -277,7 +275,6 @@ public final class IosApplicationComponentModelRegistrationFactory {
 
 				val signedApplicationBundleIdentifier = BinaryIdentifier.of(BinaryName.of("signedApplicationBundle"), SignedIosApplicationBundleInternal.class, identifier);
 				val signedApplicationBundle = registry.register(ModelRegistration.builder()
-					.withComponent(path.child("signedApplicationBundle"))
 					.withComponent(IsBinary.tag())
 					.withComponent(signedApplicationBundleIdentifier)
 					.withComponent(new FullyQualifiedNameComponent(BinaryNamer.INSTANCE.determineName(signedApplicationBundleIdentifier)))

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/IosResourceSetRegistrationFactory.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/IosResourceSetRegistrationFactory.java
@@ -33,7 +33,6 @@ public final class IosResourceSetRegistrationFactory {
 	public ModelRegistration create(LanguageSourceSetIdentifier identifier) {
 		return ModelRegistration.builder()
 			.withComponent(identifier)
-			.withComponent(toPath(identifier))
 			.withComponent(createdUsing(ModelType.of(IosResourceSetSpec.class), () -> objectFactory.newInstance(IosResourceSetSpec.class)))
 			.build();
 	}

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JavaNativeInterfaceLibraryComponentRegistrationFactory.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JavaNativeInterfaceLibraryComponentRegistrationFactory.java
@@ -117,7 +117,6 @@ public final class JavaNativeInterfaceLibraryComponentRegistrationFactory {
 	public ModelRegistration create(ComponentIdentifier identifier) {
 		val entityPath = DomainObjectIdentifierUtils.toPath(identifier);
 		return ModelRegistration.builder()
-			.withComponent(entityPath)
 			.withComponent(identifier)
 			.withComponent(new FullyQualifiedNameComponent(ComponentNamer.INSTANCE.determineName(identifier)))
 			.action(ModelActionWithInputs.of(ModelComponentReference.of(ModelPath.class), ModelComponentReference.ofAny(projectionOf(LanguageSourceSet.class)), ModelComponentReference.of(ModelState.IsAtLeastRealized.class), (entity, path, projection, ignored) -> {

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JavaNativeInterfaceLibraryVariantRegistrationFactory.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JavaNativeInterfaceLibraryVariantRegistrationFactory.java
@@ -120,7 +120,6 @@ public final class JavaNativeInterfaceLibraryVariantRegistrationFactory {
 		Preconditions.checkArgument(buildVariant.hasAxisValue(TARGET_MACHINE_COORDINATE_AXIS));
 
 		return ModelRegistration.builder()
-			.withComponent(DomainObjectIdentifierUtils.toPath(identifier))
 			.withComponent(IsVariant.tag())
 			.withComponent(identifier)
 			.withComponent(new FullyQualifiedNameComponent(VariantNamer.INSTANCE.determineName(identifier)))

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniJarBinaryRegistrationFactory.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniJarBinaryRegistrationFactory.java
@@ -43,7 +43,6 @@ public final class JniJarBinaryRegistrationFactory {
 	public ModelRegistration create(BinaryIdentifier<?> identifier) {
 		return ModelRegistration.builder()
 			.withComponent(identifier)
-			.withComponent(toPath(identifier))
 			.withComponent(IsBinary.tag())
 			.withComponent(new FullyQualifiedNameComponent(BinaryNamer.INSTANCE.determineName(identifier)))
 			.withComponent(createdUsing(of(JniJarBinary.class), ModelBackedJniJarBinary::new))

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JvmJarBinaryRegistrationFactory.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JvmJarBinaryRegistrationFactory.java
@@ -45,7 +45,6 @@ public final class JvmJarBinaryRegistrationFactory {
 	public ModelRegistration create(BinaryIdentifier<?> identifier) {
 		return ModelRegistration.builder()
 			.withComponent(identifier)
-			.withComponent(toPath(identifier))
 			.withComponent(IsBinary.tag())
 			.withComponent(new FullyQualifiedNameComponent(BinaryNamer.INSTANCE.determineName(identifier)))
 			.withComponent(createdUsing(of(JvmJarBinary.class), ModelBackedJvmJarBinary::new))

--- a/subprojects/platform-jni/src/test/groovy/dev/nokee/platform/jni/JavaNativeInterfaceLibraryVariantCLanguagePluginIntegrationTest.java
+++ b/subprojects/platform-jni/src/test/groovy/dev/nokee/platform/jni/JavaNativeInterfaceLibraryVariantCLanguagePluginIntegrationTest.java
@@ -56,7 +56,7 @@ class JavaNativeInterfaceLibraryVariantCLanguagePluginIntegrationTest extends Ab
 	void createSubject() {
 		val registry = project.getExtensions().getByType(ModelRegistry.class);
 		val componentIdentifier = ComponentIdentifier.of("liho", ProjectIdentifier.of(project));
-		registry.register(ModelRegistration.builder().withComponent(componentIdentifier).withComponent(toPath(componentIdentifier)).build());
+		registry.register(ModelRegistration.builder().withComponent(componentIdentifier).build());
 		val factory = project.getExtensions().getByType(JavaNativeInterfaceLibraryVariantRegistrationFactory.class);
 		val variantIdentifier = VariantIdentifier.of(DefaultBuildVariant.of(of("freebsd-x86")), Variant.class, componentIdentifier);
 		subject = registry.register(factory.create(variantIdentifier)).as(JniLibrary.class).get();

--- a/subprojects/platform-jni/src/test/groovy/dev/nokee/platform/jni/JavaNativeInterfaceLibraryVariantCppLanguagePluginIntegrationTest.java
+++ b/subprojects/platform-jni/src/test/groovy/dev/nokee/platform/jni/JavaNativeInterfaceLibraryVariantCppLanguagePluginIntegrationTest.java
@@ -56,7 +56,7 @@ class JavaNativeInterfaceLibraryVariantCppLanguagePluginIntegrationTest extends 
 	void createSubject() {
 		val registry = project.getExtensions().getByType(ModelRegistry.class);
 		val componentIdentifier = ComponentIdentifier.of("difi", ProjectIdentifier.of(project));
-		registry.register(ModelRegistration.builder().withComponent(componentIdentifier).withComponent(toPath(componentIdentifier)).build());
+		registry.register(ModelRegistration.builder().withComponent(componentIdentifier).build());
 		val factory = project.getExtensions().getByType(JavaNativeInterfaceLibraryVariantRegistrationFactory.class);
 		val variantIdentifier = VariantIdentifier.of(DefaultBuildVariant.of(of("windows-x86")), Variant.class, componentIdentifier);
 		subject = registry.register(factory.create(variantIdentifier)).as(JniLibrary.class).get();

--- a/subprojects/platform-jni/src/test/groovy/dev/nokee/platform/jni/JavaNativeInterfaceLibraryVariantIntegrationTest.java
+++ b/subprojects/platform-jni/src/test/groovy/dev/nokee/platform/jni/JavaNativeInterfaceLibraryVariantIntegrationTest.java
@@ -75,7 +75,7 @@ class JavaNativeInterfaceLibraryVariantIntegrationTest extends AbstractPluginTes
 	void createSubject() {
 		val registry = project.getExtensions().getByType(ModelRegistry.class);
 		val componentIdentifier = ComponentIdentifier.of("reqi", ProjectIdentifier.of(project));
-		registry.register(ModelRegistration.builder().withComponent(componentIdentifier).withComponent(toPath(componentIdentifier)).build());
+		registry.register(ModelRegistration.builder().withComponent(componentIdentifier).build());
 		val factory = project.getExtensions().getByType(JavaNativeInterfaceLibraryVariantRegistrationFactory.class);
 		val variantIdentifier = VariantIdentifier.of(DefaultBuildVariant.of(TargetMachines.of("windows-x86")), Variant.class, componentIdentifier);
 		subject = registry.register(factory.create(variantIdentifier)).as(JniLibrary.class).get();

--- a/subprojects/platform-jni/src/test/groovy/dev/nokee/platform/jni/JavaNativeInterfaceLibraryVariantNoNativeLanguagePluginIntegrationTest.java
+++ b/subprojects/platform-jni/src/test/groovy/dev/nokee/platform/jni/JavaNativeInterfaceLibraryVariantNoNativeLanguagePluginIntegrationTest.java
@@ -48,7 +48,7 @@ class JavaNativeInterfaceLibraryVariantNoNativeLanguagePluginIntegrationTest ext
 	void createSubject() {
 		val registry = project.getExtensions().getByType(ModelRegistry.class);
 		val componentIdentifier = ComponentIdentifier.of("zoko", ProjectIdentifier.of(project));
-		registry.register(ModelRegistration.builder().withComponent(componentIdentifier).withComponent(toPath(componentIdentifier)).build());
+		registry.register(ModelRegistration.builder().withComponent(componentIdentifier).build());
 		val factory = project.getExtensions().getByType(JavaNativeInterfaceLibraryVariantRegistrationFactory.class);
 		val variantIdentifier = VariantIdentifier.of(DefaultBuildVariant.of(of("unix-arm")), Variant.class, componentIdentifier);
 		subject = registry.register(factory.create(variantIdentifier)).as(JniLibrary.class).get();

--- a/subprojects/platform-jni/src/test/groovy/dev/nokee/platform/jni/JavaNativeInterfaceLibraryVariantObjectiveCLanguagePluginIntegrationTest.java
+++ b/subprojects/platform-jni/src/test/groovy/dev/nokee/platform/jni/JavaNativeInterfaceLibraryVariantObjectiveCLanguagePluginIntegrationTest.java
@@ -56,7 +56,7 @@ class JavaNativeInterfaceLibraryVariantObjectiveCLanguagePluginIntegrationTest e
 	void createSubject() {
 		val registry = project.getExtensions().getByType(ModelRegistry.class);
 		val componentIdentifier = ComponentIdentifier.of("veda", ProjectIdentifier.of(project));
-		registry.register(ModelRegistration.builder().withComponent(componentIdentifier).withComponent(toPath(componentIdentifier)).build());
+		registry.register(ModelRegistration.builder().withComponent(componentIdentifier).build());
 		val factory = project.getExtensions().getByType(JavaNativeInterfaceLibraryVariantRegistrationFactory.class);
 		val variantIdentifier = VariantIdentifier.of(DefaultBuildVariant.of(of("windows-x64")), Variant.class, componentIdentifier);
 		subject = registry.register(factory.create(variantIdentifier)).as(JniLibrary.class).get();

--- a/subprojects/platform-jni/src/test/groovy/dev/nokee/platform/jni/JavaNativeInterfaceLibraryVariantObjectiveCppLanguagePluginIntegrationTest.java
+++ b/subprojects/platform-jni/src/test/groovy/dev/nokee/platform/jni/JavaNativeInterfaceLibraryVariantObjectiveCppLanguagePluginIntegrationTest.java
@@ -56,7 +56,7 @@ class JavaNativeInterfaceLibraryVariantObjectiveCppLanguagePluginIntegrationTest
 	void createSubject() {
 		val registry = project.getExtensions().getByType(ModelRegistry.class);
 		val componentIdentifier = ComponentIdentifier.of("xapi", ProjectIdentifier.of(project));
-		registry.register(ModelRegistration.builder().withComponent(componentIdentifier).withComponent(toPath(componentIdentifier)).build());
+		registry.register(ModelRegistration.builder().withComponent(componentIdentifier).build());
 		val factory = project.getExtensions().getByType(JavaNativeInterfaceLibraryVariantRegistrationFactory.class);
 		val variantIdentifier = VariantIdentifier.of(DefaultBuildVariant.of(of("linux-x64")), Variant.class, componentIdentifier);
 		subject = registry.register(factory.create(variantIdentifier)).as(JniLibrary.class).get();

--- a/subprojects/platform-jni/src/test/groovy/dev/nokee/platform/jni/JavaNativeInterfaceLibraryVariantToStringIntegrationTest.java
+++ b/subprojects/platform-jni/src/test/groovy/dev/nokee/platform/jni/JavaNativeInterfaceLibraryVariantToStringIntegrationTest.java
@@ -43,7 +43,7 @@ class JavaNativeInterfaceLibraryVariantToStringIntegrationTest extends AbstractP
 	void createSubject() {
 		val registry = project.getExtensions().getByType(ModelRegistry.class);
 		val componentIdentifier = ComponentIdentifier.builder().name(ComponentName.of("zagi")).withProjectIdentifier(ProjectIdentifier.of(project)).displayName("my JNI library").build();
-		registry.register(ModelRegistration.builder().withComponent(componentIdentifier).withComponent(toPath(componentIdentifier)).build());
+		registry.register(ModelRegistration.builder().withComponent(componentIdentifier).build());
 		val factory = project.getExtensions().getByType(JavaNativeInterfaceLibraryVariantRegistrationFactory.class);
 		val variantIdentifier = VariantIdentifier.of(DefaultBuildVariant.of(TargetMachines.of("macos-x64")), Variant.class, componentIdentifier);
 		subject = registry.register(factory.create(variantIdentifier)).as(JniLibrary.class).get();

--- a/subprojects/platform-jni/src/test/groovy/dev/nokee/platform/jni/JniJarBinaryIntegrationTest.java
+++ b/subprojects/platform-jni/src/test/groovy/dev/nokee/platform/jni/JniJarBinaryIntegrationTest.java
@@ -52,9 +52,9 @@ class JniJarBinaryIntegrationTest extends AbstractPluginTest {
 	void createSubject() {
 		val registry = project.getExtensions().getByType(ModelRegistry.class);
 		val componentIdentifier = ComponentIdentifier.of("poto", ProjectIdentifier.of(project));
-		registry.register(ModelRegistration.builder().withComponent(componentIdentifier).withComponent(toPath(componentIdentifier)).build());
+		registry.register(ModelRegistration.builder().withComponent(componentIdentifier).build());
 		val variantIdentifier = VariantIdentifier.of("qile", Variant.class, componentIdentifier);
-		registry.register(ModelRegistration.builder().withComponent(variantIdentifier).withComponent(toPath(variantIdentifier)).build());
+		registry.register(ModelRegistration.builder().withComponent(variantIdentifier).build());
 		val factory = project.getExtensions().getByType(JniJarBinaryRegistrationFactory.class);
 		subject = registry.register(factory.create(BinaryIdentifier.of(variantIdentifier, BinaryIdentity.of("tuva", "Liha binary")))).as(JniJarBinary.class).get();
 	}

--- a/subprojects/platform-jni/src/test/groovy/dev/nokee/platform/jni/JvmJarBinaryIntegrationTest.java
+++ b/subprojects/platform-jni/src/test/groovy/dev/nokee/platform/jni/JvmJarBinaryIntegrationTest.java
@@ -53,7 +53,7 @@ class JvmJarBinaryIntegrationTest extends AbstractPluginTest {
 	void createSubject() {
 		val registry = project.getExtensions().getByType(ModelRegistry.class);
 		val componentIdentifier = ComponentIdentifier.of("rina", ProjectIdentifier.of(project));
-		registry.register(ModelRegistration.builder().withComponent(componentIdentifier).withComponent(toPath(componentIdentifier)).build());
+		registry.register(ModelRegistration.builder().withComponent(componentIdentifier).build());
 		val factory = project.getExtensions().getByType(JvmJarBinaryRegistrationFactory.class);
 		subject = registry.register(factory.create(BinaryIdentifier.of(componentIdentifier, BinaryIdentity.of("wuke", "FASI binary")))).as(JvmJarBinary.class).get();
 	}

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/SharedLibraryBinaryRegistrationFactory.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/SharedLibraryBinaryRegistrationFactory.java
@@ -70,7 +70,6 @@ public final class SharedLibraryBinaryRegistrationFactory {
 	public ModelRegistration create(BinaryIdentifier<?> identifier) {
 		return ModelRegistration.builder()
 			.withComponent(identifier)
-			.withComponent(toPath(identifier))
 			.withComponent(IsBinary.tag())
 			.withComponent(new FullyQualifiedNameComponent(BinaryNamer.INSTANCE.determineName(identifier)))
 			.action(new AttachLinkLibrariesToLinkTaskRule(identifier))

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeApplicationPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeApplicationPlugin.java
@@ -130,7 +130,6 @@ public class NativeApplicationPlugin implements Plugin<Project> {
 				val registry = project.getExtensions().getByType(ModelRegistry.class);
 				val binaryIdentifier = BinaryIdentifier.of(BinaryName.of("executable"), ExecutableBinaryInternal.class, identifier); // TODO: Use input to get variant identifier
 				val binaryEntity = registry.register(ModelRegistration.builder()
-					.withComponent(path.child("executable"))
 					.withComponent(IsBinary.tag())
 					.withComponent(binaryIdentifier)
 					.withComponent(new FullyQualifiedNameComponent(BinaryNamer.INSTANCE.determineName(binaryIdentifier)))

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeLibraryPlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeLibraryPlugin.java
@@ -152,7 +152,6 @@ public class NativeLibraryPlugin implements Plugin<Project> {
 				if (identifier.getBuildVariant().hasAxisOf(NativeRuntimeBasePlugin.TARGET_LINKAGE_FACTORY.getShared())) {
 					val binaryIdentifier = BinaryIdentifier.of(BinaryName.of("sharedLibrary"), SharedLibraryBinaryInternal.class, identifier); // TODO: Use input to get variant identifier
 					val binaryEntity = registry.register(ModelRegistration.builder()
-						.withComponent(path.child("sharedLibrary"))
 						.withComponent(IsBinary.tag())
 						.withComponent(binaryIdentifier)
 						.withComponent(new FullyQualifiedNameComponent(BinaryNamer.INSTANCE.determineName(binaryIdentifier)))
@@ -166,7 +165,6 @@ public class NativeLibraryPlugin implements Plugin<Project> {
 				} else {
 					val binaryIdentifier = BinaryIdentifier.of(BinaryName.of("staticLibrary"), StaticLibraryBinaryInternal.class, identifier); // TODO: Use input to get variant identifier
 					val binaryEntity = registry.register(ModelRegistration.builder()
-						.withComponent(path.child("staticLibrary"))
 						.withComponent(IsBinary.tag())
 						.withComponent(binaryIdentifier)
 						.withComponent(new FullyQualifiedNameComponent(BinaryNamer.INSTANCE.determineName(binaryIdentifier)))

--- a/subprojects/platform-native/src/test/groovy/dev/nokee/platform/nativebase/SharedLibraryBinaryTest.java
+++ b/subprojects/platform-native/src/test/groovy/dev/nokee/platform/nativebase/SharedLibraryBinaryTest.java
@@ -87,9 +87,9 @@ class SharedLibraryBinaryTest extends AbstractPluginTest {
 		val registry = project.getExtensions().getByType(ModelRegistry.class);
 		val projectIdentifier = ProjectIdentifier.of(project);
 		val componentIdentifier = ComponentIdentifier.of("nuli", projectIdentifier);
-		registry.register(ModelRegistration.builder().withComponent(toPath(componentIdentifier)).build());
+		registry.register(ModelRegistration.builder().withComponent(componentIdentifier).build());
 		val variantIdentifier = VariantIdentifier.of("cuzu", Variant.class, componentIdentifier);
-		registry.register(ModelRegistration.builder().withComponent(toPath(variantIdentifier)).build());
+		registry.register(ModelRegistration.builder().withComponent(variantIdentifier).build());
 		subject = registry.register(factory.create(BinaryIdentifier.of(variantIdentifier, "ruca"))).as(SharedLibraryBinary.class).get();
 	}
 
@@ -172,7 +172,6 @@ class SharedLibraryBinaryTest extends AbstractPluginTest {
 				val newPropertyIdentifier = ModelPropertyIdentifier.of(ModelNodes.of(compileTasks).getComponent(DomainObjectIdentifier.class), "tovi");
 				project.getExtensions().getByType(ModelRegistry.class).register(ModelRegistration.builder()
 					.withComponent(newPropertyIdentifier)
-					.withComponent(toPath(newPropertyIdentifier))
 					.withComponent(ModelPropertyTag.instance())
 					.withComponent(new ModelPropertyTypeComponent(ModelType.of(SourceCompile.class)))
 					.withComponent(createdUsing(ModelType.of(TaskProvider.class), () -> compileTask))
@@ -198,7 +197,6 @@ class SharedLibraryBinaryTest extends AbstractPluginTest {
 				val newPropertyIdentifier = ModelPropertyIdentifier.of(ModelNodes.of(compileTasks).getComponent(DomainObjectIdentifier.class), "vavu");
 				project.getExtensions().getByType(ModelRegistry.class).register(ModelRegistration.builder()
 					.withComponent(newPropertyIdentifier)
-					.withComponent(toPath(newPropertyIdentifier))
 					.withComponent(ModelPropertyTag.instance())
 					.withComponent(new ModelPropertyTypeComponent(ModelType.of(SourceCompile.class)))
 					.withComponent(createdUsing(ModelType.of(TaskProvider.class), () -> compileTask))
@@ -235,7 +233,6 @@ class SharedLibraryBinaryTest extends AbstractPluginTest {
 				val newPropertyIdentifier = ModelPropertyIdentifier.of(ModelNodes.of(compileTasks).getComponent(DomainObjectIdentifier.class), "qizo");
 				project.getExtensions().getByType(ModelRegistry.class).register(ModelRegistration.builder()
 					.withComponent(newPropertyIdentifier)
-					.withComponent(toPath(newPropertyIdentifier))
 					.withComponent(ModelPropertyTag.instance())
 					.withComponent(new ModelPropertyTypeComponent(ModelType.of(SourceCompile.class)))
 					.withComponent(createdUsing(ModelType.of(SourceCompile.class), () -> compileTask))
@@ -252,7 +249,6 @@ class SharedLibraryBinaryTest extends AbstractPluginTest {
 			val newPropertyIdentifier = ModelPropertyIdentifier.of(ModelNodes.of(compileTasks).getComponent(DomainObjectIdentifier.class), "xuvi");
 			project.getExtensions().getByType(ModelRegistry.class).register(ModelRegistration.builder()
 				.withComponent(newPropertyIdentifier)
-				.withComponent(toPath(newPropertyIdentifier))
 				.withComponent(ModelPropertyTag.instance())
 				.withComponent(new ModelPropertyTypeComponent(ModelType.of(SourceCompile.class)))
 				.withComponent(createdUsing(ModelType.of(TaskProvider.class), () -> compileTask))
@@ -301,7 +297,6 @@ class SharedLibraryBinaryTest extends AbstractPluginTest {
 				val newPropertyIdentifier = ModelPropertyIdentifier.of(ModelNodes.of(compileTasks).getComponent(DomainObjectIdentifier.class), "suti");
 				project.getExtensions().getByType(ModelRegistry.class).register(ModelRegistration.builder()
 					.withComponent(newPropertyIdentifier)
-					.withComponent(toPath(newPropertyIdentifier))
 					.withComponent(ModelPropertyTag.instance())
 					.withComponent(new ModelPropertyTypeComponent(ModelType.of(SourceCompile.class)))
 					.withComponent(createdUsing(ModelType.of(TaskProvider.class), () -> compileTask))
@@ -324,7 +319,6 @@ class SharedLibraryBinaryTest extends AbstractPluginTest {
 				val newPropertyIdentifier = ModelPropertyIdentifier.of(ModelNodes.of(compileTasks).getComponent(DomainObjectIdentifier.class), "kedi");
 				project.getExtensions().getByType(ModelRegistry.class).register(ModelRegistration.builder()
 					.withComponent(newPropertyIdentifier)
-					.withComponent(toPath(newPropertyIdentifier))
 					.withComponent(ModelPropertyTag.instance())
 					.withComponent(new ModelPropertyTypeComponent(ModelType.of(SourceCompile.class)))
 					.withComponent(createdUsing(ModelType.of(TaskProvider.class), () -> compileTask))
@@ -340,7 +334,6 @@ class SharedLibraryBinaryTest extends AbstractPluginTest {
 				val newPropertyIdentifier = ModelPropertyIdentifier.of(ModelNodes.of(compileTasks).getComponent(DomainObjectIdentifier.class), "xuvi");
 				project.getExtensions().getByType(ModelRegistry.class).register(ModelRegistration.builder()
 					.withComponent(newPropertyIdentifier)
-					.withComponent(toPath(newPropertyIdentifier))
 					.withComponent(ModelPropertyTag.instance())
 					.withComponent(new ModelPropertyTypeComponent(ModelType.of(SourceCompile.class)))
 					.withComponent(createdUsing(ModelType.of(TaskProvider.class), () -> compileTask))

--- a/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/plugins/NativeUnitTestingPlugin.java
+++ b/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/plugins/NativeUnitTestingPlugin.java
@@ -235,7 +235,6 @@ public class NativeUnitTestingPlugin implements Plugin<Project> {
 				val binaryRepository = project.getExtensions().getByType(BinaryRepository.class);
 				val binaryIdentifier = BinaryIdentifier.of(BinaryName.of("executable"), ExecutableBinaryInternal.class, identifier);
 				val binaryEntity = registry.register(ModelRegistration.builder()
-					.withComponent(path.child("executable"))
 					.withComponent(IsBinary.tag())
 					.withComponent(binaryIdentifier)
 					.withComponent(new FullyQualifiedNameComponent(BinaryNamer.INSTANCE.determineName(binaryIdentifier)))

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/plugins/ObjectiveCXCTestTestSuitePlugin.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/plugins/ObjectiveCXCTestTestSuitePlugin.java
@@ -216,7 +216,6 @@ public class ObjectiveCXCTestTestSuitePlugin implements Plugin<Project> {
 						val binaryConfigurer = project.getExtensions().getByType(BinaryConfigurer.class);
 						val binaryIdentifierXCTestBundle = BinaryIdentifier.of(BinaryName.of("unitTestXCTestBundle"), IosXCTestBundle.class, variantIdentifier);
 						val xcTestBundleEntity = registry.register(ModelRegistration.builder()
-							.withComponent(DomainObjectIdentifierUtils.toPath(binaryIdentifierXCTestBundle))
 							.withComponent(IsBinary.tag())
 							.withComponent(binaryIdentifierXCTestBundle)
 							.withComponent(new FullyQualifiedNameComponent(BinaryNamer.INSTANCE.determineName(binaryIdentifierXCTestBundle)))
@@ -226,7 +225,6 @@ public class ObjectiveCXCTestTestSuitePlugin implements Plugin<Project> {
 
 						val binaryIdentifierApplicationBundle = BinaryIdentifier.of(BinaryName.of("signedApplicationBundle"), SignedIosApplicationBundleInternal.class, variantIdentifier);
 						val applicationBundleEntity = registry.register(ModelRegistration.builder()
-							.withComponent(path.child(variantIdentifier.getUnambiguousName()).child("signedApplicationBundle"))
 							.withComponent(IsBinary.tag())
 							.withComponent(binaryIdentifierApplicationBundle)
 							.withComponent(new FullyQualifiedNameComponent(BinaryNamer.INSTANCE.determineName(binaryIdentifierApplicationBundle)))
@@ -335,7 +333,6 @@ public class ObjectiveCXCTestTestSuitePlugin implements Plugin<Project> {
 						val binaryConfigurer = project.getExtensions().getByType(BinaryConfigurer.class);
 						val binaryIdentifierApplicationBundle = BinaryIdentifier.of(BinaryName.of("launcherApplicationBundle"), IosApplicationBundleInternal.class, variantIdentifier);
 						val launcherApplicationBundleEntity = registry.register(ModelRegistration.builder()
-							.withComponent(path.child(variantIdentifier.getUnambiguousName()).child("unitTestXCTestBundle"))
 							.withComponent(IsBinary.tag())
 							.withComponent(binaryIdentifierApplicationBundle)
 							.withComponent(new FullyQualifiedNameComponent(BinaryNamer.INSTANCE.determineName(binaryIdentifierApplicationBundle)))
@@ -345,7 +342,6 @@ public class ObjectiveCXCTestTestSuitePlugin implements Plugin<Project> {
 
 						val binaryIdentifierSignedApplicationBundle = BinaryIdentifier.of(BinaryName.of("signedLauncherApplicationBundle"), SignedIosApplicationBundleInternal.class, variantIdentifier);
 						val signedLauncherApplicationBundleEntity = registry.register(ModelRegistration.builder()
-							.withComponent(path.child(variantIdentifier.getUnambiguousName()).child("signedLauncherApplicationBundle"))
 							.withComponent(IsBinary.tag())
 							.withComponent(binaryIdentifierSignedApplicationBundle)
 							.withComponent(new FullyQualifiedNameComponent(BinaryNamer.INSTANCE.determineName(binaryIdentifierSignedApplicationBundle)))


### PR DESCRIPTION
We are trying to remove the `ModelPath` in favour of better-defined components. This PR declutter most of the codebase by centralizing the generation of `ModelPath`.