### PR TITLE
Introduce the distributions management plugin for Nokee

### DIFF
--- a/gradle/libraries/gradle-build-script/src/main/java/dev/gradleplugins/buildscript/blocks/DependencyNotation.java
+++ b/gradle/libraries/gradle-build-script/src/main/java/dev/gradleplugins/buildscript/blocks/DependencyNotation.java
@@ -44,6 +44,10 @@ public final class DependencyNotation {
 		return new DependencyNotation(invoke("project", string(path)).alwaysUseParenthesis());
 	}
 
+	public static DependencyNotation platform(String path) {
+		return new DependencyNotation(invoke("platform", string(path)).alwaysUseParenthesis());
+	}
+
 	Expression asExpression() {
 		return expression;
 	}

--- a/gradle/libraries/gradle-build-script/src/main/java/dev/gradleplugins/buildscript/blocks/ProjectBlock.java
+++ b/gradle/libraries/gradle-build-script/src/main/java/dev/gradleplugins/buildscript/blocks/ProjectBlock.java
@@ -24,6 +24,8 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 import static dev.gradleplugins.buildscript.syntax.Syntax.literal;
+import static dev.gradleplugins.buildscript.syntax.Syntax.property;
+import static dev.gradleplugins.buildscript.syntax.Syntax.string;
 
 public final class ProjectBlock extends AbstractBlock {
 	private ProjectBlock(Statement delegate) {
@@ -90,6 +92,11 @@ public final class ProjectBlock extends AbstractBlock {
 
 		public Builder apply(ApplyStatement.Notation notation) {
 			builder.add(ApplyStatement.apply(notation));
+			return this;
+		}
+
+		public Builder setGroup(String group) {
+			builder.add(Statement.expressionOf(property(literal("group")).assign(string(group))));
 			return this;
 		}
 

--- a/gradle/libraries/gradle-build-script/src/main/java/dev/gradleplugins/buildscript/blocks/SettingsBlock.java
+++ b/gradle/libraries/gradle-build-script/src/main/java/dev/gradleplugins/buildscript/blocks/SettingsBlock.java
@@ -72,6 +72,11 @@ public final class SettingsBlock extends AbstractBlock {
 			return this;
 		}
 
+		public Builder includeBuild(String buildPath) {
+			builder.add(IncludeBuildStatement.includeBuild(buildPath));
+			return this;
+		}
+
 		public Builder rootProject(Function<? super PropertyExpression, ? extends Expression> mapper) {
 			builder.add(ExpressionStatement.of(mapper.apply(property(literal("rootProject")))));
 			return this;
@@ -85,6 +90,12 @@ public final class SettingsBlock extends AbstractBlock {
 	public static final class IncludeStatement {
 		public static Statement include(String firstProjectPath, String... otherProjectPaths) {
 			return ExpressionStatement.of(invoke("include", Stream.concat(Stream.of(firstProjectPath), Stream.of(otherProjectPaths)).map(Syntax::string).toArray(Expression[]::new)));
+		}
+	}
+
+	public static final class IncludeBuildStatement {
+		public static Statement includeBuild(String path) {
+			return ExpressionStatement.of(invoke("includeBuild", Syntax.string(path)));
 		}
 	}
 }

--- a/gradle/libraries/gradle-build-script/src/main/java/dev/gradleplugins/buildscript/blocks/SettingsBlock.java
+++ b/gradle/libraries/gradle-build-script/src/main/java/dev/gradleplugins/buildscript/blocks/SettingsBlock.java
@@ -57,6 +57,11 @@ public final class SettingsBlock extends AbstractBlock {
 			return this;
 		}
 
+		public Builder apply(ApplyStatement.Notation notation) {
+			builder.add(ApplyStatement.apply(notation));
+			return this;
+		}
+
 		public Builder pluginManagement(Consumer<? super PluginManagementBlock.Builder> action) {
 			builder.add(PluginManagementBlock.pluginManagement(action));
 			return this;

--- a/gradle/plugins/nokeebuild-plugins/testing/src/main/java/nokeebuild/GradlePluginDevelopmentFunctionalTestingPlugin.java
+++ b/gradle/plugins/nokeebuild-plugins/testing/src/main/java/nokeebuild/GradlePluginDevelopmentFunctionalTestingPlugin.java
@@ -61,6 +61,9 @@ abstract /*final*/ class GradlePluginDevelopmentFunctionalTestingPlugin implemen
 		});
 		functionalTest(project, new UseJUnitJupiter(junitVersion(project)));
 		functionalTest(project, new UseSpockFramework(spockVersion(project)));
+		project.getPluginManager().withPlugin("java-test-fixtures", __ -> {
+			functionalTest(project, testSuite -> testSuite.dependencies(it -> it.implementation(it.testFixtures(project))));
+		});
 	}
 
 	private static final class MyAction implements Action<Task> {

--- a/gradle/plugins/nokeebuild-plugins/testing/src/main/java/nokeebuild/GradlePluginDevelopmentIntegrationTestingPlugin.java
+++ b/gradle/plugins/nokeebuild-plugins/testing/src/main/java/nokeebuild/GradlePluginDevelopmentIntegrationTestingPlugin.java
@@ -65,6 +65,9 @@ abstract /*final*/ class GradlePluginDevelopmentIntegrationTestingPlugin impleme
 			});
 		});
 		integrationTest(project, new UseJUnitJupiter(junitVersion(project)));
+		project.getPluginManager().withPlugin("java-test-fixtures", __ -> {
+			integrationTest(project, testSuite -> testSuite.dependencies(it -> it.implementation(it.testFixtures(project))));
+		});
 	}
 
 	private static void integrationTest(Project project, Action<? super GradlePluginDevelopmentTestSuite> action) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -48,6 +48,7 @@ subproject('distributions')
 subproject('distributions/all')
 subproject('distributions/bom')
 subproject('distributions-local')
+subproject('distributions-management')
 subproject('docs')
 subproject('docs/exemplar-kit') {
 	buildFileName = 'exemplar-kit.gradle'

--- a/subprojects/core-model/core-model.gradle
+++ b/subprojects/core-model/core-model.gradle
@@ -39,9 +39,3 @@ test {
 		implementation testFixtures(project(':coreUtils'))
 	}
 }
-
-integrationTest {
-	dependencies {
-		implementation testFixtures(project)
-	}
-}

--- a/subprojects/distributions-management/distributions-management.gradle
+++ b/subprojects/distributions-management/distributions-management.gradle
@@ -1,0 +1,16 @@
+plugins {
+	id 'nokeebuild.java-gradle-plugin'
+	id 'nokeebuild.gradle-plugin-functional-test'
+	id 'nokeebuild.gradle-plugin-integration-test'
+	id 'maven-publish'
+	id 'java-test-fixtures'
+}
+
+gradlePlugin {
+	plugins {
+		init {
+			id = 'dev.nokee.distributions-management'
+			implementationClass = 'dev.nokee.init.DistributionsManagementPlugin'
+		}
+	}
+}

--- a/subprojects/distributions-management/src/functionalTest/java/dev/nokee/init/ConfigurationCacheDetectsChangesToDotNokeeRCFileFunctionalTest.java
+++ b/subprojects/distributions-management/src/functionalTest/java/dev/nokee/init/ConfigurationCacheDetectsChangesToDotNokeeRCFileFunctionalTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.init;
+
+import dev.gradleplugins.runnerkit.BuildResult;
+import dev.gradleplugins.runnerkit.GradleRunner;
+import dev.nokee.internal.testing.junit.jupiter.ContextualGradleRunnerParameterResolver;
+import dev.nokee.internal.testing.junit.jupiter.GradleFeatureRequirement;
+import dev.nokee.internal.testing.junit.jupiter.RequiresGradleFeature;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import static dev.gradleplugins.buildscript.blocks.PluginsBlock.plugins;
+import static dev.nokee.init.fixtures.DotNokeeRCTestUtils.writeRcFileTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+@RequiresGradleFeature(GradleFeatureRequirement.CONFIGURATION_CACHE)
+@ExtendWith({TestDirectoryExtension.class, ContextualGradleRunnerParameterResolver.class})
+class ConfigurationCacheDetectsChangesToDotNokeeRCFileFunctionalTest {
+	@TestDirectory Path testDirectory;
+	GradleRunner executer;
+	BuildResult result;
+
+	@BeforeEach
+	void setup(GradleRunner runner) throws IOException {
+		writeRcFileTo(testDirectory, "0.3.0");
+		plugins(it -> it.id("dev.nokee.distributions-management")).writeTo(testDirectory.resolve("settings.gradle"));
+		executer = runner.withArgument("verify").withArgument("--configuration-cache");
+		Files.write(testDirectory.resolve("build.gradle"), Arrays.asList(
+			"plugins {",
+			"  id 'dev.nokee.jni-library'", // we must resolve a Nokee plugin so the "version" is marked as used
+			"}",
+			"tasks.register('verify')"
+		));
+		result = executer.build();
+	}
+
+	@Test
+	void reusesConfigurationCacheWhenRCFileDoesNotChanges() {
+		assertThat(executer.build().getOutput(), containsString("Reusing configuration cache"));
+	}
+
+	@Test
+	void doesNotReuseConfigurationCacheWhenRCFileChange() throws IOException {
+		writeRcFileTo(testDirectory, "0.4.0");
+		assertThat(executer.build().getOutput(), not(containsString("Reusing configuration cache")));
+	}
+}

--- a/subprojects/distributions-management/src/functionalTest/java/dev/nokee/init/NokeeManagementServiceNoVersionFunctionalTest.java
+++ b/subprojects/distributions-management/src/functionalTest/java/dev/nokee/init/NokeeManagementServiceNoVersionFunctionalTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.init;
+
+import dev.gradleplugins.runnerkit.BuildResult;
+import dev.gradleplugins.runnerkit.GradleRunner;
+import dev.nokee.internal.testing.junit.jupiter.ContextualGradleRunnerParameterResolver;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import static dev.gradleplugins.buildscript.blocks.PluginsBlock.plugins;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+@ExtendWith({TestDirectoryExtension.class, ContextualGradleRunnerParameterResolver.class})
+class NokeeManagementServiceNoVersionFunctionalTest {
+	@TestDirectory Path testDirectory;
+	GradleRunner executer;
+
+	@BeforeEach
+	void setup(GradleRunner runner) throws IOException {
+		executer = runner;
+		plugins(it -> it.id("dev.nokee.distributions-management")).writeTo(testDirectory.resolve("settings.gradle"));
+		Files.write(testDirectory.resolve("build.gradle"), Arrays.asList(
+			"def service = gradle.sharedServices.registrations.nokeeManagement.service",
+			"tasks.register('verify') {",
+			"  usesService(service)",
+			"  doLast {",
+			"    service.get().version",
+			"  }",
+			"}"
+		));
+	}
+
+	@Test
+	void showsMeaningfulError() {
+		final BuildResult result = executer.withTasks("verify").buildAndFail();
+		assertThat(result.getOutput(), containsString("Please add the Nokee version to use in a .nokeerc file."));
+	}
+}

--- a/subprojects/distributions-management/src/functionalTest/java/dev/nokee/init/NokeeManagementServiceUsesVersionFromBuildSrcParentFunctionalTest.java
+++ b/subprojects/distributions-management/src/functionalTest/java/dev/nokee/init/NokeeManagementServiceUsesVersionFromBuildSrcParentFunctionalTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.init;
+
+import dev.gradleplugins.runnerkit.GradleRunner;
+import dev.nokee.internal.testing.junit.jupiter.ContextualGradleRunnerParameterResolver;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import static dev.gradleplugins.buildscript.blocks.PluginsBlock.plugins;
+import static dev.nokee.init.fixtures.DotNokeeRCTestUtils.writeRcFileTo;
+
+@ExtendWith({TestDirectoryExtension.class, ContextualGradleRunnerParameterResolver.class})
+class NokeeManagementServiceUsesVersionFromBuildSrcParentFunctionalTest {
+	@TestDirectory Path testDirectory;
+	GradleRunner executer;
+
+	@BeforeEach
+	void setup(GradleRunner runner) throws IOException {
+		executer = runner;
+		plugins(it -> it.id("dev.nokee.distributions-management")).writeTo(testDirectory.resolve("settings.gradle"));
+		writeRcFileTo(testDirectory, "0.4.2");
+		Files.write(testDirectory.resolve("build.gradle"), Arrays.asList(
+			"tasks.register('verify')"
+		));
+
+		Files.createDirectory(testDirectory.resolve("buildSrc"));
+		plugins(it -> it.id("dev.nokee.distributions-management")).writeTo(testDirectory.resolve("buildSrc/settings.gradle"));
+		Files.write(testDirectory.resolve("buildSrc/build.gradle"), Arrays.asList(
+			"def service = gradle.sharedServices.registrations.nokeeManagement.service",
+			"def verifyTask = tasks.register('verify') {",
+			"  usesService(service)",
+			"  doLast {",
+			"    assert service.get().version.toString() == '0.4.2'",
+			"  }",
+			"}",
+			"tasks.named('build') { finalizedBy(verifyTask) }"
+		));
+	}
+
+	@Test
+	void fetchesNokeeVersionFromMainBuild() {
+		executer.withTasks("verify").build();
+	}
+}

--- a/subprojects/distributions-management/src/functionalTest/java/dev/nokee/init/NokeeManagementServiceUsesVersionFromIncludedBuildParentFunctionalTest.java
+++ b/subprojects/distributions-management/src/functionalTest/java/dev/nokee/init/NokeeManagementServiceUsesVersionFromIncludedBuildParentFunctionalTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.init;
+
+import dev.gradleplugins.buildscript.blocks.SettingsBlock;
+import dev.gradleplugins.runnerkit.GradleRunner;
+import dev.nokee.internal.testing.junit.jupiter.ContextualGradleRunnerParameterResolver;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import static dev.gradleplugins.buildscript.blocks.PluginsBlock.plugins;
+import static dev.nokee.init.fixtures.DotNokeeRCTestUtils.writeRcFileTo;
+
+@ExtendWith({TestDirectoryExtension.class, ContextualGradleRunnerParameterResolver.class})
+class NokeeManagementServiceUsesVersionFromIncludedBuildParentFunctionalTest {
+	@TestDirectory Path testDirectory;
+	GradleRunner executer;
+
+	@BeforeEach
+	void setup(GradleRunner runner) throws IOException {
+		executer = runner;
+		SettingsBlock.builder().plugins(it -> it.id("dev.nokee.distributions-management"))
+			.includeBuild("build-src")
+			.build()
+			.writeTo(testDirectory.resolve("settings.gradle"));
+		writeRcFileTo(testDirectory, "0.4.2");
+		Files.write(testDirectory.resolve("build.gradle"), Arrays.asList(
+			"tasks.register('verify') {",
+			"  dependsOn gradle.includedBuild('build-src').task(':verify')",
+			"}"
+		));
+
+		Files.createDirectory(testDirectory.resolve("build-src"));
+		plugins(it -> it.id("dev.nokee.distributions-management")).writeTo(testDirectory.resolve("build-src/settings.gradle"));
+		Files.write(testDirectory.resolve("build-src/build.gradle"), Arrays.asList(
+			"def service = gradle.sharedServices.registrations.nokeeManagement.service",
+			"tasks.register('verify') {",
+			"  usesService(service)",
+			"  doLast {",
+			"    assert service.get().version.toString() == '0.4.2'",
+			"  }",
+			"}"
+		));
+	}
+
+	@Test
+	void fetchesNokeeVersionFromParentBuild() {
+		executer.withTasks("verify").build();
+	}
+}

--- a/subprojects/distributions-management/src/functionalTest/java/dev/nokee/init/NokeeManagementServiceUsesVersionFromIncludedBuildTopMostParentFunctionalTest.java
+++ b/subprojects/distributions-management/src/functionalTest/java/dev/nokee/init/NokeeManagementServiceUsesVersionFromIncludedBuildTopMostParentFunctionalTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.init;
+
+import dev.gradleplugins.buildscript.blocks.SettingsBlock;
+import dev.gradleplugins.runnerkit.GradleRunner;
+import dev.nokee.internal.testing.junit.jupiter.ContextualGradleRunnerParameterResolver;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import static dev.gradleplugins.buildscript.blocks.PluginsBlock.plugins;
+import static dev.nokee.init.fixtures.DotNokeeRCTestUtils.writeRcFileTo;
+
+@ExtendWith({TestDirectoryExtension.class, ContextualGradleRunnerParameterResolver.class})
+class NokeeManagementServiceUsesVersionFromIncludedBuildTopMostParentFunctionalTest {
+	@TestDirectory Path testDirectory;
+	GradleRunner executer;
+
+	@BeforeEach
+	void setup(GradleRunner runner) throws IOException {
+		executer = runner;
+		SettingsBlock.builder().plugins(it -> it.id("dev.nokee.distributions-management"))
+			.includeBuild("build-src")
+			.build()
+			.writeTo(testDirectory.resolve("settings.gradle"));
+		writeRcFileTo(testDirectory, "0.4.3");
+		Files.write(testDirectory.resolve("build.gradle"), Arrays.asList(
+			"tasks.register('verify') {",
+			"  dependsOn gradle.includedBuild('build-src').task(':verify')",
+			"}"
+		));
+
+		Files.createDirectory(testDirectory.resolve("build-src"));
+		Files.createFile(testDirectory.resolve("build-src/settings.gradle"));
+		Files.write(testDirectory.resolve("build-src/build.gradle"), Arrays.asList(
+			"tasks.register('verify')"
+		));
+
+		Files.createDirectory(testDirectory.resolve("build-src/buildSrc"));
+		plugins(it -> it.id("dev.nokee.distributions-management")).writeTo(testDirectory.resolve("build-src/buildSrc/settings.gradle"));
+		Files.write(testDirectory.resolve("build-src/buildSrc/build.gradle"), Arrays.asList(
+			"def service = gradle.sharedServices.registrations.nokeeManagement.service",
+			"def verifyTask = tasks.register('verify') {",
+			"  usesService(service)",
+			"  doLast {",
+			"    assert service.get().version.toString() == '0.4.3'",
+			"  }",
+			"}",
+			"tasks.named('build') { finalizedBy(verifyTask) }"
+		));
+	}
+
+	@Test
+	void fetchesNokeeVersionFromParentBuild() {
+		executer.withTasks("verify").build();
+	}
+}

--- a/subprojects/distributions-management/src/functionalTest/java/dev/nokee/init/NokeeManagementServiceUsesVersionFromRCFileFunctionalTest.java
+++ b/subprojects/distributions-management/src/functionalTest/java/dev/nokee/init/NokeeManagementServiceUsesVersionFromRCFileFunctionalTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.init;
+
+import dev.gradleplugins.runnerkit.GradleRunner;
+import dev.nokee.internal.testing.junit.jupiter.ContextualGradleRunnerParameterResolver;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import static dev.gradleplugins.buildscript.blocks.PluginsBlock.plugins;
+import static dev.nokee.init.fixtures.DotNokeeRCTestUtils.writeRcFileTo;
+
+@ExtendWith({TestDirectoryExtension.class, ContextualGradleRunnerParameterResolver.class})
+class NokeeManagementServiceUsesVersionFromRCFileFunctionalTest {
+	@TestDirectory Path testDirectory;
+	GradleRunner executer;
+
+	@BeforeEach
+	void setup(GradleRunner runner) throws IOException {
+		executer = runner;
+		plugins(it -> it.id("dev.nokee.distributions-management")).writeTo(testDirectory.resolve("settings.gradle"));
+		writeRcFileTo(testDirectory, "0.4.2");
+		Files.write(testDirectory.resolve("build.gradle"), Arrays.asList(
+			"def service = gradle.sharedServices.registrations.nokeeManagement.service",
+			"tasks.register('verify') {",
+			"  usesService(service)",
+			"  doLast {",
+			"    assert service.get().version.toString() == '0.4.2'",
+			"  }",
+			"}"
+		));
+	}
+
+	@Test
+	void loadsNokeeVersionFromDotNokeeRCFile() {
+		executer.withTasks("verify").build();
+	}
+}

--- a/subprojects/distributions-management/src/functionalTest/java/dev/nokee/init/PluginManagementDefaultRepositoriesFunctionalTest.java
+++ b/subprojects/distributions-management/src/functionalTest/java/dev/nokee/init/PluginManagementDefaultRepositoriesFunctionalTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.init;
+
+import dev.gradleplugins.buildscript.blocks.RepositoriesBlock;
+import dev.gradleplugins.buildscript.blocks.SettingsBlock;
+import dev.gradleplugins.runnerkit.GradleRunner;
+import dev.nokee.internal.testing.junit.jupiter.ContextualGradleRunnerParameterResolver;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import static dev.gradleplugins.buildscript.blocks.PluginsBlock.plugins;
+import static dev.nokee.init.fixtures.DotNokeeRCTestUtils.writeRcFileTo;
+
+@ExtendWith({TestDirectoryExtension.class, ContextualGradleRunnerParameterResolver.class})
+class PluginManagementDefaultRepositoriesFunctionalTest {
+	@TestDirectory Path testDirectory;
+	GradleRunner executer;
+
+	@BeforeEach
+	void setup(GradleRunner runner) throws IOException {
+		executer = runner;
+		writeRcFileTo(testDirectory, "0.5.21");
+	}
+
+	@Test
+	void usesGradlePluginPortalRepositoryAsFirstRepositoryWhenNoRepositoryPresent() throws IOException {
+		plugins(it -> it.id("dev.nokee.distributions-management")).writeTo(testDirectory.resolve("settings.gradle"));
+
+		Files.write(testDirectory.resolve("build.gradle"), Arrays.asList(
+			"tasks.register('verify') {",
+			"  doLast {",
+			"    assert gradle.settings.pluginManagement.repositories.first().url.toString() == 'https://plugins.gradle.org/m2'",
+			"  }",
+			"}"
+		));
+		executer.withTasks("verify").build();
+	}
+
+	@Test
+	void doesNotIncludeGradlePluginPortalRepositoryWhenRepositoriesArePresent() throws IOException {
+		SettingsBlock.builder().pluginManagement(it -> it.repositories(RepositoriesBlock.Builder::mavenCentral))
+			.plugins(it -> it.id("dev.nokee.distributions-management"))
+			.build().writeTo(testDirectory.resolve("settings.gradle"));
+
+		Files.write(testDirectory.resolve("build.gradle"), Arrays.asList(
+			"tasks.register('verify') {",
+			"  doLast {",
+			"    assert !gradle.settings.pluginManagement.repositories.any { it.url.toString() == 'https://plugins.gradle.org/m2' }",
+			"  }",
+			"}"
+		));
+		executer.withTasks("verify").build();
+	}
+}

--- a/subprojects/distributions-management/src/functionalTest/java/dev/nokee/init/PluginManagementNokeeRepositoriesFunctionalTest.java
+++ b/subprojects/distributions-management/src/functionalTest/java/dev/nokee/init/PluginManagementNokeeRepositoriesFunctionalTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.init;
+
+import dev.gradleplugins.runnerkit.GradleRunner;
+import dev.nokee.internal.testing.junit.jupiter.ContextualGradleRunnerParameterResolver;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import static dev.gradleplugins.buildscript.blocks.PluginsBlock.plugins;
+import static dev.nokee.init.fixtures.DotNokeeRCTestUtils.writeRcFileTo;
+
+@ExtendWith({TestDirectoryExtension.class, ContextualGradleRunnerParameterResolver.class})
+class PluginManagementNokeeRepositoriesFunctionalTest {
+	@TestDirectory Path testDirectory;
+	GradleRunner executer;
+
+	@BeforeEach
+	void setup(GradleRunner runner) throws IOException {
+		executer = runner;
+		plugins(it -> it.id("dev.nokee.distributions-management")).writeTo(testDirectory.resolve("settings.gradle"));
+	}
+
+	@Test
+	void usesReleaseRepositoriesOnReleaseVersion() throws IOException {
+		writeRcFileTo(testDirectory, "0.4.0");
+		Files.write(testDirectory.resolve("build.gradle"), Arrays.asList(
+			"tasks.register('verify') {",
+			"  doLast {",
+			"    assert gradle.settings.pluginManagement.repositories.any { it.url.toString() == 'https://repo.nokee.dev/release' }",
+			"    assert !gradle.settings.pluginManagement.repositories.any { it.url.toString() == 'https://repo.nokee.dev/snapshot' }",
+			"  }",
+			"}"
+		));
+		executer.withTasks("verify").build();
+	}
+
+	@Test
+	void usesSnapshotRepositoriesOnIntegrationVersion() throws IOException {
+		writeRcFileTo(testDirectory, "0.4.2190-202205201507.5d969a1e");
+		Files.write(testDirectory.resolve("build.gradle"), Arrays.asList(
+			"tasks.register('verify') {",
+			"  doLast {",
+			"    assert !gradle.settings.pluginManagement.repositories.any { it.url.toString() == 'https://repo.nokee.dev/release' }",
+			"    assert gradle.settings.pluginManagement.repositories.any { it.url.toString() == 'https://repo.nokee.dev/snapshot' }",
+			"  }",
+			"}"
+		));
+		executer.withTasks("verify").build();
+	}
+
+	@Test
+	void usesSnapshotRepositoriesOnSnapshotVersion() throws IOException {
+		writeRcFileTo(testDirectory, "0.5.0-SNAPSHOT");
+		Files.write(testDirectory.resolve("build.gradle"), Arrays.asList(
+			"tasks.register('verify') {",
+			"  doLast {",
+			"    assert !gradle.settings.pluginManagement.repositories.any { it.url.toString() == 'https://repo.nokee.dev/release' }",
+			"    assert gradle.settings.pluginManagement.repositories.any { it.url.toString() == 'https://repo.nokee.dev/snapshot' }",
+			"  }",
+			"}"
+		));
+		executer.withTasks("verify").build();
+	}
+}

--- a/subprojects/distributions-management/src/integrationTest/java/dev/nokee/init/NokeeRCVersionSourceIntegrationTest.java
+++ b/subprojects/distributions-management/src/integrationTest/java/dev/nokee/init/NokeeRCVersionSourceIntegrationTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.init;
+
+import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static dev.nokee.init.NokeeRCVersionSource.rcFile;
+import static dev.nokee.init.fixtures.DotNokeeRCTestUtils.writeRcFileTo;
+import static dev.nokee.internal.testing.GradleProviderMatchers.absentProvider;
+import static dev.nokee.internal.testing.GradleProviderMatchers.providerOf;
+import static dev.nokee.internal.testing.util.ProjectTestUtils.providerFactory;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ExtendWith(TestDirectoryExtension.class)
+class NokeeRCVersionSourceIntegrationTest {
+	@TestDirectory Path testDirectory;
+
+	@Test
+	void provideVersionFromDotNokeercFile() throws IOException {
+		writeRcFileTo(testDirectory, "0.2.0");
+		assertThat(providerFactory().of(NokeeRCVersionSource.class, rcFile(testDirectory.toFile())), providerOf(NokeeVersion.version("0.2.0")));
+	}
+
+	@Test
+	void doesNotProvideVersionWhenDotNokeercFileAbsent() {
+		assertThat(providerFactory().of(NokeeRCVersionSource.class, rcFile(testDirectory.toFile())), absentProvider());
+	}
+}

--- a/subprojects/distributions-management/src/main/java/dev/nokee/init/DistributionsManagementPlugin.java
+++ b/subprojects/distributions-management/src/main/java/dev/nokee/init/DistributionsManagementPlugin.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.init;
+
+import org.gradle.api.Action;
+import org.gradle.api.Plugin;
+import org.gradle.api.Transformer;
+import org.gradle.api.initialization.Settings;
+import org.gradle.api.invocation.Gradle;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.services.BuildServiceRegistration;
+
+import javax.inject.Inject;
+import java.util.function.Function;
+
+import static dev.nokee.init.NokeeManagementService.registerService;
+import static dev.nokee.init.NokeeManagementService.toNokeeVersion;
+import static dev.nokee.init.NokeeRCVersionSource.rcFile;
+import static dev.nokee.init.ProviderUtils.forUseAtConfigurationTime;
+
+// FIXME: Javadoc fail if no public class
+public class DistributionsManagementPlugin implements Plugin<Settings> {
+	private final ProviderFactory providers;
+
+	@Inject
+	public DistributionsManagementPlugin(ProviderFactory providers) {
+		this.providers = providers;
+	}
+
+	@Override
+	public void apply(Settings settings) {
+		final Provider<NokeeManagementService> service = forUseAtConfigurationTime(registerService(settings.getGradle(), defaultParameters(settings)));
+		final Provider<NokeeVersion> version = service.map(NokeeManagementService::getVersion);
+
+		settings.pluginManagement(spec -> {
+			// TODO: Allow disable of the default gradlePluginPortal()
+			spec.repositories(repositories -> {
+				if (spec.getRepositories().size() == 0) {
+					spec.getRepositories().gradlePluginPortal();
+				}
+			});
+			spec.repositories(new NokeeRepositoryAction(version.map(new InferNokeeRepositoryUrl())));
+			spec.resolutionStrategy(strategy -> strategy.eachPlugin(new OnlyIfUnderNokeeNamespaceAction(details -> {
+				details.useVersion(version.get().toString());
+			})));
+		});
+	}
+
+	@SuppressWarnings("UnstableApiUsage")
+	private Action<NokeeManagementService.Parameters> defaultParameters(Settings settings) {
+		return new Action<NokeeManagementService.Parameters>() {
+			@Override
+			public void execute(NokeeManagementService.Parameters parameters) {
+				parameters.getNokeeVersion().value(
+					providers.provider(settings::getGradle).flatMap(forEachParent(NokeeManagementService::findServiceRegistration)).map(toNokeeVersion())
+						.orElse(forUseAtConfigurationTime(providers.of(NokeeRCVersionSource.class, rcFile(settings.getSettingsDir())))));
+			}
+
+			private Transformer<Provider<NokeeManagementService>, Gradle> forEachParent(Function<Gradle, BuildServiceRegistration<NokeeManagementService, NokeeManagementService.Parameters>> mapper) {
+				return gradle -> {
+					while (gradle.getParent() != null) {
+						gradle = gradle.getParent();
+						final BuildServiceRegistration<NokeeManagementService, NokeeManagementService.Parameters> serviceRegistration = mapper.apply(gradle);
+
+						if (serviceRegistration != null) {
+							return serviceRegistration.getService();
+						}
+					}
+					return providers.provider(() -> null);
+				};
+			}
+		};
+	}
+}

--- a/subprojects/distributions-management/src/main/java/dev/nokee/init/InferNokeeRepositoryUrl.java
+++ b/subprojects/distributions-management/src/main/java/dev/nokee/init/InferNokeeRepositoryUrl.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.init;
+
+import org.gradle.api.Transformer;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+// TODO: Allow override of the Nokee repositories
+final class InferNokeeRepositoryUrl implements Transformer<URI, NokeeVersion> {
+	@Override
+	public URI transform(NokeeVersion version) {
+		if (version.isSnapshot()) {
+			return uri("https://repo.nokee.dev/snapshot");
+		} else {
+			return uri("https://repo.nokee.dev/release");
+		}
+	}
+
+	private static URI uri(String s) {
+		try {
+			return new URI(s);
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/subprojects/distributions-management/src/main/java/dev/nokee/init/NokeeManagementService.java
+++ b/subprojects/distributions-management/src/main/java/dev/nokee/init/NokeeManagementService.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.init;
+
+import org.gradle.api.Action;
+import org.gradle.api.Transformer;
+import org.gradle.api.invocation.Gradle;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.services.BuildService;
+import org.gradle.api.services.BuildServiceParameters;
+import org.gradle.api.services.BuildServiceRegistration;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import java.lang.reflect.InvocationTargetException;
+
+@SuppressWarnings("UnstableApiUsage")
+abstract class NokeeManagementService implements BuildService<NokeeManagementService.Parameters> {
+	private static final String SERVICE_NAME = "nokeeManagement";
+
+	interface Parameters extends BuildServiceParameters {
+		Property<NokeeVersion> getNokeeVersion();
+	}
+
+	@Inject
+	public NokeeManagementService() {}
+
+	public NokeeVersion getVersion() {
+		final NokeeVersion result = getParameters().getNokeeVersion().getOrNull();
+		if (result == null) {
+			throw new RuntimeException("Please add the Nokee version to use in a .nokeerc file.");
+		}
+		return result;
+	}
+
+	public static Provider<NokeeManagementService> registerService(Gradle gradle, Action<? super Parameters> action) {
+		return gradle.getSharedServices().registerIfAbsent(SERVICE_NAME, NokeeManagementService.class, it -> {
+			it.parameters(action);
+		});
+	}
+
+	@SuppressWarnings("unchecked")
+	public static Provider<NokeeManagementService> fromService(Gradle gradle) {
+		return (Provider<NokeeManagementService>) gradle.getSharedServices().getRegistrations().getByName(SERVICE_NAME).getService();
+	}
+
+	@Nullable
+	@SuppressWarnings("unchecked")
+	public static BuildServiceRegistration<NokeeManagementService, NokeeManagementService.Parameters> findServiceRegistration(Gradle gradle) {
+		return (BuildServiceRegistration<NokeeManagementService, NokeeManagementService.Parameters>) gradle.getSharedServices().getRegistrations().findByName(SERVICE_NAME);
+	}
+
+	public static Transformer<NokeeVersion, BuildService<?>> toNokeeVersion() {
+		return service -> {
+			// Not the same class loader so classes don't align, reflection required
+			try {
+				return NokeeVersion.version(service.getClass().getMethod("getVersion").invoke(service).toString());
+			} catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
+				throw new RuntimeException(e);
+			}
+		};
+	}
+}

--- a/subprojects/distributions-management/src/main/java/dev/nokee/init/NokeeRCVersionSource.java
+++ b/subprojects/distributions-management/src/main/java/dev/nokee/init/NokeeRCVersionSource.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.init;
+
+import org.gradle.api.Action;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.ValueSource;
+import org.gradle.api.provider.ValueSourceParameters;
+import org.gradle.api.provider.ValueSourceSpec;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+abstract class NokeeRCVersionSource implements ValueSource<NokeeVersion, NokeeRCVersionSource.Parameters> {
+	interface Parameters extends ValueSourceParameters {
+		RegularFileProperty getNokeeRCFile();
+	}
+
+	@Inject
+	public NokeeRCVersionSource() {}
+
+	@Nullable
+	@Override
+	public NokeeVersion obtain() {
+		final Path rcFile = getParameters().getNokeeRCFile().get().getAsFile().toPath();
+		if (Files.exists(rcFile)) {
+			try {
+				return NokeeVersion.version(new String(Files.readAllBytes(rcFile)));
+			} catch (IOException e) {
+				throw new UncheckedIOException(e);
+			}
+		}
+		return null;
+	}
+
+	public static Action<ValueSourceSpec<Parameters>> rcFile(File baseDirectory) {
+		return spec -> spec.parameters(parameters -> parameters.getNokeeRCFile().fileValue(new File(baseDirectory, ".nokeerc")));
+	}
+}

--- a/subprojects/distributions-management/src/main/java/dev/nokee/init/NokeeRepositoryAction.java
+++ b/subprojects/distributions-management/src/main/java/dev/nokee/init/NokeeRepositoryAction.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.init;
+
+import org.gradle.api.Action;
+import org.gradle.api.artifacts.dsl.RepositoryHandler;
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
+import org.gradle.api.provider.Provider;
+
+import java.net.URI;
+
+final class NokeeRepositoryAction implements Action<RepositoryHandler> {
+	private final Provider<URI> repositoryUrl;
+
+	public NokeeRepositoryAction(Provider<URI> repositoryUrl) {
+		this.repositoryUrl = repositoryUrl;
+	}
+
+	@Override
+	public void execute(RepositoryHandler repositories) {
+		repositories.maven(this::nokeeRepository);
+	}
+
+	private void nokeeRepository(MavenArtifactRepository repository) {
+		repository.setName("Nokee Artifact Repository");
+		repository.setUrl(repositoryUrl);
+		repository.mavenContent(content -> {
+			content.includeGroupByRegex("dev\\.nokee.*");
+		});
+	}
+}

--- a/subprojects/distributions-management/src/main/java/dev/nokee/init/NokeeVersion.java
+++ b/subprojects/distributions-management/src/main/java/dev/nokee/init/NokeeVersion.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.init;
+
+import javax.annotation.Nullable;
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A version number with format major.minor.micro-qualifier.
+ */
+final class NokeeVersion implements Comparable<NokeeVersion>, Serializable {
+	public static final NokeeVersion UNKNOWN = new NokeeVersion(0, 0, 0, null);
+
+	private static final Pattern versionPattern = Pattern.compile("(\\d+)(?:\\.(\\d+))?+(?:\\.(\\d+))?+(?:[-.](.+))?");
+	private static final String versionTemplate = "%d.%d.%d%s";
+
+	private final int major;
+	private final int minor;
+	private final int micro;
+	private final String qualifier;
+
+	public NokeeVersion(int major, int minor, int micro, @Nullable String qualifier) {
+		this.major = major;
+		this.minor = minor;
+		this.micro = micro;
+		this.qualifier = qualifier;
+	}
+
+	public int getMajor() {
+		return major;
+	}
+
+	public int getMinor() {
+		return minor;
+	}
+
+	public int getMicro() {
+		return micro;
+	}
+
+	public String getQualifier() {
+		return qualifier;
+	}
+
+	public boolean isSnapshot() {
+		return qualifier != null;
+	}
+
+	@Override
+	public int compareTo(NokeeVersion other) {
+		if (major != other.major)
+			return major - other.major;
+		if (minor != other.minor)
+			return minor - other.minor;
+		if (micro != other.micro)
+			return micro - other.micro;
+		return Objects.compare(qualifier, other.qualifier, String::compareTo);
+	}
+
+	public boolean equals(Object other) {
+		return other instanceof NokeeVersion && compareTo((NokeeVersion) other) == 0;
+	}
+
+	public int hashCode() {
+		int result = major;
+		result = 31 * result + minor;
+		result = 31 * result + micro;
+		result = 31 * result + Objects.hashCode(qualifier);
+		return result;
+	}
+
+	public String toString() {
+		return String.format(versionTemplate, major, minor, micro, qualifier == null ? "" : "-" + qualifier);
+	}
+
+	public static NokeeVersion version(String versionString) {
+		if (versionString == null)
+			return UNKNOWN;
+		Matcher m = versionPattern.matcher(versionString);
+		if (!m.matches())
+			return UNKNOWN;
+
+		int major = Integer.parseInt(m.group(1));
+		String minorString = m.group(2);
+		int minor = minorString == null ? 0 : Integer.parseInt(minorString);
+		String microString = m.group(3);
+		int micro = microString == null ? 0 : Integer.parseInt(microString);
+		String qualifier = m.group(4);
+
+		return new NokeeVersion(major, minor, micro, qualifier);
+	}
+}

--- a/subprojects/distributions-management/src/main/java/dev/nokee/init/OnlyIfUnderNokeeNamespaceAction.java
+++ b/subprojects/distributions-management/src/main/java/dev/nokee/init/OnlyIfUnderNokeeNamespaceAction.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.init;
+
+import org.gradle.api.Action;
+import org.gradle.plugin.management.PluginResolveDetails;
+
+final class OnlyIfUnderNokeeNamespaceAction implements Action<PluginResolveDetails> {
+	private final Action<? super PluginResolveDetails> delegate;
+
+	OnlyIfUnderNokeeNamespaceAction(Action<? super PluginResolveDetails> delegate) {
+		this.delegate = delegate;
+	}
+
+	@Override
+	public void execute(PluginResolveDetails details) {
+		if (details.getRequested().getId().getId().startsWith("dev.nokee.")) {
+			delegate.execute(details);
+		}
+	}
+}

--- a/subprojects/distributions-management/src/main/java/dev/nokee/init/ProviderUtils.java
+++ b/subprojects/distributions-management/src/main/java/dev/nokee/init/ProviderUtils.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.init;
+
+import org.gradle.api.provider.Provider;
+import org.gradle.util.GradleVersion;
+
+import java.lang.reflect.InvocationTargetException;
+
+final class ProviderUtils {
+	public static <T> Provider<T> forUseAtConfigurationTime(Provider<T> self) {
+		if (GradleVersion.current().compareTo(GradleVersion.version("6.5")) >= 0 && GradleVersion.current().compareTo(GradleVersion.version("7.0")) < 0) {
+			try {
+				Provider.class.getMethod("forUseAtConfigurationTime").invoke(self);
+			} catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
+				throw new RuntimeException(e);
+			}
+		}
+		return self;
+	}
+}

--- a/subprojects/distributions-management/src/main/java/dev/nokee/init/package-info.java
+++ b/subprojects/distributions-management/src/main/java/dev/nokee/init/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NonNullApi
+package dev.nokee.init;
+
+import org.gradle.api.NonNullApi;

--- a/subprojects/distributions-management/src/testFixtures/java/dev/nokee/init/fixtures/DotNokeeRCTestUtils.java
+++ b/subprojects/distributions-management/src/testFixtures/java/dev/nokee/init/fixtures/DotNokeeRCTestUtils.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.init.fixtures;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class DotNokeeRCTestUtils {
+	public static void writeRcFileTo(Path testDirectory, String version) throws IOException {
+		Files.write(testDirectory.resolve(".nokeerc"), version.getBytes(StandardCharsets.UTF_8));
+	}
+}

--- a/subprojects/language-c/language-c.gradle
+++ b/subprojects/language-c/language-c.gradle
@@ -44,7 +44,6 @@ test {
 integrationTest {
 	dependencies {
 		implementation project(':platformBase')
-		implementation testFixtures(project)
 		implementation testFixtures(project(':coreScript'))
 	}
 }

--- a/subprojects/language-cpp/language-cpp.gradle
+++ b/subprojects/language-cpp/language-cpp.gradle
@@ -44,7 +44,6 @@ test {
 integrationTest {
 	dependencies {
 		implementation project(':platformBase')
-		implementation testFixtures(project)
 		implementation testFixtures(project(':coreScript'))
 	}
 }

--- a/subprojects/language-objective-c/language-objective-c.gradle
+++ b/subprojects/language-objective-c/language-objective-c.gradle
@@ -46,7 +46,6 @@ test {
 integrationTest {
 	dependencies {
 		implementation project(':platformBase')
-		implementation testFixtures(project)
 		implementation testFixtures(project(':coreScript'))
 	}
 }

--- a/subprojects/language-objective-cpp/language-objective-cpp.gradle
+++ b/subprojects/language-objective-cpp/language-objective-cpp.gradle
@@ -46,7 +46,6 @@ test {
 integrationTest {
 	dependencies {
 		implementation project(':platformBase')
-		implementation testFixtures(project)
 		implementation testFixtures(project(':coreScript'))
 	}
 }

--- a/subprojects/language-swift/language-swift.gradle
+++ b/subprojects/language-swift/language-swift.gradle
@@ -50,7 +50,6 @@ test {
 integrationTest {
 	dependencies {
 		implementation project(':platformBase')
-		implementation testFixtures(project)
 		implementation testFixtures(project(':coreScript'))
 	}
 }

--- a/subprojects/platform-base/platform-base.gradle
+++ b/subprojects/platform-base/platform-base.gradle
@@ -41,9 +41,3 @@ test {
 		implementation testFixtures(project(':coreUtils'))
 	}
 }
-
-integrationTest {
-	dependencies {
-		implementation testFixtures(project)
-	}
-}


### PR DESCRIPTION
There may still be some gap in terms of functionality but it should replace the current configuration blob in the `settings.gradle[.kts]` script for most use cases.

Fixes https://github.com/nokeedev/gradle-native/issues/594