### PR TITLE
Redirect subprojects build directory to root project's build directory (in Xcode build adapter)

### DIFF
--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/RedirectProjectBuildDirectoryToRootBuildDirectoryFunctionalTest.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/RedirectProjectBuildDirectoryToRootBuildDirectoryFunctionalTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode;
+
+import dev.gradleplugins.runnerkit.GradleRunner;
+import dev.nokee.internal.testing.junit.jupiter.ContextualGradleRunnerParameterResolver;
+import dev.nokee.platform.xcode.EmptyXCProject;
+import dev.nokee.platform.xcode.XCWorkspaceElement;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static dev.gradleplugins.buildscript.blocks.PluginsBlock.plugins;
+import static dev.nokee.buildadapter.xcode.GradleTestSnippets.assertVerifyTask;
+
+@ExtendWith({TestDirectoryExtension.class, ContextualGradleRunnerParameterResolver.class})
+class RedirectProjectBuildDirectoryToRootBuildDirectoryFunctionalTest {
+	@TestDirectory static Path testDirectory;
+
+	@BeforeAll
+	static void setup() throws IOException {
+		new XCWorkspaceElement("App", "App", "Lib1", "Pods/Lib1", "Pods/Lib2").writeToProject(testDirectory);
+		new EmptyXCProject("App").writeToProject(testDirectory);
+		new EmptyXCProject("Lib1").writeToProject(testDirectory);
+		new EmptyXCProject("Pods/Lib1").writeToProject(testDirectory);
+		new EmptyXCProject("Pods/Lib2").writeToProject(testDirectory);
+		plugins(it -> it.id("dev.nokee.xcode-build-adapter")).writeTo(testDirectory.resolve("settings.gradle"));
+	}
+
+	@Test
+	void redirectsSubprojectBuildDirectoryToRootProjectBuildDirectory(GradleRunner runner) throws IOException {
+		assertVerifyTask(
+			"project(':').buildDir.absolutePath.endsWith('/build')",
+			"project(':App').buildDir.absolutePath.endsWith('/build/subprojects/App-29bgbf8mfc')",
+			"project(':Lib1').buildDir.absolutePath.endsWith('/build/subprojects/Lib1-22ji4v30pv3')",
+			"project(':Pods').buildDir.absolutePath.endsWith('/build/subprojects/Pods-22ji7ch9sql')",
+			"project(':Pods:Lib1').buildDir.absolutePath.endsWith('/build/subprojects/Lib1-3vq31ktoy17hb')",
+			"project(':Pods:Lib2').buildDir.absolutePath.endsWith('/build/subprojects/Lib2-3vq31ktoy1z7k')"
+		).writeTo(testDirectory.resolve("build.gradle"));
+		runner.withTasks("verify").build();
+	}
+}

--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/RedirectProjectBuildDirectoryToRootBuildDirectoryFunctionalTest.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/RedirectProjectBuildDirectoryToRootBuildDirectoryFunctionalTest.java
@@ -50,12 +50,12 @@ class RedirectProjectBuildDirectoryToRootBuildDirectoryFunctionalTest {
 	@Test
 	void redirectsSubprojectBuildDirectoryToRootProjectBuildDirectory(GradleRunner runner) throws IOException {
 		assertVerifyTask(
-			"project(':').buildDir.absolutePath.endsWith('/build')",
-			"project(':App').buildDir.absolutePath.endsWith('/build/subprojects/App-29bgbf8mfc')",
-			"project(':Lib1').buildDir.absolutePath.endsWith('/build/subprojects/Lib1-22ji4v30pv3')",
-			"project(':Pods').buildDir.absolutePath.endsWith('/build/subprojects/Pods-22ji7ch9sql')",
-			"project(':Pods:Lib1').buildDir.absolutePath.endsWith('/build/subprojects/Lib1-3vq31ktoy17hb')",
-			"project(':Pods:Lib2').buildDir.absolutePath.endsWith('/build/subprojects/Lib2-3vq31ktoy1z7k')"
+			"project(':').buildDir.absolutePath.replace('\\', '/').endsWith('/build')",
+			"project(':App').buildDir.absolutePath.replace('\\', '/').endsWith('/build/subprojects/App-29bgbf8mfc')",
+			"project(':Lib1').buildDir.absolutePath.replace('\\', '/').endsWith('/build/subprojects/Lib1-22ji4v30pv3')",
+			"project(':Pods').buildDir.absolutePath.replace('\\', '/').endsWith('/build/subprojects/Pods-22ji7ch9sql')",
+			"project(':Pods:Lib1').buildDir.absolutePath.replace('\\', '/').endsWith('/build/subprojects/Lib1-3vq31ktoy17hb')",
+			"project(':Pods:Lib2').buildDir.absolutePath.replace('\\', '/').endsWith('/build/subprojects/Lib2-3vq31ktoy1z7k')"
 		).writeTo(testDirectory.resolve("build.gradle"));
 		runner.withTasks("verify").build();
 	}

--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/RedirectProjectBuildDirectoryToRootBuildDirectoryFunctionalTest.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/RedirectProjectBuildDirectoryToRootBuildDirectoryFunctionalTest.java
@@ -21,13 +21,11 @@ import dev.nokee.platform.xcode.EmptyXCProject;
 import dev.nokee.platform.xcode.XCWorkspaceElement;
 import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
 import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
-import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static dev.gradleplugins.buildscript.blocks.PluginsBlock.plugins;
@@ -50,12 +48,12 @@ class RedirectProjectBuildDirectoryToRootBuildDirectoryFunctionalTest {
 	@Test
 	void redirectsSubprojectBuildDirectoryToRootProjectBuildDirectory(GradleRunner runner) throws IOException {
 		assertVerifyTask(
-			"project(':').buildDir.absolutePath.replace('\\', '/').endsWith('/build')",
-			"project(':App').buildDir.absolutePath.replace('\\', '/').endsWith('/build/subprojects/App-29bgbf8mfc')",
-			"project(':Lib1').buildDir.absolutePath.replace('\\', '/').endsWith('/build/subprojects/Lib1-22ji4v30pv3')",
-			"project(':Pods').buildDir.absolutePath.replace('\\', '/').endsWith('/build/subprojects/Pods-22ji7ch9sql')",
-			"project(':Pods:Lib1').buildDir.absolutePath.replace('\\', '/').endsWith('/build/subprojects/Lib1-3vq31ktoy17hb')",
-			"project(':Pods:Lib2').buildDir.absolutePath.replace('\\', '/').endsWith('/build/subprojects/Lib2-3vq31ktoy1z7k')"
+			"project(':').buildDir.absolutePath.replace('\\\\', '/').endsWith('/build')",
+			"project(':App').buildDir.absolutePath.replace('\\\\', '/').endsWith('/build/subprojects/App-29bgbf8mfc')",
+			"project(':Lib1').buildDir.absolutePath.replace('\\\\', '/').endsWith('/build/subprojects/Lib1-22ji4v30pv3')",
+			"project(':Pods').buildDir.absolutePath.replace('\\\\', '/').endsWith('/build/subprojects/Pods-22ji7ch9sql')",
+			"project(':Pods:Lib1').buildDir.absolutePath.replace('\\\\', '/').endsWith('/build/subprojects/Lib1-3vq31ktoy17hb')",
+			"project(':Pods:Lib2').buildDir.absolutePath.replace('\\\\', '/').endsWith('/build/subprojects/Lib2-3vq31ktoy1z7k')"
 		).writeTo(testDirectory.resolve("build.gradle"));
 		runner.withTasks("verify").build();
 	}

--- a/subprojects/build-adapter-xcode/src/integrationTest/java/dev/nokee/buildadapter/xcode/internal/RedirectProjectBuildDirectoryToRootBuildDirectoryAddProjectFirstWithHashCollisionIntegrationTest.java
+++ b/subprojects/build-adapter-xcode/src/integrationTest/java/dev/nokee/buildadapter/xcode/internal/RedirectProjectBuildDirectoryToRootBuildDirectoryAddProjectFirstWithHashCollisionIntegrationTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal;
+
+import com.google.common.collect.ImmutableMap;
+import dev.nokee.buildadapter.xcode.internal.plugins.RedirectProjectBuildDirectoryToRootBuildDirectory;
+import dev.nokee.buildadapter.xcode.internal.plugins.RedirectProjectBuildDirectoryToRootBuildDirectory.HashFunction;
+import dev.nokee.internal.testing.util.ProjectTestUtils;
+import lombok.val;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static dev.nokee.internal.testing.FileSystemMatchers.aFile;
+import static dev.nokee.internal.testing.FileSystemMatchers.withAbsolutePath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({TestDirectoryExtension.class, MockitoExtension.class})
+class RedirectProjectBuildDirectoryToRootBuildDirectoryAddProjectFirstWithHashCollisionIntegrationTest {
+	static HashFunction algorithm = Mockito.mock(HashFunction.class);
+	static Action<Project> subject;
+	@TestDirectory static Path testDirectory;
+	static Project rootProject;
+	static Project projectA;
+	static Project projectB;
+	static Project projectB_A;
+
+	@BeforeAll
+	static void setup() throws IOException {
+		save(testDirectory.resolve("build/subprojects/mapping.ser"), ImmutableMap.of(":B", "B-1g", ":B:A", "A-16"));
+		subject = new RedirectProjectBuildDirectoryToRootBuildDirectory(algorithm);
+		rootProject = ProjectTestUtils.createRootProject(testDirectory);
+		projectA = ProjectTestUtils.createChildProject(rootProject, "A");
+		projectB = ProjectTestUtils.createChildProject(rootProject, "B");
+		projectB_A = ProjectTestUtils.createChildProject(projectB, "A");
+
+		when(algorithm.hash(":A[0]")).thenReturn(42L);
+		when(algorithm.hash(":A[1]")).thenReturn(62L);
+		subject.execute(rootProject);
+	}
+
+	@Test
+	void doesNotUseSameBuildDirectoryBetweenAmbiguousProject() {
+		assertThat(projectA.getBuildDir(), not(equalTo(projectB_A.getBuildDir())));
+	}
+
+	@Test
+	void hasProject_A_BuildDirectory() {
+		assertThat(projectA.getBuildDir(), aFile(withAbsolutePath(endsWith("/build/subprojects/A-1q"))));
+	}
+
+	@Test
+	void hasProject_B_BuildDirectory() {
+		assertThat(projectB.getBuildDir(), aFile(withAbsolutePath(endsWith("/build/subprojects/A-1q"))));
+	}
+
+	@Test
+	void hasProject_A_B_BuildDirectory() {
+		assertThat(projectB_A.getBuildDir(), aFile(withAbsolutePath(endsWith("/build/subprojects/A-16"))));
+	}
+
+	@Test
+	void reuseCachedBuildDirectories() {
+		verify(algorithm, never()).hash(":B[0]");
+		verify(algorithm, never()).hash(":B:A[0]");
+	}
+
+	@Test
+	void computesNewProjectBuildDirectoryUsingDisambiguateAlgorithm() {
+		val inOrder = Mockito.inOrder(algorithm);
+		inOrder.verify(algorithm).hash(":A[0]");
+		inOrder.verify(algorithm).hash(":A[1]");
+	}
+
+	private static void save(Path cacheFile, Map<String, String> cache) throws IOException {
+		Files.createDirectories(cacheFile.getParent());
+		try (final ObjectOutputStream outStream = new ObjectOutputStream(Files.newOutputStream(cacheFile))) {
+			outStream.writeObject(new LinkedHashMap<>(cache));
+		}
+	}
+}

--- a/subprojects/build-adapter-xcode/src/integrationTest/java/dev/nokee/buildadapter/xcode/internal/RedirectProjectBuildDirectoryToRootBuildDirectoryAddProjectFirstWithHashCollisionIntegrationTest.java
+++ b/subprojects/build-adapter-xcode/src/integrationTest/java/dev/nokee/buildadapter/xcode/internal/RedirectProjectBuildDirectoryToRootBuildDirectoryAddProjectFirstWithHashCollisionIntegrationTest.java
@@ -84,7 +84,7 @@ class RedirectProjectBuildDirectoryToRootBuildDirectoryAddProjectFirstWithHashCo
 
 	@Test
 	void hasProject_B_BuildDirectory() {
-		assertThat(projectB.getBuildDir(), aFile(withAbsolutePath(endsWith("/build/subprojects/A-1q"))));
+		assertThat(projectB.getBuildDir(), aFile(withAbsolutePath(endsWith("/build/subprojects/B-1g"))));
 	}
 
 	@Test

--- a/subprojects/build-adapter-xcode/src/integrationTest/java/dev/nokee/buildadapter/xcode/internal/RedirectProjectBuildDirectoryToRootBuildDirectoryProjectNameDuplicateWithHashCollisionIntegrationTest.java
+++ b/subprojects/build-adapter-xcode/src/integrationTest/java/dev/nokee/buildadapter/xcode/internal/RedirectProjectBuildDirectoryToRootBuildDirectoryProjectNameDuplicateWithHashCollisionIntegrationTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal;
+
+import dev.nokee.buildadapter.xcode.internal.plugins.RedirectProjectBuildDirectoryToRootBuildDirectory;
+import dev.nokee.buildadapter.xcode.internal.plugins.RedirectProjectBuildDirectoryToRootBuildDirectory.HashFunction;
+import dev.nokee.internal.testing.util.ProjectTestUtils;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.nio.file.Path;
+
+import static dev.nokee.internal.testing.FileSystemMatchers.aFile;
+import static dev.nokee.internal.testing.FileSystemMatchers.withAbsolutePath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({TestDirectoryExtension.class, MockitoExtension.class})
+class RedirectProjectBuildDirectoryToRootBuildDirectoryProjectNameDuplicateWithHashCollisionIntegrationTest {
+	static HashFunction algorithm = Mockito.mock(HashFunction.class);
+	static Action<Project> subject = new RedirectProjectBuildDirectoryToRootBuildDirectory(algorithm);;
+	@TestDirectory static Path testDirectory;
+	static Project rootProject;
+	static Project projectA;
+	static Project projectB;
+	static Project projectB_A;
+
+	@BeforeAll
+	static void setup() {
+		rootProject = ProjectTestUtils.createRootProject(testDirectory);
+		projectA = ProjectTestUtils.createChildProject(rootProject, "A");
+		projectB = ProjectTestUtils.createChildProject(rootProject, "B");
+		projectB_A = ProjectTestUtils.createChildProject(projectB, "A");
+
+		when(algorithm.hash(":A[0]")).thenReturn(42L);
+		when(algorithm.hash(":B[0]")).thenReturn(52L);
+		when(algorithm.hash(":B:A[0]")).thenReturn(42L);
+		when(algorithm.hash(":B:A[1]")).thenReturn(62L);
+		subject.execute(rootProject);
+	}
+
+	@Test
+	void doesNotUseSameBuildDirectoryBetweenAmbiguousProject() {
+		assertThat(projectA.getBuildDir(), not(equalTo(projectB_A.getBuildDir())));
+	}
+
+	@Test
+	void hasProject_A_BuildDirectory() {
+		assertThat(projectA.getBuildDir(), aFile(withAbsolutePath(endsWith("/build/subprojects/A-16"))));
+	}
+
+	@Test
+	void hasProject_B_BuildDirectory() {
+		assertThat(projectB.getBuildDir(), aFile(withAbsolutePath(endsWith("/build/subprojects/B-1g"))));
+	}
+
+	@Test
+	void hasProject_A_B_BuildDirectory() {
+		assertThat(projectB_A.getBuildDir(), aFile(withAbsolutePath(endsWith("/build/subprojects/A-1q"))));
+	}
+}

--- a/subprojects/build-adapter-xcode/src/integrationTest/java/dev/nokee/buildadapter/xcode/internal/RedirectProjectBuildDirectoryToRootBuildDirectoryRestoreFromCacheIntegrationTest.java
+++ b/subprojects/build-adapter-xcode/src/integrationTest/java/dev/nokee/buildadapter/xcode/internal/RedirectProjectBuildDirectoryToRootBuildDirectoryRestoreFromCacheIntegrationTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal;
+
+import com.google.common.collect.ImmutableMap;
+import dev.nokee.buildadapter.xcode.internal.plugins.RedirectProjectBuildDirectoryToRootBuildDirectory;
+import dev.nokee.buildadapter.xcode.internal.plugins.RedirectProjectBuildDirectoryToRootBuildDirectory.HashFunction;
+import dev.nokee.internal.testing.util.ProjectTestUtils;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
+import org.checkerframework.checker.units.qual.A;
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static dev.nokee.internal.testing.FileSystemMatchers.aFile;
+import static dev.nokee.internal.testing.FileSystemMatchers.withAbsolutePath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith({TestDirectoryExtension.class, MockitoExtension.class})
+class RedirectProjectBuildDirectoryToRootBuildDirectoryRestoreFromCacheIntegrationTest {
+	static HashFunction algorithm = Mockito.mock(HashFunction.class);
+	static Action<Project> subject;
+	@TestDirectory static Path testDirectory;
+	static Project rootProject;
+	static Project projectA;
+	static Project projectB;
+	static Project projectB_A;
+
+	@BeforeAll
+	static void setup() throws IOException {
+		save(testDirectory.resolve("build/subprojects/mapping.ser"), ImmutableMap.of(":A", "A-16", ":B", "B-1g", ":B:A", "A-1q"));
+		subject = new RedirectProjectBuildDirectoryToRootBuildDirectory(algorithm);
+		rootProject = ProjectTestUtils.createRootProject(testDirectory);
+		projectA = ProjectTestUtils.createChildProject(rootProject, "A");
+		projectB = ProjectTestUtils.createChildProject(rootProject, "B");
+		projectB_A = ProjectTestUtils.createChildProject(projectB, "A");
+
+		subject.execute(rootProject);
+	}
+
+	@Test
+	void doesNotUseSameBuildDirectoryBetweenAmbiguousProject() {
+		assertThat(projectA.getBuildDir(), not(equalTo(projectB_A.getBuildDir())));
+	}
+
+	@Test
+	void reuseCachedBuildDirectories() {
+		verify(algorithm, never()).hash(any()); // all build path restore from cache
+	}
+
+	@Test
+	void hasProject_A_BuildDirectory() {
+		assertThat(projectA.getBuildDir(), aFile(withAbsolutePath(endsWith("/build/subprojects/A-16"))));
+	}
+
+	@Test
+	void hasProject_B_BuildDirectory() {
+		assertThat(projectB.getBuildDir(), aFile(withAbsolutePath(endsWith("/build/subprojects/B-1g"))));
+	}
+
+	@Test
+	void hasProject_A_B_BuildDirectory() {
+		assertThat(projectB_A.getBuildDir(), aFile(withAbsolutePath(endsWith("/build/subprojects/A-1q"))));
+	}
+
+	private static void save(Path cacheFile, Map<String, String> cache) throws IOException {
+		Files.createDirectories(cacheFile.getParent());
+		try (final ObjectOutputStream outStream = new ObjectOutputStream(Files.newOutputStream(cacheFile))) {
+			outStream.writeObject(new LinkedHashMap<>(cache));
+		}
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/RedirectProjectBuildDirectoryToRootBuildDirectory.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/RedirectProjectBuildDirectoryToRootBuildDirectory.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal.plugins;
+
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.invocation.Gradle;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.services.BuildService;
+import org.gradle.api.services.BuildServiceParameters;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import static dev.nokee.buildadapter.xcode.internal.plugins.RedirectProjectBuildDirectoryToRootBuildDirectory.BuildDirectoryService.registerService;
+import static dev.nokee.utils.ProjectUtils.isRootProject;
+import static dev.nokee.utils.ProviderUtils.forUseAtConfigurationTime;
+
+public final class RedirectProjectBuildDirectoryToRootBuildDirectory implements Action<Project> {
+	private static final String BUILD_PATH_PREFIX = "subprojects/";
+	private static final char BUILD_PATH_SEPARATOR_CHAR = '-';
+	private final HashFunction algorithm;
+
+	public RedirectProjectBuildDirectoryToRootBuildDirectory() {
+		this(djb2());
+	}
+
+	public RedirectProjectBuildDirectoryToRootBuildDirectory(HashFunction algorithm) {
+		this.algorithm = algorithm;
+	}
+
+	@Override
+	public void execute(Project rootProject) {
+		assert isRootProject(rootProject) : "can only execute on root project";
+
+		final Provider<BuildDirectoryService> service = forUseAtConfigurationTime(registerService(rootProject.getGradle(), parameters -> parameters.getBuildDirectoriesCacheFile().set(rootProject.getLayout().getBuildDirectory().file(BUILD_PATH_PREFIX + "mapping.ser"))));
+
+		rootProject.subprojects(project -> {
+			project.getLayout().getBuildDirectory().set(rootProject.getLayout().getBuildDirectory().dir(service.map(it -> BUILD_PATH_PREFIX + it.computeIfAbsent(project, algorithm::hash))));
+		});
+	}
+
+	public interface HashFunction {
+		long hash(String str);
+	}
+
+	public static HashFunction djb2() {
+		return new Djb2HashAlgorithm();
+	}
+
+	private static final class Djb2HashAlgorithm implements HashFunction {
+		@Override
+		public long hash(String str) {
+			return hash(str.toCharArray());
+		}
+
+		private long hash(char[] str) {
+			long hash = 5381;
+
+			int i = 0;
+			while (i < str.length) {
+				int c = str[i++];
+				hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
+			}
+
+			return hash;
+		}
+	}
+
+	@SuppressWarnings("UnstableApiUsage")
+	static abstract class BuildDirectoryService implements BuildService<BuildDirectoryService.Parameters>, AutoCloseable {
+		interface Parameters extends BuildServiceParameters {
+			RegularFileProperty getBuildDirectoriesCacheFile();
+		}
+
+		private final Map<String, String> projectToBuildPathMapping;
+		private final Set<String> knownBuildPaths = new HashSet<>();
+		private boolean isDirty = false;
+
+		@Inject
+		public BuildDirectoryService() {
+			this.projectToBuildPathMapping = load(getParameters().getBuildDirectoriesCacheFile().getAsFile().get());
+			this.knownBuildPaths.addAll(projectToBuildPathMapping.values());
+		}
+
+		private static Map<String, String> load(File cacheFile) {
+			try (final ObjectInputStream inStream = new ObjectInputStream(new FileInputStream(cacheFile))) {
+				@SuppressWarnings("unchecked")
+				final Map<String, String> result = (Map<String, String>) inStream.readObject();
+				return result;
+			} catch (Exception e) {
+				return new LinkedHashMap<>(); // just assume a new cache
+			}
+		}
+
+		public String computeIfAbsent(Project project, Function<? super String, ? extends Long> mapper) {
+			if (projectToBuildPathMapping.containsKey(project.getPath())) {
+				return projectToBuildPathMapping.get(project.getPath());
+			} else {
+				String result = null;
+				for (int i = 0; result == null || !knownBuildPaths.add(result); ++i) {
+					long hash = mapper.apply(project.getPath() + "[" + i + "]");
+					result = project.getName() + BUILD_PATH_SEPARATOR_CHAR + Long.toUnsignedString(hash, Character.MAX_RADIX);
+				}
+				projectToBuildPathMapping.put(project.getPath(), result);
+				isDirty = true;
+				return result;
+			}
+		}
+
+		@Override
+		public void close() {
+			if (isDirty) {
+				save(getParameters().getBuildDirectoriesCacheFile().getAsFile().get(), projectToBuildPathMapping);
+			}
+		}
+
+		private static void save(File cacheFile, Map<String, String> cache) {
+			try (final ObjectOutputStream outStream = new ObjectOutputStream(new FileOutputStream(cacheFile))) {
+				outStream.writeObject(cache);
+			} catch (Exception e) {
+				// just ignore saving the cache
+			}
+		}
+
+		public static Provider<BuildDirectoryService> registerService(Gradle gradle, Action<? super Parameters> action) {
+			return gradle.getSharedServices().registerIfAbsent("buildDirectoriesService", BuildDirectoryService.class, registration -> {
+				registration.parameters(action);
+			});
+		}
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeBuildAdapterPlugin.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeBuildAdapterPlugin.java
@@ -50,6 +50,8 @@ class XcodeBuildAdapterPlugin implements Plugin<Settings> {
 
 	@Override
 	public void apply(Settings settings) {
+		settings.getGradle().rootProject(new RedirectProjectBuildDirectoryToRootBuildDirectory());
+
 		val allWorkspaceLocations = forUseAtConfigurationTime(providers.of(AllXCWorkspaceLocationsValueSource.class, it -> it.parameters(p -> p.getSearchDirectory().set(settings.getSettingsDir()))));
 		val selectedWorkspaceLocation = allWorkspaceLocations.map(new SelectXCWorkspaceLocationTransformation());
 


### PR DESCRIPTION
This is not a trivial task to accomplish without user guidance. There are a lot of things to consider. The strategy we used here is a flat layout in `<root-project>/build/subprojects` composed of the project name and a hash of the project path. To overcome hash collision, we suffix the project path with `[<digits>]` where `<digits>` is a number from zero to infinity incremented on each hash collision (per-project path). The chosen build path is serialized into `<root-project>/build/subprojects/mapping.ser` using standard Java serialization at the end of the build (as needed). At the beginning of each build, we load the mapping back and reuse the previous mapping. This is important to keep a stable build path across execution, especially when hash collisions happen.

For a complete out-of-build `build` folder, we could simply set `rootProject.layout.buildDirectory` property to another location. All subprojects build directory would be relocated as well. At the moment, we keep the root `build` folder in the standard location.

Fixes https://github.com/nokeedev/gradle-native/issues/651