### PR TITLE
First implementation of implicit dependencies between Gradle projects

### DIFF
--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/ConfigurationCacheDetectsXcodeProjectChangesFunctionalTest.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/ConfigurationCacheDetectsXcodeProjectChangesFunctionalTest.java
@@ -21,6 +21,11 @@ import dev.nokee.internal.testing.junit.jupiter.ContextualGradleRunnerParameterR
 import dev.nokee.internal.testing.junit.jupiter.GradleFeatureRequirement;
 import dev.nokee.internal.testing.junit.jupiter.RequiresGradleFeature;
 import dev.nokee.platform.xcode.XcodeSwiftApp;
+import dev.nokee.xcode.objects.PBXProject;
+import dev.nokee.xcode.project.GidGenerator;
+import dev.nokee.xcode.project.PBXObjectArchiver;
+import dev.nokee.xcode.project.PBXProjWriter;
+import lombok.val;
 import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
 import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -35,7 +41,6 @@ import java.util.Collections;
 
 import static dev.gradleplugins.buildscript.blocks.PluginsBlock.plugins;
 import static dev.nokee.buildadapter.xcode.GradleTestSnippets.doSomethingVerifyTask;
-import static dev.nokee.xcode.utils.PropertyListTestUtils.writeAsciiPlistTo;
 import static dev.nokee.xcode.utils.PropertyListTestUtils.writeXmlPlistTo;
 import static dev.nokee.xcode.utils.XCWorkspaceDataTestUtils.emptyWorkspaceData;
 import static dev.nokee.xcode.utils.XCWorkspaceDataTestUtils.writeTo;
@@ -86,7 +91,13 @@ class ConfigurationCacheDetectsXcodeProjectChangesFunctionalTest {
 
 	@Test
 	void doesNotReuseConfigurationCacheWhenProjectPbxprojChangeInMeaningfulWay() throws IOException {
-		writeAsciiPlistTo(emptyMap(), testDirectory.resolve("XcodeSwiftApp.xcodeproj/project.pbxproj"));
+		writeEmptyProjectDotPbxProjFile(testDirectory.resolve("XcodeSwiftApp.xcodeproj/project.pbxproj"));
 		assertThat(executer.build().getOutput(), not(containsString("Reusing configuration cache")));
+	}
+
+	private static void writeEmptyProjectDotPbxProjFile(Path path) throws IOException {
+		try (val writer = new PBXProjWriter(Files.newBufferedWriter(path, StandardCharsets.UTF_8))) {
+			writer.write(new PBXObjectArchiver(new GidGenerator(Collections.emptySet())).encode(PBXProject.builder().build()));
+		}
 	}
 }

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/AllXCProjectLocationsValueSource.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/AllXCProjectLocationsValueSource.java
@@ -16,11 +16,9 @@
 package dev.nokee.buildadapter.xcode.internal.plugins;
 
 import dev.nokee.xcode.XCProjectReference;
-import dev.nokee.xcode.XCWorkspaceReference;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.ValueSource;
 import org.gradle.api.provider.ValueSourceParameters;
-import org.gradle.api.tasks.Input;
 
 import javax.annotation.Nullable;
 import java.util.stream.Collectors;
@@ -30,7 +28,6 @@ public abstract class AllXCProjectLocationsValueSource implements ValueSource<It
 	private static final XCProjectLocator XCODE_PROJECT_LOCATOR = new XCProjectLocator();
 
 	interface Parameters extends ValueSourceParameters {
-		@Input
 		DirectoryProperty getSearchDirectory();
 	}
 

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/AllXCWorkspaceLocationsValueSource.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/AllXCWorkspaceLocationsValueSource.java
@@ -19,7 +19,6 @@ import dev.nokee.xcode.XCWorkspaceReference;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.ValueSource;
 import org.gradle.api.provider.ValueSourceParameters;
-import org.gradle.api.tasks.Input;
 
 import javax.annotation.Nullable;
 import java.util.stream.Collectors;
@@ -29,7 +28,6 @@ public abstract class AllXCWorkspaceLocationsValueSource implements ValueSource<
 	private static final XCWorkspaceLocator XCODE_WORKSPACE_LOCATOR = new XCWorkspaceLocator();
 
 	interface Parameters extends ValueSourceParameters {
-		@Input
 		DirectoryProperty getSearchDirectory();
 	}
 

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/SelectXCProjectLocationTransformation.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/SelectXCProjectLocationTransformation.java
@@ -34,7 +34,7 @@ public final class SelectXCProjectLocationTransformation implements Transformer<
 				break;
 			default:
 				result = projectLocations.iterator().next();
-				LOGGER.warn(String.format("The plugin 'dev.nokee.xcode-build-adapter' will use Xcode project located at '%s' because multiple Xcode project were found without workspace in '%s'. See https://nokee.fyi/using-xcode-build-adapter for more details.", result, result.getLocation().getParent()));
+				LOGGER.warn(String.format("The plugin 'dev.nokee.xcode-build-adapter' will use Xcode project located at '%s' because multiple Xcode project were found without workspace in '%s'. See https://nokee.fyi/using-xcode-build-adapter for more details.", result.getLocation(), result.getLocation().getParent()));
 				break;
 		}
 		return result;

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XCLoaderService.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XCLoaderService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal.plugins;
+
+import dev.nokee.xcode.XCCache;
+import org.gradle.api.services.BuildService;
+import org.gradle.api.services.BuildServiceParameters;
+
+public abstract class XCLoaderService implements BuildService<BuildServiceParameters.None>, AutoCloseable {
+	@Override
+	public void close() {
+		XCCache.clear();
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeBuildAdapterPlugin.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeBuildAdapterPlugin.java
@@ -126,14 +126,13 @@ class XcodeBuildAdapterPlugin implements Plugin<Settings> {
 						attributes.attribute(Usage.USAGE_ATTRIBUTE, project.getObjects().named(Usage.class, "xcode-derived-data"));
 					});
 					configuration.getDependencies().addAllLater(finalizeValueOnRead(project.getObjects().listProperty(Dependency.class).value(service.map(it -> {
-						val allTargets = target.load().getInputFiles().stream().map(it::findTarget).filter(Objects::nonNull).map(t -> {
+						return target.load().getInputFiles().stream().map(it::findTarget).filter(Objects::nonNull).map(t -> {
 							val dep = (ProjectDependency) project.getDependencies().create(project.project(":" + it.asProjectPath(t.getProject())));
 							dep.capabilities(capabilities -> {
 								capabilities.requireCapability("net.nokeedev.xcode:" + t.getName() + ":1.0");
 							});
 							return dep;
 						}).collect(Collectors.toList());
-						return allTargets;
 					}))).orElse(Collections.emptyList()));
 				});
 

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeImplicitDependenciesService.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeImplicitDependenciesService.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal.plugins;
+
+import dev.nokee.xcode.XCFileReference;
+import dev.nokee.xcode.XCProjectReference;
+import dev.nokee.xcode.XCTarget;
+import dev.nokee.xcode.XCTargetReference;
+import dev.nokee.xcode.XCWorkspaceReference;
+import lombok.val;
+import org.apache.commons.io.FilenameUtils;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.provider.Property;
+import org.gradle.api.services.BuildService;
+import org.gradle.api.services.BuildServiceParameters;
+
+import javax.annotation.Nullable;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public abstract class XcodeImplicitDependenciesService implements BuildService<XcodeImplicitDependenciesService.Parameters> {
+	private static final Logger LOGGER = Logging.getLogger(XcodeImplicitDependenciesService.class);
+
+	interface Parameters extends BuildServiceParameters {
+		Property<XCWorkspaceReference> getLocation();
+	}
+
+	private final List<XCTarget> targets;
+	private final Map<XCProjectReference, String> projectPaths;
+
+	public XcodeImplicitDependenciesService() {
+		val workspace = getParameters().getLocation().get().load();
+		targets = workspace.getProjectLocations().stream().map(XCProjectReference::load).flatMap(it -> it.getTargets().stream()).map(XCTargetReference::load).collect(Collectors.toList());
+		projectPaths = workspace.getProjectLocations().stream().collect(Collectors.toMap(Function.identity(), project -> {
+			// TODO: What happen if a workspace reference project in parent directory? It would break the project mapping.
+			val relativePath = workspace.getLocation().getParent().relativize(project.getLocation());
+			val projectPath = asProjectPath(relativePath);
+			LOGGER.info(String.format("Mapping Xcode project '%s' to Gradle project '%s'.", relativePath, projectPath));
+			return projectPath;
+		}));
+	}
+
+	public String asProjectPath(XCProjectReference project) {
+		return projectPaths.get(project);
+	}
+
+	private static String asProjectPath(Path relativePath) {
+		return FilenameUtils.separatorsToUnix(FilenameUtils.removeExtension(relativePath.toString())).replace('/', ':');
+	}
+
+	@Nullable
+	public XCTarget findTarget(XCFileReference file) {
+		if (file.getType() == XCFileReference.XCFileType.BUILT_PRODUCT) {
+			return targets.stream().filter(it -> it.getOutputFile().equals(file)).findFirst().orElseThrow(RuntimeException::new);
+		} else {
+			return null;
+		}
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeTargetExecTask.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeTargetExecTask.java
@@ -83,7 +83,7 @@ public abstract class XcodeTargetExecTask extends DefaultTask implements Xcodebu
 				ifPresent(getConfiguration(), buildType -> spec.args("-configuration", buildType));
 				spec.args(
 					// Disable code signing, see https://stackoverflow.com/a/39901677/13624023
-					"CODE_SIGN_IDENTITY=\"\"", "CODE_SIGNING_REQUIRED=NO", "CODE_SIGN_ENTITLEMENTS=\"\"", "CODE_SIGNING_ALLOWED=\"NO\"");
+					"CODE_SIGN_IDENTITY=\"\"", "CODE_SIGNING_REQUIRED=NO", "CODE_SIGN_ENTITLEMENTS=\"\"", "CODE_SIGNING_ALLOWED=NO");
 				ifPresent(getWorkingDirectory(), spec::workingDir);
 				spec.setStandardOutput(outStream);
 				spec.setErrorOutput(outStream);

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeTargetExecTask.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeTargetExecTask.java
@@ -59,6 +59,9 @@ public abstract class XcodeTargetExecTask extends DefaultTask implements Xcodebu
 	@InputFiles
 	public abstract ConfigurableFileCollection getInputFiles();
 
+	@InputFiles
+	public abstract ConfigurableFileCollection getInputDerivedData();
+
 	@OutputDirectory
 	public abstract DirectoryProperty getOutputDirectory();
 
@@ -67,6 +70,14 @@ public abstract class XcodeTargetExecTask extends DefaultTask implements Xcodebu
 
 	@TaskAction
 	private void doExec() throws IOException {
+		// TODO: if derived data path is not present, we should "guess" the default path by using -showBuildSettings
+		ifPresent(getDerivedDataPath().map(FileSystemLocationUtils::asPath), derivedDataPath -> {
+			getFileOperations().sync(spec -> {
+				spec.from(getInputDerivedData());
+				spec.into(getDerivedDataPath());
+			});
+		});
+
 		ExecResult result = null;
 		try (val outStream = new FileOutputStream(new File(getTemporaryDir(), "outputs.txt"))) {
 			result = getExecOperations().exec(spec -> {

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCCache.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCCache.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.xcode;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
+
+public final class XCCache {
+	private static final ConcurrentMap<Object, Object> cache = new ConcurrentHashMap<>();
+
+	public static void clear() {
+		cache.clear();
+	}
+
+	static synchronized <KEY, VALUE> VALUE cacheIfAbsent(KEY key, Function<? super KEY, ? extends VALUE> factory) {
+		@SuppressWarnings("unchecked")
+		VALUE result = (VALUE) cache.get(key);
+		if (result == null) {
+			result = factory.apply(key);
+			cache.put(key, result);
+		}
+		return result;
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCFileReference.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCFileReference.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.xcode;
+
+import lombok.EqualsAndHashCode;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Objects;
+
+public abstract class XCFileReference {
+	public abstract Path resolve(ResolveContext context);
+
+	public abstract XCFileType getType();
+
+	public interface ResolveContext {
+		Path getSourceRoot();
+
+		Path getBuiltProductDirectory();
+
+		Path getSdkRoot();
+	}
+
+	public enum XCFileType {
+		ABSOLUTE, SOURCE_ROOT, BUILT_PRODUCT, SDKROOT
+	}
+
+	public static XCFileReference absoluteFile(String path) {
+		return new AbsoluteFileReference(Objects.requireNonNull(path));
+	}
+
+	public static XCFileReference sourceRoot(String path) {
+		return new SourceRootFileReference(Objects.requireNonNull(path));
+	}
+
+	public static XCFileReference builtProduct(String path) {
+		return new BuiltProductReference(Objects.requireNonNull(path));
+	}
+
+	public static XCFileReference sdkRoot(String path) {
+		return new SdkRootFileReference(Objects.requireNonNull(path));
+	}
+
+	@EqualsAndHashCode(callSuper = false)
+	private static final class AbsoluteFileReference extends XCFileReference {
+		private final Path path;
+
+		private AbsoluteFileReference(String path) {
+			this.path = new File(path).toPath();
+		}
+
+		@Override
+		public Path resolve(ResolveContext context) {
+			return path;
+		}
+
+		@Override
+		public XCFileType getType() {
+			return XCFileType.ABSOLUTE;
+		}
+
+		@Override
+		public String toString() {
+			return path.toString();
+		}
+	}
+
+	@EqualsAndHashCode(callSuper = false)
+	private static final class SourceRootFileReference extends XCFileReference {
+		private final String path;
+
+		private SourceRootFileReference(String path) {
+			this.path = path;
+		}
+
+		@Override
+		public Path resolve(ResolveContext context) {
+			return context.getSourceRoot().resolve(path);
+		}
+
+		@Override
+		public XCFileType getType() {
+			return XCFileType.SOURCE_ROOT;
+		}
+
+		@Override
+		public String toString() {
+			return "$(SOURCE_ROOT)/" + path;
+		}
+	}
+
+	@EqualsAndHashCode(callSuper = false)
+	private static final class SdkRootFileReference extends XCFileReference {
+		private final String path;
+
+		private SdkRootFileReference(String path) {
+			this.path = path;
+		}
+
+		@Override
+		public Path resolve(ResolveContext context) {
+			return context.getSdkRoot().resolve(path);
+		}
+
+		@Override
+		public XCFileType getType() {
+			return XCFileType.SDKROOT;
+		}
+
+		@Override
+		public String toString() {
+			return "$(SDKROOT)/" + path;
+		}
+	}
+
+	@EqualsAndHashCode(callSuper = false)
+	private static final class BuiltProductReference extends XCFileReference {
+		private final String path;
+
+		private BuiltProductReference(String path) {
+			this.path = path;
+		}
+
+		@Override
+		public Path resolve(ResolveContext context) {
+			return context.getBuiltProductDirectory().resolve(path);
+		}
+
+		@Override
+		public XCFileType getType() {
+			return XCFileType.BUILT_PRODUCT;
+		}
+
+		@Override
+		public String toString() {
+			return "$(BUILT_PRODUCT_DIR)/" + path;
+		}
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCProject.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCProject.java
@@ -29,8 +29,8 @@ public final class XCProject {
 	private final Path location;
 	private final ImmutableSet<XCTargetReference> targets;
 	private final ImmutableSet<String> schemeNames;
-	private final PBXProject project;
-	private XCTargetReference.XCFileReferences references;
+	private transient final PBXProject project;
+	private transient XCTargetReference.XCFileReferences references;
 
 	// friends with XCProjectReference
 	XCProject(Path location, ImmutableSet<XCTargetReference> targets, ImmutableSet<String> schemeNames, PBXProject project) {

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCProject.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCProject.java
@@ -27,7 +27,8 @@ public final class XCProject {
 	private final ImmutableSet<XCTargetReference> targets;
 	private final ImmutableSet<String> schemeNames;
 
-	public XCProject(Path location, ImmutableSet<XCTargetReference> targets, ImmutableSet<String> schemeNames) {
+	// friends with XCProjectReference
+	XCProject(Path location, ImmutableSet<XCTargetReference> targets, ImmutableSet<String> schemeNames) {
 		this.location = location;
 		this.targets = targets;
 		this.schemeNames = schemeNames;

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCProject.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCProject.java
@@ -16,22 +16,28 @@
 package dev.nokee.xcode;
 
 import com.google.common.collect.ImmutableSet;
+import dev.nokee.xcode.objects.PBXProject;
 import lombok.EqualsAndHashCode;
 
 import java.nio.file.Path;
 import java.util.Set;
+
+import static dev.nokee.xcode.XCTargetReference.walk;
 
 @EqualsAndHashCode
 public final class XCProject {
 	private final Path location;
 	private final ImmutableSet<XCTargetReference> targets;
 	private final ImmutableSet<String> schemeNames;
+	private final PBXProject project;
+	private XCTargetReference.XCFileReferences references;
 
 	// friends with XCProjectReference
-	XCProject(Path location, ImmutableSet<XCTargetReference> targets, ImmutableSet<String> schemeNames) {
+	XCProject(Path location, ImmutableSet<XCTargetReference> targets, ImmutableSet<String> schemeNames, PBXProject project) {
 		this.location = location;
 		this.targets = targets;
 		this.schemeNames = schemeNames;
+		this.project = project;
 	}
 
 	public Set<XCTargetReference> getTargets() {
@@ -44,5 +50,16 @@ public final class XCProject {
 
 	public XCProjectReference toReference() {
 		return XCProjectReference.of(location);
+	}
+
+	PBXProject getModel() {
+		return project;
+	}
+
+	XCTargetReference.XCFileReferences getFileReferences() {
+		if (references == null) {
+			references = walk(project);
+		}
+		return references;
 	}
 }

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCProjectReference.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCProjectReference.java
@@ -53,7 +53,7 @@ public final class XCProjectReference implements Serializable {
 
 	@Override
 	public String toString() {
-		return location.toString();
+		return "project '" + location + "'";
 	}
 
 	public XCProject load() {

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCTarget.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCTarget.java
@@ -15,17 +15,46 @@
  */
 package dev.nokee.xcode;
 
-import java.nio.file.Path;
 import java.util.List;
 
 public final class XCTarget {
-	private final List<Path> inputFiles;
+	private final String name;
+	private final XCProjectReference project;
+	private final List<XCFileReference> inputFiles;
+	private final List<XCTargetReference> dependencies;
+	private final XCFileReference outputFile;
 
-	public XCTarget(List<Path> inputFiles) {
+	public XCTarget(String name, XCProjectReference project, List<XCFileReference> inputFiles, List<XCTargetReference> dependencies, XCFileReference outputFile) {
+		this.name = name;
+		this.project = project;
+		this.dependencies = dependencies;
+		this.outputFile = outputFile;
 		this.inputFiles = inputFiles;
 	}
 
-	public List<Path> getInputFiles() {
+	public String getName() {
+		return name;
+	}
+
+	public List<XCTargetReference> getDependencies() {
+		return dependencies;
+	}
+
+	// TODO: Switch to only the input file of THIS XCTarget
+	public List<XCFileReference> getInputFiles() {
 		return inputFiles;
+	}
+
+	public XCFileReference getOutputFile() {
+		return outputFile;
+	}
+
+	public XCProjectReference getProject() {
+		return project;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("target '%s' in project '%s'", name, project.getLocation());
 	}
 }

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCTarget.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCTarget.java
@@ -24,7 +24,8 @@ public final class XCTarget {
 	private final List<XCTargetReference> dependencies;
 	private final XCFileReference outputFile;
 
-	public XCTarget(String name, XCProjectReference project, List<XCFileReference> inputFiles, List<XCTargetReference> dependencies, XCFileReference outputFile) {
+	// friends with XCTargetReference
+	XCTarget(String name, XCProjectReference project, List<XCFileReference> inputFiles, List<XCTargetReference> dependencies, XCFileReference outputFile) {
 		this.name = name;
 		this.project = project;
 		this.dependencies = dependencies;

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCTargetReference.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCTargetReference.java
@@ -73,13 +73,13 @@ public final class XCTargetReference implements Serializable {
 	}
 
 	public static Stream<PBXFileReference> findInputFiles(PBXTarget target) {
-		return Stream.concat(target.getBuildPhases().stream().flatMap(it -> it.getFiles().stream()).map(it -> it.getFileRef()).flatMap(it -> {
+		return target.getBuildPhases().stream().flatMap(it -> it.getFiles().stream()).map(it -> it.getFileRef()).flatMap(it -> {
 			if (it instanceof PBXFileReference) {
 				return Stream.of((PBXFileReference) it);
 			} else {
 				return Stream.empty();
 			}
-		}), target.getDependencies().stream().flatMap(it -> findInputFiles(it.getTarget())));
+		});
 	}
 
 	private static final class FileNode {

--- a/subprojects/core-utils/src/main/java/dev/nokee/utils/ProviderUtils.java
+++ b/subprojects/core-utils/src/main/java/dev/nokee/utils/ProviderUtils.java
@@ -103,7 +103,7 @@ public final class ProviderUtils {
 	}
 
 	public static <S> Provider<S> forUseAtConfigurationTime(Provider<S> provider) {
-		if (GradleVersion.current().compareTo(GradleVersion.version("6.5")) >= 0) {
+		if (GradleVersion.current().compareTo(GradleVersion.version("6.5")) >= 0 && GradleVersion.current().compareTo(GradleVersion.version("7.0")) < 0) {
 			try {
 				Method method = Provider.class.getMethod("forUseAtConfigurationTime");
 				return Cast.uncheckedCast("using reflection to support newer Gradle", method.invoke(provider));

--- a/subprojects/core-utils/src/main/java/dev/nokee/utils/ProviderUtils.java
+++ b/subprojects/core-utils/src/main/java/dev/nokee/utils/ProviderUtils.java
@@ -155,4 +155,16 @@ public final class ProviderUtils {
 			action.execute(value);
 		}
 	}
+
+	/**
+	 * Allows fluent call to {@link HasConfigurableValue#finalizeValueOnRead()}.
+	 *
+	 * @param self  the configurable value, must not be null
+	 * @param <S>  the type of configurable value
+	 * @return the specified configurable value, never null
+	 */
+	public static <S extends HasConfigurableValue> S finalizeValueOnRead(S self) {
+		self.finalizeValueOnRead();
+		return self;
+	}
 }

--- a/subprojects/core-utils/src/test/groovy/dev/nokee/utils/ProviderUtils_FinalizeValueOnReadTest.java
+++ b/subprojects/core-utils/src/test/groovy/dev/nokee/utils/ProviderUtils_FinalizeValueOnReadTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.utils;
+
+import org.gradle.api.provider.HasConfigurableValue;
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.utils.ProviderUtils.finalizeValueOnRead;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@SuppressWarnings("UnstableApiUsage")
+class ProviderUtils_FinalizeValueOnReadTest {
+	@Test
+	void callsFinalizeValueOnReadOnSubject() {
+		final HasConfigurableValue subject = mock(HasConfigurableValue.class);
+		finalizeValueOnRead(subject);
+		verify(subject).finalizeValueOnRead();
+		verifyNoMoreInteractions(subject);
+	}
+
+	@Test
+	void returnsSubject() {
+		final HasConfigurableValue subject = mock(HasConfigurableValue.class);
+		assertSame(subject, finalizeValueOnRead(subject));
+	}
+}

--- a/subprojects/nokee-version-management/src/main/java/dev/nokee/nvm/ProviderUtils.java
+++ b/subprojects/nokee-version-management/src/main/java/dev/nokee/nvm/ProviderUtils.java
@@ -24,7 +24,9 @@ final class ProviderUtils {
 	public static <T> Provider<T> forUseAtConfigurationTime(Provider<T> self) {
 		if (GradleVersion.current().compareTo(GradleVersion.version("6.5")) >= 0 && GradleVersion.current().compareTo(GradleVersion.version("7.0")) < 0) {
 			try {
-				return (Provider<T>) Provider.class.getMethod("forUseAtConfigurationTime").invoke(self);
+				@SuppressWarnings("unchecked")
+				Provider<T> result = (Provider<T>) Provider.class.getMethod("forUseAtConfigurationTime").invoke(self);
+				return result;
 			} catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
 				throw new RuntimeException(e);
 			}

--- a/subprojects/nokee-version-management/src/main/java/dev/nokee/nvm/ProviderUtils.java
+++ b/subprojects/nokee-version-management/src/main/java/dev/nokee/nvm/ProviderUtils.java
@@ -24,7 +24,7 @@ final class ProviderUtils {
 	public static <T> Provider<T> forUseAtConfigurationTime(Provider<T> self) {
 		if (GradleVersion.current().compareTo(GradleVersion.version("6.5")) >= 0 && GradleVersion.current().compareTo(GradleVersion.version("7.0")) < 0) {
 			try {
-				Provider.class.getMethod("forUseAtConfigurationTime").invoke(self);
+				return (Provider<T>) Provider.class.getMethod("forUseAtConfigurationTime").invoke(self);
 			} catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
 				throw new RuntimeException(e);
 			}

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/PBXProject.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/PBXProject.java
@@ -68,7 +68,11 @@ public final class PBXProject extends PBXContainer {
 
 	@Override
 	public int stableHash() {
-		return name.hashCode();
+		if (name != null) {
+			return name.hashCode();
+		} else {
+			return super.stableHash();
+		}
 	}
 
 	public static Builder builder() {
@@ -78,7 +82,7 @@ public final class PBXProject extends PBXContainer {
 	public static final class Builder {
 		private String name;
 		private final List<PBXTarget> targets = new ArrayList<>();
-		private XCConfigurationList buildConfigurations;
+		private XCConfigurationList buildConfigurations = XCConfigurationList.builder().build();
 		private final List<PBXReference> mainGroupChildren = new ArrayList<>();
 		private PBXGroup mainGroup;
 
@@ -106,7 +110,7 @@ public final class PBXProject extends PBXContainer {
 		}
 
 		public Builder buildConfigurations(XCConfigurationList buildConfigurations) {
-			this.buildConfigurations = buildConfigurations;
+			this.buildConfigurations = Objects.requireNonNull(buildConfigurations);
 			return this;
 		}
 

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/project/PBXObjectUnarchiver.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/project/PBXObjectUnarchiver.java
@@ -54,6 +54,7 @@ public final class PBXObjectUnarchiver {
 		}
 
 		public <T extends PBXObject> T decode(String gid) {
+			assert gid != null;
 			return decode(objects.getById(gid));
 		}
 

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/project/PBXObjectUnarchiver.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/project/PBXObjectUnarchiver.java
@@ -59,9 +59,13 @@ public final class PBXObjectUnarchiver {
 
 		@SuppressWarnings("unchecked")
 		private <T extends PBXObject> T decode(PBXObjectReference objectRef) {
-			return (T) decodedObjects.computeIfAbsent(objectRef.getGlobalID(), (uid) -> {
-				return Objects.requireNonNull(coders.get(objectRef.isa()), "missing coder for '" + objectRef.isa() + "'").read(new BaseDecoder(this, objectRef.getFields()));
-			});
+			// DO NOT USE computeIfAbsent as it's not reentrant
+			T result = (T) decodedObjects.get(objectRef.getGlobalID());
+			if (result == null) {
+				result = (T) Objects.requireNonNull(coders.get(objectRef.isa()), "missing coder for '" + objectRef.isa() + "'").read(new BaseDecoder(this, objectRef.getFields()));
+				decodedObjects.put(objectRef.getGlobalID(), result);
+			}
+			return result;
 		}
 	}
 


### PR DESCRIPTION
We rely on `XCFileReference`s that are built products. We can cross-reference those with the target's output to create a list of dependencies. It's not finished but it gives us enough support to test full end-to-end build performance. In our early testing, we can confirm a pretty massive improvement in performance. We are still skeptical about the improvement we are seeing. We are pretty confident in our measurement, however, we have a hard time believing the Xcode build system has such basic issues.