### PR TITLE
Improve Xcode build adapter with more model and CocoaPods support

### DIFF
--- a/gradle/libraries/gradle-build-script/src/main/java/dev/gradleplugins/buildscript/blocks/GradleBlock.java
+++ b/gradle/libraries/gradle-build-script/src/main/java/dev/gradleplugins/buildscript/blocks/GradleBlock.java
@@ -29,6 +29,12 @@ public final class GradleBlock extends AbstractBlock {
 		super(delegate);
 	}
 
+	public static BlockStatement<ProjectBlock> rootProject(Consumer<? super ProjectBlock.Builder> action) {
+		final ProjectBlock.Builder builder = ProjectBlock.builder();
+		action.accept(builder);
+		return BlockStatement.of(literal("rootProject"), builder.build());
+	}
+
 	public static Builder builder() {
 		return new Builder();
 	}

--- a/gradle/libraries/gradle-build-script/src/main/java/dev/gradleplugins/buildscript/statements/Statement.java
+++ b/gradle/libraries/gradle-build-script/src/main/java/dev/gradleplugins/buildscript/statements/Statement.java
@@ -40,7 +40,13 @@ public interface Statement {
 	}
 
 	default void writeTo(Path path) throws IOException {
-		try (PrettyPrinter writer = new PrettyPrinter(new FileWriter(path.toFile()), path.getFileName().toString().endsWith(".gradle") ? new GroovySyntax() : new KotlinSyntax())) {
+		try (PrettyPrinter writer = new PrettyPrinter(new FileWriter(path.toFile(), false), path.getFileName().toString().endsWith(".gradle") ? new GroovySyntax() : new KotlinSyntax())) {
+			writeTo(writer);
+		}
+	}
+
+	default void appendTo(Path path) throws IOException {
+		try (PrettyPrinter writer = new PrettyPrinter(new FileWriter(path.toFile(), true), path.getFileName().toString().endsWith(".gradle") ? new GroovySyntax() : new KotlinSyntax())) {
 			writeTo(writer);
 		}
 	}

--- a/subprojects/build-adapter-xcode/build-adapter-xcode.gradle
+++ b/subprojects/build-adapter-xcode/build-adapter-xcode.gradle
@@ -30,6 +30,10 @@ gradlePlugin {
 			id = 'dev.nokee.xcode-build-adapter'
 			implementationClass = 'dev.nokee.buildadapter.xcode.internal.plugins.XcodeBuildAdapterPlugin'
 		}
+		cocoapodsSupport {
+			id = 'dev.nokee.cocoapods-support'
+			implementationClass = 'dev.nokee.buildadapter.cocoapods.internal.CocoapodSupportPlugin'
+		}
 	}
 }
 

--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/cocoapods/CocoapodsFunctionalTest.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/cocoapods/CocoapodsFunctionalTest.java
@@ -23,6 +23,8 @@ import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
 import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
@@ -38,6 +40,7 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.io.FileMatchers.anExistingDirectory;
 import static org.hamcrest.io.FileMatchers.anExistingFile;
 
+@EnabledOnOs(OS.MAC)
 @ExtendWith({TestDirectoryExtension.class, ContextualGradleRunnerParameterResolver.class})
 class CocoapodsFunctionalTest {
 	GradleRunner executer;

--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/cocoapods/CocoapodsFunctionalTest.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/cocoapods/CocoapodsFunctionalTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.cocoapods;
+
+import dev.gradleplugins.runnerkit.BuildResult;
+import dev.gradleplugins.runnerkit.GradleRunner;
+import dev.nokee.internal.testing.junit.jupiter.ContextualGradleRunnerParameterResolver;
+import dev.nokee.platform.xcode.XcodeSwiftApp;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import static dev.gradleplugins.buildscript.blocks.PluginsBlock.plugins;
+import static dev.nokee.buildadapter.xcode.GradleTestSnippets.doSomethingVerifyTask;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.io.FileMatchers.anExistingDirectory;
+import static org.hamcrest.io.FileMatchers.anExistingFile;
+
+@ExtendWith({TestDirectoryExtension.class, ContextualGradleRunnerParameterResolver.class})
+class CocoapodsFunctionalTest {
+	GradleRunner executer;
+	@TestDirectory Path testDirectory;
+	BuildResult result;
+
+	@BeforeEach
+	void setup(GradleRunner runner) throws IOException {
+		new XcodeSwiftApp().writeToProject(testDirectory.toFile());
+		Files.write(testDirectory.resolve("Podfile"), Arrays.asList(
+			"platform :ios, '9.0'",
+			"target 'XcodeSwiftApp' do",
+			"  use_frameworks!",
+			"  pod 'Alamofire', '~> 3.0'",
+			"end"));
+		doSomethingVerifyTask().writeTo(testDirectory.resolve("build.gradle"));
+		plugins(it -> it.id("dev.nokee.cocoapods-support")).writeTo(testDirectory.resolve("settings.gradle"));
+		executer = runner.withArgument("verify");
+		result = executer.build();
+	}
+
+	@Test
+	void createsNewPodfileLockFile() {
+		assertThat(testDirectory.resolve("Podfile.lock").toFile(), anExistingFile());
+	}
+
+	@Test
+	void createsPodsInstallationDirectory() {
+		assertThat(testDirectory.resolve("Pods").toFile(), anExistingDirectory());
+	}
+
+	@Test
+	void updatesPodfileLockFileOnNextBuild() throws IOException {
+		Files.write(testDirectory.resolve("Podfile"), Arrays.asList(
+			"platform :ios, '9.0'",
+			"target 'XcodeSwiftApp' do",
+			"  use_frameworks!",
+			"  pod 'Alamofire', '~> 3.0'",
+			"  pod 'GoogleAnalytics', '~> 3.1'",
+			"end"));
+		executer.build();
+		assertThat(Files.readAllLines(testDirectory.resolve("Podfile.lock")), hasItems(containsString("GoogleAnalytics (~> 3.1)")));
+	}
+}

--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/cocoapods/ConfigurationCacheDetectsCocoapodsInitializationFunctionalTest.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/cocoapods/ConfigurationCacheDetectsCocoapodsInitializationFunctionalTest.java
@@ -26,6 +26,8 @@ import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
 import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
@@ -39,6 +41,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 
+@EnabledOnOs(OS.MAC)
 @RequiresGradleFeature(GradleFeatureRequirement.CONFIGURATION_CACHE)
 @ExtendWith({TestDirectoryExtension.class, ContextualGradleRunnerParameterResolver.class})
 class ConfigurationCacheDetectsCocoapodsInitializationFunctionalTest {

--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/cocoapods/ConfigurationCacheDetectsCocoapodsInitializationFunctionalTest.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/cocoapods/ConfigurationCacheDetectsCocoapodsInitializationFunctionalTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.cocoapods;
+
+import dev.gradleplugins.runnerkit.BuildResult;
+import dev.gradleplugins.runnerkit.GradleRunner;
+import dev.nokee.core.exec.CommandLine;
+import dev.nokee.internal.testing.junit.jupiter.ContextualGradleRunnerParameterResolver;
+import dev.nokee.internal.testing.junit.jupiter.GradleFeatureRequirement;
+import dev.nokee.internal.testing.junit.jupiter.RequiresGradleFeature;
+import dev.nokee.platform.xcode.XcodeSwiftApp;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import static dev.gradleplugins.buildscript.blocks.PluginsBlock.plugins;
+import static dev.nokee.buildadapter.xcode.GradleTestSnippets.doSomethingVerifyTask;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+@RequiresGradleFeature(GradleFeatureRequirement.CONFIGURATION_CACHE)
+@ExtendWith({TestDirectoryExtension.class, ContextualGradleRunnerParameterResolver.class})
+class ConfigurationCacheDetectsCocoapodsInitializationFunctionalTest {
+	GradleRunner executer;
+	@TestDirectory Path testDirectory;
+	BuildResult result;
+
+	@BeforeEach
+	void setup(GradleRunner runner) throws IOException {
+		new XcodeSwiftApp().writeToProject(testDirectory.toFile());
+
+		Files.write(testDirectory.resolve("Podfile"), Arrays.asList(
+			"platform :ios, '9.0'",
+			"target 'XcodeSwiftApp' do",
+			"  use_frameworks!",
+			"  pod 'Alamofire', '~> 3.0'",
+			"end"));
+		CommandLine.of("pod", "install").execute(null, testDirectory.toFile()).waitFor().assertNormalExitValue();
+		Files.delete(testDirectory.resolve("Podfile"));
+
+		doSomethingVerifyTask().writeTo(testDirectory.resolve("build.gradle"));
+		plugins(it -> it.id("dev.nokee.cocoapods-support")).writeTo(testDirectory.resolve("settings.gradle"));
+		executer = runner.withArgument("verify").withArgument("--configuration-cache");
+		result = executer.build();
+	}
+
+	@Test
+	void reuseConfigurationCacheWhenNoPodfile() {
+		assertThat(executer.build().getOutput(), containsString("Reusing configuration cache"));
+	}
+
+	@Test
+	void doesNotReuseConfigurationWhenPodfileAppears() throws IOException {
+		Files.write(testDirectory.resolve("Podfile"), Arrays.asList(
+			"platform :ios, '9.0'",
+			"target 'XcodeSwiftApp' do",
+			"  use_frameworks!",
+			"  pod 'Alamofire', '~> 3.0'",
+			"end"));
+		assertThat(executer.build().getOutput(), not(containsString("Reusing configuration cache")));
+	}
+}

--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/cocoapods/ConfigurationCacheDetectsPodfileChangesFunctionalTest.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/cocoapods/ConfigurationCacheDetectsPodfileChangesFunctionalTest.java
@@ -26,6 +26,8 @@ import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
 import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
@@ -40,6 +42,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 
+@EnabledOnOs(OS.MAC)
 @RequiresGradleFeature(GradleFeatureRequirement.CONFIGURATION_CACHE)
 @ExtendWith({TestDirectoryExtension.class, ContextualGradleRunnerParameterResolver.class})
 class ConfigurationCacheDetectsPodfileChangesFunctionalTest {

--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/cocoapods/ConfigurationCacheDetectsPodfileChangesFunctionalTest.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/cocoapods/ConfigurationCacheDetectsPodfileChangesFunctionalTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.cocoapods;
+
+import dev.gradleplugins.runnerkit.BuildResult;
+import dev.gradleplugins.runnerkit.GradleRunner;
+import dev.nokee.core.exec.CommandLine;
+import dev.nokee.internal.testing.junit.jupiter.ContextualGradleRunnerParameterResolver;
+import dev.nokee.internal.testing.junit.jupiter.GradleFeatureRequirement;
+import dev.nokee.internal.testing.junit.jupiter.RequiresGradleFeature;
+import dev.nokee.platform.xcode.XcodeSwiftApp;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+
+import static dev.gradleplugins.buildscript.blocks.PluginsBlock.plugins;
+import static dev.nokee.buildadapter.xcode.GradleTestSnippets.doSomethingVerifyTask;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+@RequiresGradleFeature(GradleFeatureRequirement.CONFIGURATION_CACHE)
+@ExtendWith({TestDirectoryExtension.class, ContextualGradleRunnerParameterResolver.class})
+class ConfigurationCacheDetectsPodfileChangesFunctionalTest {
+	GradleRunner executer;
+	@TestDirectory Path testDirectory;
+	BuildResult result;
+
+	@BeforeEach
+	void setup(GradleRunner runner) throws IOException {
+		new XcodeSwiftApp().writeToProject(testDirectory.toFile());
+		Files.write(testDirectory.resolve("Podfile"), Arrays.asList(
+			"platform :ios, '9.0'",
+			"target 'XcodeSwiftApp' do",
+			"  use_frameworks!",
+			"  pod 'Alamofire', '~> 3.0'",
+			"end"));
+		CommandLine.of("pod", "install").execute(null, testDirectory.toFile()).waitFor().assertNormalExitValue();
+		doSomethingVerifyTask().writeTo(testDirectory.resolve("build.gradle"));
+		plugins(it -> it.id("dev.nokee.cocoapods-support")).writeTo(testDirectory.resolve("settings.gradle"));
+		executer = runner.withArgument("verify").withArgument("--configuration-cache");
+		result = executer.build();
+	}
+
+	@Test
+	void reuseConfigurationCacheWhenNoChanges() {
+		assertThat(executer.build().getOutput(), containsString("Reusing configuration cache"));
+	}
+
+	@Test
+	void doesNotReuseConfigurationWhenPodfileChanges() throws IOException {
+		Files.write(testDirectory.resolve("Podfile"), Arrays.asList(
+			"platform :ios, '9.0'",
+			"target 'XcodeSwiftApp' do",
+			"  use_frameworks!",
+			"  pod 'Alamofire', '~> 3.0'",
+			"  pod 'GoogleAnalytics', '~> 3.1'",
+			"end"));
+		assertThat(executer.build().getOutput(), not(containsString("Reusing configuration cache")));
+	}
+
+	@Test
+	void doesNotReuseConfigurationWhenPodfileLockChanges() throws IOException {
+		Files.write(testDirectory.resolve("Podfile.lock"), Arrays.asList("# something, different"), StandardOpenOption.APPEND);
+		assertThat(executer.build().getOutput(), not(containsString("Reusing configuration cache")));
+	}
+
+	@Test
+	void reusesConfigurationWhenPodfileLockDeleted() throws IOException {
+		Files.delete(testDirectory.resolve("Podfile.lock")); // when we reinstall, everything is the same
+		assertThat(executer.build().getOutput(), containsString("Reusing configuration cache"));
+	}
+
+	@Test
+	void doesNotReuseConfigurationWhenManifestLockChanges() throws IOException {
+		Files.write(testDirectory.resolve("Pods/Manifest.lock"), Arrays.asList("# something, different"), StandardOpenOption.APPEND);
+		assertThat(executer.build().getOutput(), containsString("Reusing configuration cache"));
+	}
+
+	@Test
+	void reusesConfigurationWhenManifestLockDeleted() throws IOException {
+		Files.delete(testDirectory.resolve("Pods/Manifest.lock")); // when we reinstall, everything is the same
+		assertThat(executer.build().getOutput(), containsString("Reusing configuration cache"));
+	}
+}

--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/GradleTestSnippets.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/GradleTestSnippets.java
@@ -15,10 +15,14 @@
  */
 package dev.nokee.buildadapter.xcode;
 
+import dev.gradleplugins.buildscript.blocks.ProjectBlock;
 import dev.gradleplugins.buildscript.blocks.TaskBlock;
 import dev.gradleplugins.buildscript.blocks.TasksBlock;
+import dev.gradleplugins.buildscript.statements.GroupStatement;
 import dev.gradleplugins.buildscript.statements.Statement;
 import org.gradle.api.Action;
+
+import java.util.function.Consumer;
 
 import static dev.gradleplugins.buildscript.statements.Statement.expressionOf;
 import static dev.gradleplugins.buildscript.syntax.Syntax.invoke;
@@ -45,5 +49,17 @@ public final class GradleTestSnippets {
 				builder.add(expressionOf(invoke("assert", literal(assertion))));
 			}
 		})));
+	}
+
+	public static Consumer<ProjectBlock.Builder> registerVerifyTask(Consumer<? super GroupStatement.Builder> builderConsumer) {
+		return project -> project.add(TasksBlock.tasks(tasks -> tasks.register("verify", task -> task.doLast(builderConsumer))));
+	}
+
+	public static Consumer<GroupStatement.Builder> assertStatements(String... assertions) {
+		return builder -> {
+			for (String assertion : assertions) {
+				builder.add(expressionOf(invoke("assert", literal(assertion))));
+			}
+		};
 	}
 }

--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/XcodeBuildAdapterPluginFunctionalTest.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/XcodeBuildAdapterPluginFunctionalTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode;
+
+import dev.gradleplugins.runnerkit.GradleRunner;
+import dev.nokee.internal.testing.junit.jupiter.ContextualGradleRunnerParameterResolver;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static dev.gradleplugins.buildscript.blocks.GradleBlock.rootProject;
+import static dev.gradleplugins.buildscript.blocks.PluginsBlock.plugins;
+import static dev.gradleplugins.buildscript.statements.Statement.block;
+import static dev.nokee.buildadapter.xcode.GradleTestSnippets.assertStatements;
+import static dev.nokee.buildadapter.xcode.GradleTestSnippets.registerVerifyTask;
+
+@ExtendWith({TestDirectoryExtension.class, ContextualGradleRunnerParameterResolver.class})
+public class XcodeBuildAdapterPluginFunctionalTest {
+	@TestDirectory Path testDirectory;
+
+	@BeforeEach
+	void setup() throws IOException {
+		plugins(it -> it.id("dev.nokee.xcode-build-adapter")).writeTo(testDirectory.resolve("settings.gradle"));
+	}
+
+	@Test
+	void appliesCocoaPodsSupportPlugin(GradleRunner runner) throws IOException {
+		block("gradle", rootProject(registerVerifyTask(assertStatements("settings.pluginManager.hasPlugin('dev.nokee.cocoapods-support')")))).useGetter().appendTo(testDirectory.resolve("settings.gradle"));
+		runner.withArgument("verify").build();
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/cocoapods/internal/CachingCocoaPods.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/cocoapods/internal/CachingCocoaPods.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.cocoapods.internal;
+
+import lombok.val;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.function.Consumer;
+
+final class CachingCocoaPods implements CocoaPods {
+	private final CocoaPods delegate;
+	private final File cacheFile;
+
+	public CachingCocoaPods(CocoaPods delegate, File cacheFile) {
+		this.delegate = delegate;
+		this.cacheFile = cacheFile;
+	}
+
+	@Override
+	public Podfile getPodfile() {
+		return delegate.getPodfile();
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return delegate.isEnabled();
+	}
+
+	@Override
+	public boolean isOutOfDate() {
+		if (delegate.isOutOfDate()) {
+			return true;
+		} else {
+			val podfileContent = getPodfile().getContent();
+			val previousPodfileContent = load().getContent();
+			return !podfileContent.equals(previousPodfileContent);
+		}
+	}
+
+	public Podfile load() {
+		return Podfile.of(cacheFile);
+	}
+
+	private void clear() {
+		try {
+			if (Files.exists(cacheFile.toPath())) {
+				Files.delete(cacheFile.toPath());
+			}
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+	}
+
+	private void update() {
+		try {
+			Files.copy(getPodfile().getLocation(), cacheFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+	}
+
+	@Override
+	public void ifOutOfDate(Consumer<? super Object> consumer) {
+		if (!isEnabled()) {
+			clear();
+		} else if (isOutOfDate()) {
+			consumer.accept(null);
+			update();
+		}
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/cocoapods/internal/CocoaPods.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/cocoapods/internal/CocoaPods.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.cocoapods.internal;
+
+import java.util.function.Consumer;
+
+interface CocoaPods {
+	Podfile getPodfile();
+	boolean isEnabled();
+	boolean isOutOfDate();
+	void ifOutOfDate(Consumer<? super Object> consumer);
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/cocoapods/internal/CocoaPodsInstallation.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/cocoapods/internal/CocoaPodsInstallation.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.cocoapods.internal;
+
+import lombok.EqualsAndHashCode;
+
+import java.io.Serializable;
+
+@EqualsAndHashCode
+final class CocoaPodsInstallation implements Serializable {
+	private /*final*/ byte[] podfileLockFile;
+
+	public CocoaPodsInstallation(byte[] podfileLockFile) {
+		this.podfileLockFile = podfileLockFile;
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/cocoapods/internal/CocoaPodsProviders.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/cocoapods/internal/CocoaPodsProviders.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.cocoapods.internal;
+
+import lombok.val;
+import org.gradle.api.Action;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.provider.ValueSource;
+import org.gradle.api.provider.ValueSourceParameters;
+import org.gradle.api.provider.ValueSourceSpec;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@SuppressWarnings("UnstableApiUsage")
+final class CocoaPodsProviders {
+	private final ProviderFactory providers;
+
+	public CocoaPodsProviders(ProviderFactory providers) {
+		this.providers = providers;
+	}
+
+	public Provider<Podfile> podfile(File path) {
+		return providers.of(PodfileLoader.class, parameters(it -> it.getPodfileFile().set(path)));
+	}
+
+	public Provider<CocoaPodsInstallation> installation(Action<? super CocoaPodsInstallationSpec> action) {
+		return providers.of(CocoaPodsInstallationSource.class, parameters(action));
+	}
+
+	public interface CocoaPodsInstallationSpec {
+		Property<Podfile> getPodfile();
+		RegularFileProperty getCacheFile();
+	}
+
+	abstract static class PodfileLoader implements ValueSource<Podfile, PodfileLoader.Parameters> {
+		interface Parameters extends ValueSourceParameters {
+			RegularFileProperty getPodfileFile();
+		}
+
+		@Inject
+		public PodfileLoader() {}
+
+		@Nullable
+		@Override
+		public Podfile obtain() {
+			val location = getParameters().getPodfileFile().getAsFile().getOrNull();
+			if (location != null) {
+				return Podfile.of(location);
+			}
+			return null;
+		}
+	}
+
+	private static <T extends ValueSourceParameters> Action<ValueSourceSpec<T>> parameters(Action<? super T> action) {
+		return spec -> spec.parameters(action);
+	}
+
+	abstract static class CocoaPodsInstallationSource implements ValueSource<CocoaPodsInstallation, CocoaPodsInstallationSource.Parameters> {
+		private static final CocoaPodsService service = new CocoaPodsService();
+		private final CocoaPods pod;
+
+		interface Parameters extends ValueSourceParameters, CocoaPodsInstallationSpec {
+			Property<Podfile> getPodfile();
+
+			RegularFileProperty getCacheFile();
+		}
+
+		@Inject
+		public CocoaPodsInstallationSource() {
+			this.pod = new CachingCocoaPods(DefaultCocoaPods.inDirectory(getWorkingDirectory().toFile()), getParameters().getCacheFile().getAsFile().get());
+		}
+
+		private Path getWorkingDirectory() {
+			return getParameters().getPodfile().get().getLocation().getParent();
+		}
+
+		private Path getPodfileLockFile() {
+			return getWorkingDirectory().resolve("Podfile.lock");
+		}
+
+		private Podfile getPodfileFile() {
+			return getParameters().getPodfile().get();
+		}
+
+		@Nullable
+		@Override
+		public CocoaPodsInstallation obtain() {
+			pod.ifOutOfDate(it -> {
+				service.install(getPodfileFile().getLocation().getParent());
+			});
+
+			// CocoaPods could be disabled (no Podfile) and still has Podfile.lock
+			if (!pod.isEnabled()) {
+				return null;
+			} else {
+				try {
+					byte[] podfileLockContent = Files.readAllBytes(getPodfileLockFile());
+					// only need to capture Podfile.lock and manifest.lock has the same content after install
+					return new CocoaPodsInstallation(podfileLockContent);
+				} catch (IOException e) {
+					throw new UncheckedIOException(e);
+				}
+			}
+		}
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/cocoapods/internal/CocoaPodsService.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/cocoapods/internal/CocoaPodsService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.cocoapods.internal;
+
+import dev.nokee.core.exec.CommandLine;
+
+import java.nio.file.Path;
+
+final class CocoaPodsService {
+	public void install(Path workingDirectory) {
+		CommandLine.of("pod", "install").execute(null, workingDirectory.toFile()).waitFor().assertNormalExitValue();
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/cocoapods/internal/CocoaPodsService.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/cocoapods/internal/CocoaPodsService.java
@@ -21,6 +21,6 @@ import java.nio.file.Path;
 
 final class CocoaPodsService {
 	public void install(Path workingDirectory) {
-		CommandLine.of("pod", "install").execute(null, workingDirectory.toFile()).waitFor().assertNormalExitValue();
+		CommandLine.of("pod", "install", "--repo-update").execute(null, workingDirectory.toFile()).waitFor().assertNormalExitValue();
 	}
 }

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/cocoapods/internal/CocoapodSupportPlugin.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/cocoapods/internal/CocoapodSupportPlugin.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.cocoapods.internal;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.initialization.Settings;
+import org.gradle.api.provider.ProviderFactory;
+
+import javax.inject.Inject;
+import java.io.File;
+
+import static dev.nokee.utils.ProviderUtils.forUseAtConfigurationTime;
+
+abstract class CocoapodSupportPlugin implements Plugin<Settings> {
+	private final CocoaPodsProviders providers;
+
+	@Inject
+	public CocoapodSupportPlugin(ProviderFactory providers) {
+		this.providers = new CocoaPodsProviders(providers);
+	}
+
+	@Override
+	public void apply(Settings settings) {
+		forUseAtConfigurationTime(providers.installation(spec -> {
+			spec.getPodfile().set(forUseAtConfigurationTime(providers.podfile(new File(settings.getSettingsDir(), "Podfile"))));
+			spec.getCacheFile().set(new File(settings.getSettingsDir(), ".gradle/Podfile"));
+		})).getOrNull();
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/cocoapods/internal/DefaultCocoaPods.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/cocoapods/internal/DefaultCocoaPods.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.cocoapods.internal;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.function.Consumer;
+
+final class DefaultCocoaPods implements CocoaPods {
+	private final File workingDirectory;
+
+	private DefaultCocoaPods(File workingDirectory) {
+		this.workingDirectory = workingDirectory;
+	}
+
+	private Path getPodfileLockFile() {
+		return new File(workingDirectory, "Podfile.lock").toPath();
+	}
+
+	private Path getManifestLockFile() {
+		return new File(workingDirectory, "Pods/manifest.lock").toPath();
+	}
+
+	private Path getPodfileFile() {
+		return new File(workingDirectory, "Podfile").toPath();
+	}
+
+	public static DefaultCocoaPods inDirectory(File workingDirectory) {
+		return new DefaultCocoaPods(workingDirectory);
+	}
+
+	@Override
+	public boolean isOutOfDate() {
+		if (Files.notExists(getPodfileLockFile())) {
+			return true;
+		} else if (Files.notExists(getManifestLockFile())) {
+			return true;
+		}
+
+		try {
+			byte[] podfileLockContent = Files.readAllBytes(getPodfileLockFile());
+			byte[] manifestLockContent = Files.readAllBytes(getManifestLockFile());
+			if (!Arrays.equals(podfileLockContent, manifestLockContent)) {
+				return true;
+			}
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+
+		return false;
+	}
+
+	@Override
+	public Podfile getPodfile() {
+		return Podfile.of(getPodfileFile().toFile());
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return Files.exists(getPodfileFile());
+	}
+
+	@Override
+	public void ifOutOfDate(Consumer<? super Object> consumer) {
+		if (isOutOfDate()) {
+			consumer.accept(null);
+		}
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/cocoapods/internal/Podfile.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/cocoapods/internal/Podfile.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.cocoapods.internal;
+
+import lombok.EqualsAndHashCode;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@EqualsAndHashCode
+final class Podfile implements Serializable {
+	private /*final*/ File location;
+	private Content content;
+
+	public Podfile(File location) {
+		this.location = location;
+	}
+
+	public boolean exists() {
+		return location.exists();
+	}
+
+	public Path getLocation() {
+		return location.toPath();
+	}
+
+	public Content getContent() {
+		if (content == null) {
+			content = Content.load(location.toPath());
+		}
+		return content;
+	}
+
+	@EqualsAndHashCode
+	public static final class Content implements Serializable {
+		private final byte[] content;
+
+		public Content(byte[] content) {
+			this.content = content;
+		}
+
+		private static Content load(Path location) {
+			try {
+				if (Files.exists(location)) {
+					return new Content(Files.readAllBytes(location));
+				} else {
+					return new Content(new byte[0]);
+				}
+			} catch (IOException e) {
+				throw new UncheckedIOException(e);
+			}
+		}
+	}
+
+	private void readObject(ObjectInputStream inStream) throws ClassNotFoundException, IOException {
+		location = (File) inStream.readObject();
+		content = (Content) inStream.readObject();
+	}
+
+	private void writeObject(ObjectOutputStream outStream) throws IOException {
+		outStream.writeObject(location);
+		outStream.writeObject(content);
+	}
+
+	public static Podfile of(File location) {
+		return new Podfile(location);
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeBuildAdapterPlugin.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeBuildAdapterPlugin.java
@@ -181,6 +181,12 @@ class XcodeBuildAdapterPlugin implements Plugin<Settings> {
 								return null;
 							}).get();
 						}
+
+						@Override
+						public Path getDeveloperDirectory() {
+							// TODO: Use -showBuildSettings to get DEVELOPER_DIR value (or we could guess it)
+							return new File("/Applications/Xcode.app/Contents/Developer").toPath();
+						}
 					})).collect(Collectors.toList()));
 					task.getInputFiles().finalizeValueOnRead();
 					action.execute(task);

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeBuildAdapterPlugin.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeBuildAdapterPlugin.java
@@ -70,6 +70,7 @@ class XcodeBuildAdapterPlugin implements Plugin<Settings> {
 
 	@Override
 	public void apply(Settings settings) {
+		settings.getPluginManager().apply("dev.nokee.cocoapods-support");
 		settings.getGradle().rootProject(new RedirectProjectBuildDirectoryToRootBuildDirectory());
 
 		forUseAtConfigurationTime(settings.getGradle().getSharedServices().registerIfAbsent("loader", XCLoaderService.class, ActionUtils.doNothing())).get();

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeBuildAdapterPlugin.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeBuildAdapterPlugin.java
@@ -147,7 +147,7 @@ class XcodeBuildAdapterPlugin implements Plugin<Settings> {
 							});
 							return dep;
 						}).collect(Collectors.toList());
-					}))).orElse(Collections.emptyList()));
+					}).orElse(Collections.emptyList()))));
 				});
 
 				val targetTask = project.getTasks().register(target.getName(), XcodeTargetExecTask.class, task -> {

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCFileReference.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCFileReference.java
@@ -32,10 +32,12 @@ public abstract class XCFileReference {
 		Path getBuiltProductDirectory();
 
 		Path getSdkRoot();
+
+		Path getDeveloperDirectory();
 	}
 
 	public enum XCFileType {
-		ABSOLUTE, SOURCE_ROOT, BUILT_PRODUCT, SDKROOT
+		ABSOLUTE, SOURCE_ROOT, BUILT_PRODUCT, SDKROOT, DEVELOPER
 	}
 
 	public static XCFileReference absoluteFile(String path) {
@@ -52,6 +54,10 @@ public abstract class XCFileReference {
 
 	public static XCFileReference sdkRoot(String path) {
 		return new SdkRootFileReference(Objects.requireNonNull(path));
+	}
+
+	public static XCFileReference developer(String path) {
+		return new DeveloperFileReference(Objects.requireNonNull(path));
 	}
 
 	@EqualsAndHashCode(callSuper = false)
@@ -147,6 +153,30 @@ public abstract class XCFileReference {
 		@Override
 		public String toString() {
 			return "$(BUILT_PRODUCT_DIR)/" + path;
+		}
+	}
+
+	@EqualsAndHashCode(callSuper = false)
+	private static final class DeveloperFileReference extends XCFileReference {
+		private final String path;
+
+		private DeveloperFileReference(String path) {
+			this.path = path;
+		}
+
+		@Override
+		public Path resolve(ResolveContext context) {
+			return context.getDeveloperDirectory().resolve(path);
+		}
+
+		@Override
+		public XCFileType getType() {
+			return XCFileType.DEVELOPER;
+		}
+
+		@Override
+		public String toString() {
+			return "$(DEVELOPER_DIR)/" + path;
 		}
 	}
 }

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCTargetReference.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCTargetReference.java
@@ -132,6 +132,7 @@ public final class XCTargetReference implements Serializable {
 				case BUILT_PRODUCTS_DIR: return XCFileReference.builtProduct(path);
 				case SOURCE_ROOT: return XCFileReference.sourceRoot(path);
 				case SDKROOT: return XCFileReference.sdkRoot(path);
+				case DEVELOPER_DIR: return XCFileReference.developer(path);
 				default: throw new UnsupportedOperationException("Source tree not supported! (" + node.sourceTree + ")");
 			}
 		} while ((node = node.previous) != null);

--- a/subprojects/build-adapter-xcode/src/smokeTest/java/dev/nokee/buildadaper/xcode/VLCIosSmokeTest.java
+++ b/subprojects/build-adapter-xcode/src/smokeTest/java/dev/nokee/buildadaper/xcode/VLCIosSmokeTest.java
@@ -42,7 +42,6 @@ class VLCIosSmokeTest {
 	@BeforeAll
 	static void setup(GradleRunner runner) throws IOException {
 		CommandLine.of("git", "clone", "--depth=1", "https://code.videolan.org/videolan/vlc-ios.git", '.').execute(null, testDirectory).waitFor().assertNormalExitValue();
-		CommandLine.of("pod", "install", "--repo-update").execute(null, testDirectory).waitFor().assertNormalExitValue();
 		plugins(it -> it.id("dev.nokee.xcode-build-adapter")).writeTo(testDirectory.resolve("settings.gradle"));
 		executer = runner.withArgument(":buildVLC-iOS");
 		result = executer.build();

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/files/XCVersionGroup.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/files/XCVersionGroup.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.xcode.objects.files;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+public final class XCVersionGroup extends PBXGroupElement {
+	private XCVersionGroup(@Nullable String name, @Nullable String path, PBXSourceTree sourceTree, List<PBXReference> children) {
+		super(name, path, sourceTree, children);
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static final class Builder extends PBXGroupElement.Builder<Builder, XCVersionGroup> {
+		@Override
+		protected XCVersionGroup newGroupElement(@Nullable String name, @Nullable String path, @Nullable PBXSourceTree sourceTree, List<PBXReference> children) {
+			return new XCVersionGroup(name, path, sourceTree, children);
+		}
+	}
+}


### PR DESCRIPTION
We are still lacking some models to properly understand all Xcode projects (mainly cross-project references). We introduced draft support for CocoaPods. It lacks some configuration around the CocoaPods tools as well as error handling. We will improve as we progress further.

Fixes https://github.com/nokeedev/gradle-native/issues/649