### PR TITLE
Create execution plan for the rules before executing any rules

### DIFF
--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/registry/DefaultModelRegistry.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/registry/DefaultModelRegistry.java
@@ -203,15 +203,17 @@ public final class DefaultModelRegistry implements ModelRegistry, ModelConfigure
 		public void projectionAdded(ModelNode node, ModelComponent newComponent) {
 			List<ModelAction> c = null;
 			if (newComponent instanceof ModelProjection) {
-				c = ImmutableList.copyOf(config.get(ModelComponentType.componentOf(ModelProjection.class)));
+				c = new ArrayList<>(config.get(ModelComponentType.componentOf(ModelProjection.class)));
 			} else {
-				c = ImmutableList.copyOf(config.get(newComponent.getComponentType()));
+				c = new ArrayList<>(config.get(newComponent.getComponentType()));
 			}
 
 			Bits newComponentBits = newComponent.getComponentType().familyBits();
+			c.removeIf(configuration -> !newComponentBits.intersects(((HasInputs) configuration).getInputBits()) || !node.getComponentBits().containsAll(((HasInputs) configuration).getInputBits()));
+
 			for (int i = 0; i < c.size(); ++i) {
 				val configuration = c.get(i);
-				if (newComponentBits.intersects(((HasInputs) configuration).getInputBits())) {
+				if (newComponentBits.intersects(((HasInputs) configuration).getInputBits())) { // recheck condition in case something changes
 					configuration.execute(node);
 				}
 			}


### PR DESCRIPTION
We need to check the rules against the _current_ entity state to narrow
down the "rules to execute" before any rules are actually executed. As
the universal model is highly reactive, we could capture a rule that
isn't executable now but becomes executable when a previous rule
executes. The issue is the "becomes executable" will be handled as part
of another execution plan (a new execution plan is created on each
entity change). The rule will then execute twice, once in the newer
execution plan and a second time "while we are executing overlapping
rules" in an early execution plan. Instead, in this commit, we precheck
the execution plan to keep only the rules that match before we start
reacting to everything. We check a second time the compliance of the
rule before we execute them. This may be wrong but for now, we will do
that and revise later.