### PR TITLE
Fix minor bugs around parent version discovery

### DIFF
--- a/gradle/libraries/gradle-build-script/src/main/java/dev/gradleplugins/buildscript/blocks/PluginManagementBlock.java
+++ b/gradle/libraries/gradle-build-script/src/main/java/dev/gradleplugins/buildscript/blocks/PluginManagementBlock.java
@@ -52,6 +52,11 @@ public final class PluginManagementBlock extends AbstractBlock {
 			return this;
 		}
 
+		public Builder includeBuild(String buildPath) {
+			builder.add(SettingsBlock.IncludeBuildStatement.includeBuild(buildPath));
+			return this;
+		}
+
 		public PluginManagementBlock build() {
 			return new PluginManagementBlock(builder.build());
 		}

--- a/gradle/libraries/gradle-build-script/src/main/java/dev/gradleplugins/buildscript/blocks/PluginsBlock.java
+++ b/gradle/libraries/gradle-build-script/src/main/java/dev/gradleplugins/buildscript/blocks/PluginsBlock.java
@@ -52,6 +52,13 @@ public final class PluginsBlock extends AbstractBlock {
 			return this;
 		}
 
+		public Builder id(String pluginId, Consumer<? super IdStatement.Builder> action) {
+			final IdStatement.Builder builder = IdStatement.id(pluginId);
+			action.accept(builder);
+			this.builder.add(builder.build());
+			return this;
+		}
+
 		public PluginsBlock build() {
 			return new PluginsBlock(builder.build());
 		}

--- a/gradle/libraries/gradle-build-script/src/main/java/dev/gradleplugins/buildscript/blocks/ProjectBlock.java
+++ b/gradle/libraries/gradle-build-script/src/main/java/dev/gradleplugins/buildscript/blocks/ProjectBlock.java
@@ -163,15 +163,17 @@ public final class ProjectBlock extends AbstractBlock {
 			}
 
 			public static BlockType classify(Statement statement) {
+				Statement nestedStatement = statement;
 				if (statement instanceof GroupStatement && ((GroupStatement) statement).size() == 1) {
-					Statement nestedStatement = ((GroupStatement) statement).iterator().next();
-					if (nestedStatement instanceof BlockStatement) {
-						Statement nestedBlockContentStatement = ((BlockStatement<?>) nestedStatement).getContent();
-						if (nestedBlockContentStatement instanceof PluginsBlock) {
-							return PLUGINS;
-						} else if (nestedBlockContentStatement instanceof BuildScriptBlock) {
-							return BUILDSCRIPT;
-						}
+					nestedStatement = ((GroupStatement) statement).iterator().next();
+				}
+
+				if (nestedStatement instanceof BlockStatement) {
+					Statement nestedBlockContentStatement = ((BlockStatement<?>) nestedStatement).getContent();
+					if (nestedBlockContentStatement instanceof PluginsBlock) {
+						return PLUGINS;
+					} else if (nestedBlockContentStatement instanceof BuildScriptBlock) {
+						return BUILDSCRIPT;
 					}
 				}
 				return OTHERS;

--- a/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/junit/jupiter/ContextualGradleRunnerParameterResolver.java
+++ b/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/junit/jupiter/ContextualGradleRunnerParameterResolver.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 
 import static dev.gradleplugins.runnerkit.GradleExecutor.gradleTestKit;
+import static org.junit.jupiter.api.extension.ExtensionContext.Namespace.GLOBAL;
 import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
 
 public class ContextualGradleRunnerParameterResolver implements ParameterResolver, ExecutionCondition {
@@ -34,10 +35,14 @@ public class ContextualGradleRunnerParameterResolver implements ParameterResolve
 
 	@Override
 	public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
-		GradleRunner result = GradleRunner.create(gradleTestKit()).inDirectory(() -> extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get("temp.dir")).withPluginClasspath().withGradleVersion(System.getProperty("dev.gradleplugins.defaultGradleVersion")).beforeExecute(it -> {
-			System.out.println("Using Gradle v" + System.getProperty("dev.gradleplugins.defaultGradleVersion") + " in '" + it.getWorkingDirectory().getAbsolutePath() + "'");
-			return it;
-		});
+		GradleRunner result = GradleRunner.create(gradleTestKit())
+			.inDirectory(() -> extensionContext.getStore(GLOBAL).get("temp.dir"))
+			.withPluginClasspath()
+			.withGradleVersion(System.getProperty("dev.gradleplugins.defaultGradleVersion"))
+			.beforeExecute(it -> {
+				System.out.println("Using Gradle v" + System.getProperty("dev.gradleplugins.defaultGradleVersion") + " in '" + it.getWorkingDirectory().getAbsolutePath() + "'");
+				return it;
+			});
 		if (getGradleVersion().compareTo(VersionNumber.parse("7.6")) >= 0) {
 			result = result.withArgument("-Dorg.gradle.kotlin.dsl.precompiled.accessors.strict=true");
 		}

--- a/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/junit/jupiter/ContextualGradleRunnerParameterResolver.java
+++ b/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/junit/jupiter/ContextualGradleRunnerParameterResolver.java
@@ -34,10 +34,14 @@ public class ContextualGradleRunnerParameterResolver implements ParameterResolve
 
 	@Override
 	public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
-		return GradleRunner.create(gradleTestKit()).inDirectory(() -> extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get("temp.dir")).withPluginClasspath().withGradleVersion(System.getProperty("dev.gradleplugins.defaultGradleVersion")).beforeExecute(it -> {
+		GradleRunner result = GradleRunner.create(gradleTestKit()).inDirectory(() -> extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get("temp.dir")).withPluginClasspath().withGradleVersion(System.getProperty("dev.gradleplugins.defaultGradleVersion")).beforeExecute(it -> {
 			System.out.println("Using Gradle v" + System.getProperty("dev.gradleplugins.defaultGradleVersion") + " in '" + it.getWorkingDirectory().getAbsolutePath() + "'");
 			return it;
 		});
+		if (getGradleVersion().compareTo(VersionNumber.parse("7.6")) >= 0) {
+			result = result.withArgument("-Dorg.gradle.kotlin.dsl.precompiled.accessors.strict=true");
+		}
+		return result;
 	}
 
 	private static VersionNumber getGradleVersion() {

--- a/subprojects/nokee-version-management/nokee-version-management.gradle
+++ b/subprojects/nokee-version-management/nokee-version-management.gradle
@@ -12,7 +12,7 @@ plugins {
 	id 'com.gradle.plugin-publish' version '0.21.0' // version 1.0.0 is error-prone
 }
 
-version = '1.0.0'
+version = '1.0.1'
 
 gradlePlugin {
 	plugins {

--- a/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/NokeeVersionManagementServiceUsesVersionFromDifferentParentTypeFunctionalTest.java
+++ b/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/NokeeVersionManagementServiceUsesVersionFromDifferentParentTypeFunctionalTest.java
@@ -18,6 +18,7 @@ package dev.nokee.nvm;
 import dev.gradleplugins.buildscript.blocks.RepositoriesBlock;
 import dev.gradleplugins.runnerkit.GradleRunner;
 import dev.nokee.internal.testing.junit.jupiter.ContextualGradleRunnerParameterResolver;
+import dev.nokee.internal.testing.junit.jupiter.GradleAtLeast;
 import dev.nokee.nvm.fixtures.TestGradleBuild;
 import dev.nokee.nvm.fixtures.TestLayout;
 import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
@@ -74,6 +75,7 @@ class NokeeVersionManagementServiceUsesVersionFromDifferentParentTypeFunctionalT
 		}
 
 		@Nested
+		@GradleAtLeast("6.4")
 		class GroovyPrecompiledPluginTest extends Tester {
 			@BeforeEach
 			void setUp() {
@@ -98,6 +100,7 @@ class NokeeVersionManagementServiceUsesVersionFromDifferentParentTypeFunctionalT
 		}
 
 		@Nested
+		@GradleAtLeast("6.4")
 		class GroovyPrecompiledScriptTest extends Tester {
 			@BeforeEach
 			void setUp() {
@@ -121,6 +124,7 @@ class NokeeVersionManagementServiceUsesVersionFromDifferentParentTypeFunctionalT
 
 
 		@Nested
+		@GradleAtLeast("6.4")
 		class GroovyPrecompiledScriptPluginTest extends Tester {
 			@BeforeEach
 			void setUp() {

--- a/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/NokeeVersionManagementServiceUsesVersionFromDifferentParentTypeFunctionalTest.java
+++ b/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/NokeeVersionManagementServiceUsesVersionFromDifferentParentTypeFunctionalTest.java
@@ -37,7 +37,7 @@ import static dev.nokee.nvm.ProjectFixtures.registerVerifyTask;
 import static dev.nokee.nvm.ProjectFixtures.withVersion;
 
 @ExtendWith({TestDirectoryExtension.class, ContextualGradleRunnerParameterResolver.class})
-class NokeeVersionManagementServiceUsesVersionFromDifferentParentTypeTest {
+class NokeeVersionManagementServiceUsesVersionFromDifferentParentTypeFunctionalTest {
 	@TestDirectory Path testDirectory;
 	TestLayout testLayout;
 	GradleRunner runner;

--- a/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/NokeeVersionManagementServiceUsesVersionFromDifferentParentTypeFunctionalTest.java
+++ b/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/NokeeVersionManagementServiceUsesVersionFromDifferentParentTypeFunctionalTest.java
@@ -140,8 +140,6 @@ class NokeeVersionManagementServiceUsesVersionFromDifferentParentTypeFunctionalT
 			build.configure(applyPluginUnderTest());
 			build.buildFile(t -> {
 				t.plugins(i -> i.id("kotlin-dsl", id -> id.useKotlinAccessor())).repositories(RepositoriesBlock.Builder::mavenCentral);
-//				t.plugins(i -> i.add(expressionOf(kotlin("`kotlin-dsl`"))))
-//					.repositories(RepositoriesBlock.Builder::mavenCentral);
 			});
 			build.file("src/main/kotlin/foobuild.compile.gradle.kts", "plugins {", "  java", "}");
 			build.configure(registerVerifyTask().andThen(expect("0.6.9")));

--- a/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/NokeeVersionManagementServiceUsesVersionFromDifferentParentTypeTest.java
+++ b/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/NokeeVersionManagementServiceUsesVersionFromDifferentParentTypeTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.nvm;
+
+import dev.gradleplugins.buildscript.blocks.RepositoriesBlock;
+import dev.gradleplugins.runnerkit.GradleRunner;
+import dev.nokee.internal.testing.junit.jupiter.ContextualGradleRunnerParameterResolver;
+import dev.nokee.nvm.fixtures.TestGradleBuild;
+import dev.nokee.nvm.fixtures.TestLayout;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.annotation.Nonnull;
+import java.nio.file.Path;
+import java.util.function.Consumer;
+
+import static dev.nokee.nvm.ProjectFixtures.applyPluginUnderTest;
+import static dev.nokee.nvm.ProjectFixtures.expect;
+import static dev.nokee.nvm.ProjectFixtures.registerVerifyTask;
+import static dev.nokee.nvm.ProjectFixtures.withVersion;
+
+@ExtendWith({TestDirectoryExtension.class, ContextualGradleRunnerParameterResolver.class})
+class NokeeVersionManagementServiceUsesVersionFromDifferentParentTypeTest {
+	@TestDirectory Path testDirectory;
+	TestLayout testLayout;
+	GradleRunner runner;
+
+	@BeforeEach
+	void setUp(GradleRunner runner) {
+		testLayout = TestLayout.newBuild(testDirectory)
+			.configure(withVersion("0.6.9").andThen(registerVerifyTask()))
+			.configure(applyPluginUnderTest())
+			.configure(applyPrecompiledScriptPlugin());
+		this.runner = runner.withTasks("verify");
+	}
+
+	abstract class Tester {
+		@Test
+		void withoutBuildScansPlugin() {
+			runner.build();
+		}
+
+		@Test
+		void withBuildScansPlugin() {
+			runner.publishBuildScans().build();
+		}
+	}
+
+	@Nested
+	class BuildSrcTest {
+		@Nested
+		class KotlinPrecompiledPluginTest extends Tester {
+			@BeforeEach
+			void setUp() {
+				testLayout.buildSrc(configureKotlinPrecompiledScriptPluginBuild());
+			}
+		}
+
+		@Nested
+		class GroovyPrecompiledPluginTest extends Tester {
+			@BeforeEach
+			void setUp() {
+				testLayout.buildSrc(configureGroovyPrecompiledScriptPluginBuild());
+			}
+		}
+	}
+
+
+
+
+
+	@Nested
+	class PluginBuildTest {
+		@Nested
+		class KotlinPrecompiledPluginTest extends Tester {
+			@BeforeEach
+			void setUp() {
+				testLayout.pluginBuild("my-build-src",
+					configureKotlinPrecompiledScriptPluginBuild());
+			}
+		}
+
+		@Nested
+		class GroovyPrecompiledScriptTest extends Tester {
+			@BeforeEach
+			void setUp() {
+				testLayout.pluginBuild("my-build-src",
+					configureGroovyPrecompiledScriptPluginBuild());
+			}
+		}
+	}
+
+
+	@Nested
+	class IncludedBuildTest {
+		@Nested
+		class KotlinPrecompiledScriptPluginTest extends Tester {
+			@BeforeEach
+			void setUp() {
+				testLayout.includeBuild("my-build-src",
+					configureKotlinPrecompiledScriptPluginBuild());
+			}
+		}
+
+
+		@Nested
+		class GroovyPrecompiledScriptPluginTest extends Tester {
+			@BeforeEach
+			void setUp() {
+				testLayout.includeBuild("my-build-src",
+					configureGroovyPrecompiledScriptPluginBuild());
+			}
+		}
+	}
+
+	private static Consumer<TestGradleBuild> configureKotlinPrecompiledScriptPluginBuild() {
+		return build -> {
+			build.getBuildFile().useKotlinDsl();
+			build.configure(applyPluginUnderTest());
+			build.buildFile(t -> {
+				t.plugins(i -> i.id("kotlin-dsl", id -> id.useKotlinAccessor())).repositories(RepositoriesBlock.Builder::mavenCentral);
+//				t.plugins(i -> i.add(expressionOf(kotlin("`kotlin-dsl`"))))
+//					.repositories(RepositoriesBlock.Builder::mavenCentral);
+			});
+			build.file("src/main/kotlin/foobuild.compile.gradle.kts", "plugins {", "  java", "}");
+			build.configure(registerVerifyTask().andThen(expect("0.6.9")));
+		};
+	}
+
+	@Nonnull
+	private static Consumer<TestGradleBuild> configureGroovyPrecompiledScriptPluginBuild() {
+		return it -> {
+			it.configure(applyPluginUnderTest());
+			it.buildFile(t -> {
+				t.plugins(i -> i.id("groovy-gradle-plugin"));
+			});
+			it.file("src/main/groovy/foobuild.compile.gradle", "plugins {", "  id('java')", "}");
+			it.configure(registerVerifyTask().andThen(expect("0.6.9")));
+		};
+	}
+
+	@Nonnull
+	private static Consumer<TestGradleBuild> applyPrecompiledScriptPlugin() {
+		return build -> build.buildFile(project -> project.plugins(it -> it.id("foobuild.compile")));
+	}
+}

--- a/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/ProjectFixtures.java
+++ b/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/ProjectFixtures.java
@@ -142,7 +142,7 @@ public final class ProjectFixtures {
 
 	private static Consumer<TaskBlock.Builder> resolveNokeeVersion() {
 		return builder -> {
-			builder.doLast(task -> task.add(Statement.expressionOf(Syntax.groovy("gradle.sharedServices.registrations.nokeeVersionManagement.service.get().version.toString()"))));
+			builder.doLast(task -> task.add(Statement.expressionOf(Syntax.groovy("dev.nokee.nvm.NokeeVersionManagementService.fromBuild(gradle).get().version.toString()"))));
 		};
 	}
 
@@ -158,7 +158,10 @@ public final class ProjectFixtures {
 
 	public static Consumer<TaskBlock.Builder> assertNokeeVersion(String version) {
 		return builder -> {
-			builder.doLast(task -> task.add(Statement.expressionOf(Syntax.groovy("assert gradle.sharedServices.registrations.nokeeVersionManagement.service.get().version.toString() == '" + version + "'"))));
+			builder.doLast(task -> task.add(Statement.expressionOf(Syntax.gradle(
+				"assert dev.nokee.nvm.NokeeVersionManagementService.fromBuild(gradle).get().version.toString() == '" + version + "'",
+				"assert(dev.nokee.nvm.NokeeVersionManagementService.fromBuild(gradle).get().version.toString() == \"" + version + "\")"
+				))));
 		};
 	}
 }

--- a/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/fixtures/AbstractTestGradleBuild.java
+++ b/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/fixtures/AbstractTestGradleBuild.java
@@ -158,6 +158,25 @@ abstract class AbstractTestGradleBuild<SELF extends TestGradleBuild> implements 
 	}
 
 	@Override
+	public SELF pluginBuild(String path, Consumer<? super TestIncludedBuild> action) {
+		try {
+			settingsBuilder.pluginManagement(it -> it.includeBuild(path)).build().writeTo(location.resolve("settings.gradle"));
+			TestIncludedBuild includedBuild = includedBuilds.get(path);
+			if (includedBuild == null) {
+				includedBuild = TestIncludedBuild.newInstance(this, path);
+				includedBuilds.put(path, includedBuild);
+			}
+			action.accept(includedBuild);
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+
+		@SuppressWarnings("unchecked")
+		SELF result = (SELF) this;
+		return result;
+	}
+
+	@Override
 	public void file(String path, String... lines) {
 		try {
 			Files.write(location.resolve(path), Arrays.asList(lines));

--- a/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/fixtures/AbstractTestGradleBuild.java
+++ b/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/fixtures/AbstractTestGradleBuild.java
@@ -179,7 +179,9 @@ abstract class AbstractTestGradleBuild<SELF extends TestGradleBuild> implements 
 	@Override
 	public void file(String path, String... lines) {
 		try {
-			Files.write(location.resolve(path), Arrays.asList(lines));
+			final Path location = this.location.resolve(path);
+			Files.createDirectories(location.getParent());
+			Files.write(location, Arrays.asList(lines));
 		} catch (IOException e) {
 			throw new UncheckedIOException(e);
 		}

--- a/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/fixtures/AbstractTestGradleBuild.java
+++ b/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/fixtures/AbstractTestGradleBuild.java
@@ -186,4 +186,13 @@ abstract class AbstractTestGradleBuild<SELF extends TestGradleBuild> implements 
 			throw new UncheckedIOException(e);
 		}
 	}
+
+	@Override
+	public SELF configure(Consumer<? super TestGradleBuild> action) {
+		action.accept(this);
+
+		@SuppressWarnings("unchecked")
+		SELF result = (SELF) this;
+		return result;
+	}
 }

--- a/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/fixtures/AbstractTestGradleBuild.java
+++ b/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/fixtures/AbstractTestGradleBuild.java
@@ -28,7 +28,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
-abstract class AbstractTestGradleBuild implements TestGradleBuild {
+abstract class AbstractTestGradleBuild<SELF extends TestGradleBuild> implements TestGradleBuild {
 	private final SettingsBlock.Builder settingsBuilder = SettingsBlock.builder();
 	private final ProjectBlock.Builder buildBuilder = ProjectBlock.builder();
 	private final Path location;
@@ -54,6 +54,7 @@ abstract class AbstractTestGradleBuild implements TestGradleBuild {
 		}
 	}
 
+	@Override
 	public BuildScriptFile getBuildFile() {
 		return new BuildScriptFile() {
 			@Override
@@ -126,15 +127,19 @@ abstract class AbstractTestGradleBuild implements TestGradleBuild {
 	}
 
 	@Override
-	public void buildSrc(Consumer<? super TestBuildSrc> action) {
+	public SELF buildSrc(Consumer<? super TestBuildSrc> action) {
 		if (buildSrcBuild == null) {
 			buildSrcBuild = TestBuildSrc.newInstance(this);
 		}
 		action.accept(buildSrcBuild);
+
+		@SuppressWarnings("unchecked")
+		SELF result = (SELF) this;
+		return result;
 	}
 
 	@Override
-	public void includeBuild(String path, Consumer<? super TestIncludedBuild> action) {
+	public SELF includeBuild(String path, Consumer<? super TestIncludedBuild> action) {
 		try {
 			settingsBuilder.includeBuild(path).build().writeTo(location.resolve("settings.gradle"));
 			TestIncludedBuild includedBuild = includedBuilds.get(path);
@@ -146,6 +151,10 @@ abstract class AbstractTestGradleBuild implements TestGradleBuild {
 		} catch (IOException e) {
 			throw new UncheckedIOException(e);
 		}
+
+		@SuppressWarnings("unchecked")
+		SELF result = (SELF) this;
+		return result;
 	}
 
 	@Override

--- a/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/fixtures/HasBuildFile.java
+++ b/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/fixtures/HasBuildFile.java
@@ -21,4 +21,6 @@ import java.util.function.Consumer;
 
 public interface HasBuildFile {
 	void buildFile(Consumer<? super ProjectBlock.Builder> action);
+
+	BuildScriptFile getBuildFile();
 }

--- a/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/fixtures/TestBuildSrc.java
+++ b/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/fixtures/TestBuildSrc.java
@@ -21,7 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.function.Consumer;
 
-public final class TestBuildSrc extends AbstractTestGradleBuild implements TestGradleBuild, Configurable<TestBuildSrc> {
+public final class TestBuildSrc extends AbstractTestGradleBuild<TestBuildSrc> implements TestGradleBuild, Configurable<TestBuildSrc> {
 	private final TestGradleBuild parent;
 
 	public TestBuildSrc(TestGradleBuild parent, Path location) {

--- a/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/fixtures/TestBuildSrc.java
+++ b/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/fixtures/TestBuildSrc.java
@@ -21,7 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.function.Consumer;
 
-public final class TestBuildSrc extends AbstractTestGradleBuild<TestBuildSrc> implements TestGradleBuild, Configurable<TestBuildSrc> {
+public final class TestBuildSrc extends AbstractTestGradleBuild<TestBuildSrc> implements TestGradleBuild {
 	private final TestGradleBuild parent;
 
 	public TestBuildSrc(TestGradleBuild parent, Path location) {
@@ -42,11 +42,5 @@ public final class TestBuildSrc extends AbstractTestGradleBuild<TestBuildSrc> im
 
 	public void parentBuild(Consumer<? super TestGradleBuild> action) {
 		action.accept(parent);
-	}
-
-	@Override
-	public TestBuildSrc configure(Consumer<? super TestBuildSrc> action) {
-		action.accept(this);
-		return this;
 	}
 }

--- a/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/fixtures/TestGradleBuild.java
+++ b/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/fixtures/TestGradleBuild.java
@@ -25,7 +25,7 @@ public interface TestGradleBuild extends HasSettingsFile, HasBuildFile, HasFileS
 
 	void subproject(String path, Consumer<? super TestSubproject> action);
 
-	void buildSrc(Consumer<? super TestBuildSrc> action);
+	TestGradleBuild buildSrc(Consumer<? super TestBuildSrc> action);
 
-	void includeBuild(String path, Consumer<? super TestIncludedBuild> action);
+	TestGradleBuild includeBuild(String path, Consumer<? super TestIncludedBuild> action);
 }

--- a/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/fixtures/TestGradleBuild.java
+++ b/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/fixtures/TestGradleBuild.java
@@ -28,4 +28,6 @@ public interface TestGradleBuild extends HasSettingsFile, HasBuildFile, HasFileS
 	TestGradleBuild buildSrc(Consumer<? super TestBuildSrc> action);
 
 	TestGradleBuild includeBuild(String path, Consumer<? super TestIncludedBuild> action);
+
+	TestGradleBuild pluginBuild(String path, Consumer<? super TestIncludedBuild> action);
 }

--- a/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/fixtures/TestGradleBuild.java
+++ b/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/fixtures/TestGradleBuild.java
@@ -18,7 +18,7 @@ package dev.nokee.nvm.fixtures;
 import java.nio.file.Path;
 import java.util.function.Consumer;
 
-public interface TestGradleBuild extends HasSettingsFile, HasBuildFile, HasFileSystem {
+public interface TestGradleBuild extends HasSettingsFile, HasBuildFile, HasFileSystem, Configurable<TestGradleBuild> {
 	Path getLocation();
 
 	void subproject(String path);

--- a/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/fixtures/TestIncludedBuild.java
+++ b/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/fixtures/TestIncludedBuild.java
@@ -21,7 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.function.Consumer;
 
-public final class TestIncludedBuild extends AbstractTestGradleBuild<TestIncludedBuild> implements TestGradleBuild, Configurable<TestIncludedBuild> {
+public final class TestIncludedBuild extends AbstractTestGradleBuild<TestIncludedBuild> implements TestGradleBuild {
 	private final TestGradleBuild parent;
 	private final String buildPath;
 
@@ -50,11 +50,5 @@ public final class TestIncludedBuild extends AbstractTestGradleBuild<TestInclude
 
 	public void parentBuild(Consumer<? super TestGradleBuild> action) {
 		action.accept(parent);
-	}
-
-	@Override
-	public TestIncludedBuild configure(Consumer<? super TestIncludedBuild> action) {
-		action.accept(this);
-		return this;
 	}
 }

--- a/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/fixtures/TestIncludedBuild.java
+++ b/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/fixtures/TestIncludedBuild.java
@@ -21,7 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.function.Consumer;
 
-public final class TestIncludedBuild extends AbstractTestGradleBuild implements TestGradleBuild, Configurable<TestIncludedBuild> {
+public final class TestIncludedBuild extends AbstractTestGradleBuild<TestIncludedBuild> implements TestGradleBuild, Configurable<TestIncludedBuild> {
 	private final TestGradleBuild parent;
 	private final String buildPath;
 

--- a/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/fixtures/TestLayout.java
+++ b/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/fixtures/TestLayout.java
@@ -18,7 +18,7 @@ package dev.nokee.nvm.fixtures;
 import java.nio.file.Path;
 import java.util.function.Consumer;
 
-public final class TestLayout extends AbstractTestGradleBuild implements TestGradleBuild, Configurable<TestLayout> {
+public final class TestLayout extends AbstractTestGradleBuild<TestLayout> implements TestGradleBuild, Configurable<TestLayout> {
 	private TestLayout(Path location) {
 		super(location);
 	}

--- a/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/fixtures/TestLayout.java
+++ b/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/fixtures/TestLayout.java
@@ -16,9 +16,8 @@
 package dev.nokee.nvm.fixtures;
 
 import java.nio.file.Path;
-import java.util.function.Consumer;
 
-public final class TestLayout extends AbstractTestGradleBuild<TestLayout> implements TestGradleBuild, Configurable<TestLayout> {
+public final class TestLayout extends AbstractTestGradleBuild<TestLayout> implements TestGradleBuild {
 	private TestLayout(Path location) {
 		super(location);
 	}
@@ -30,12 +29,6 @@ public final class TestLayout extends AbstractTestGradleBuild<TestLayout> implem
 	// TODO: Return BuildScriptFile via getBuildFile()
 
 	// TODO: Return BuildScriptFile via getSettingsFile()
-
-	@Override
-	public TestLayout configure(Consumer<? super TestLayout> action) {
-		action.accept(this);
-		return this;
-	}
 
 //	interface SubprojectBuilder {
 //		// build filename -> build

--- a/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/fixtures/TestSubproject.java
+++ b/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/fixtures/TestSubproject.java
@@ -55,4 +55,9 @@ public final class TestSubproject implements HasBuildFile {
 			throw new UncheckedIOException(e);
 		}
 	}
+
+	@Override
+	public BuildScriptFile getBuildFile() {
+		throw new UnsupportedOperationException("Not yet implemented");
+	}
 }

--- a/subprojects/nokee-version-management/src/main/java/dev/nokee/nvm/BestEffortParentNokeeVersionFinder.java
+++ b/subprojects/nokee-version-management/src/main/java/dev/nokee/nvm/BestEffortParentNokeeVersionFinder.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.nvm;
+
+import org.gradle.api.invocation.Gradle;
+
+import javax.annotation.Nullable;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+final class BestEffortParentNokeeVersionFinder implements Callable<NokeeVersion> {
+	private final DefaultNokeeVersionLoader versionLoader = DefaultNokeeVersionLoader.INSTANCE;
+	private final Gradle gradle;
+
+	public BestEffortParentNokeeVersionFinder(Gradle gradle) {
+		this.gradle = gradle;
+	}
+
+	@Override
+	@Nullable
+	public NokeeVersion call() throws Exception {
+		if (gradle.getParent() == null) {
+			return null;
+		}
+		final Path currentDirectory = gradle.getParent().getStartParameter().getCurrentDir().toPath();
+		Path settingsFile = currentDirectory.resolve("settings.gradle");
+		final Pattern pluginPattern = Pattern.compile("id[\\( ][\"']dev\\.nokee\\.nokee-version-management[\"']\\)?");
+		if (Files.notExists(settingsFile)) {
+			settingsFile = currentDirectory.resolve("settings.gradle.kts");
+		}
+		try (final Stream<String> lineStream = Files.lines(settingsFile)) {
+			if (lineStream.anyMatch(it -> pluginPattern.matcher(it).find())) {
+				final Path versionFile = currentDirectory.resolve(".nokee-version");
+				return versionLoader.fromFile(versionFile);
+			}
+		}
+		return null;
+	}
+}

--- a/subprojects/nokee-version-management/src/main/java/dev/nokee/nvm/DefaultNokeeVersionManagementService.java
+++ b/subprojects/nokee-version-management/src/main/java/dev/nokee/nvm/DefaultNokeeVersionManagementService.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.nvm;
+
+import org.gradle.api.Action;
+import org.gradle.api.invocation.Gradle;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.services.BuildService;
+import org.gradle.api.services.BuildServiceParameters;
+import org.gradle.api.services.BuildServiceRegistration;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+@SuppressWarnings("UnstableApiUsage")
+abstract class DefaultNokeeVersionManagementService implements BuildService<DefaultNokeeVersionManagementService.Parameters>, NokeeVersionManagementService {
+	static final String SERVICE_NAME = "nokeeVersionManagement";
+
+	interface Parameters extends BuildServiceParameters {
+		Property<NokeeVersion> getNokeeVersion();
+	}
+
+	@Inject
+	public DefaultNokeeVersionManagementService() {}
+
+	@Override
+	public NokeeVersion getVersion() {
+		final NokeeVersion result = getParameters().getNokeeVersion().getOrNull();
+		if (result == null) {
+			throw new RuntimeException("Please add the Nokee version to use in a .nokee-version file.");
+		}
+		return result;
+	}
+
+	public static Provider<DefaultNokeeVersionManagementService> registerService(Gradle gradle, Action<? super Parameters> action) {
+		return gradle.getSharedServices().registerIfAbsent(SERVICE_NAME, DefaultNokeeVersionManagementService.class, it -> {
+			it.parameters(action);
+		});
+	}
+
+//	@SuppressWarnings("unchecked")
+//	public static Provider<DefaultNokeeVersionManagementService> fromService(Gradle gradle) {
+//		return (Provider<DefaultNokeeVersionManagementService>) gradle.getSharedServices().getRegistrations().getByName(SERVICE_NAME).getService();
+//	}
+
+	@Nullable
+	@SuppressWarnings("unchecked")
+	public static BuildServiceRegistration<DefaultNokeeVersionManagementService, DefaultNokeeVersionManagementService.Parameters> findServiceRegistration(Gradle gradle) {
+		return (BuildServiceRegistration<DefaultNokeeVersionManagementService, DefaultNokeeVersionManagementService.Parameters>) gradle.getSharedServices().getRegistrations().findByName(SERVICE_NAME);
+	}
+
+	public static NokeeVersion asNokeeVersion(BuildService<?> service) {
+		// Not the same class loader so classes don't align, reflection required
+		try {
+			Method getVersion = service.getClass().getMethod("getVersion");
+			getVersion.setAccessible(true);
+			return NokeeVersion.version(getVersion.invoke(service).toString());
+		} catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/subprojects/nokee-version-management/src/main/java/dev/nokee/nvm/NokeeVersionManagementPlugin.java
+++ b/subprojects/nokee-version-management/src/main/java/dev/nokee/nvm/NokeeVersionManagementPlugin.java
@@ -38,8 +38,7 @@ import java.util.function.Function;
 import static dev.nokee.nvm.DefaultNokeeVersionManagementService.registerService;
 import static dev.nokee.nvm.ProviderUtils.forUseAtConfigurationTime;
 
-// FIXME: Javadoc fail if no public class
-public class NokeeVersionManagementPlugin implements Plugin<Settings> {
+class NokeeVersionManagementPlugin implements Plugin<Settings> {
 	private final ProviderFactory providers;
 
 	@Inject

--- a/subprojects/nokee-version-management/src/main/java/dev/nokee/nvm/NokeeVersionManagementPlugin.java
+++ b/subprojects/nokee-version-management/src/main/java/dev/nokee/nvm/NokeeVersionManagementPlugin.java
@@ -75,7 +75,9 @@ public class NokeeVersionManagementPlugin implements Plugin<Settings> {
 			public void execute(DefaultNokeeVersionManagementService.Parameters parameters) {
 				parameters.getNokeeVersion().value(fromParentNokeeBuilds()
 					.orElse(fromSystemProperty()).orElse(fromGradleProperty())
-					.orElse(fromEnvironmentVariable()).orElse(fromNokeeVersionFile()));
+					.orElse(fromEnvironmentVariable())
+					.orElse(fromBestEffortParent())
+					.orElse(fromNokeeVersionFile()));
 			}
 
 			private Provider<NokeeVersion> fromEnvironmentVariable() {
@@ -101,6 +103,12 @@ public class NokeeVersionManagementPlugin implements Plugin<Settings> {
 
 			private <T> Transformer<T, Gradle> forEachParent(Function<Gradle, T> mapper) {
 				return new ForEachParentGradleTransformer<>(mapper);
+			}
+			//endregion
+
+			//region best effort
+			private Provider<NokeeVersion> fromBestEffortParent() {
+				return providers.provider(new BestEffortParentNokeeVersionFinder(settings.getGradle()));
 			}
 			//endregion
 

--- a/subprojects/nokee-version-management/src/main/java/dev/nokee/nvm/NokeeVersionManagementService.java
+++ b/subprojects/nokee-version-management/src/main/java/dev/nokee/nvm/NokeeVersionManagementService.java
@@ -15,63 +15,25 @@
  */
 package dev.nokee.nvm;
 
-import org.gradle.api.Action;
-import org.gradle.api.Transformer;
+import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.invocation.Gradle;
-import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
-import org.gradle.api.services.BuildService;
-import org.gradle.api.services.BuildServiceParameters;
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.services.BuildServiceRegistration;
 
-import javax.annotation.Nullable;
-import javax.inject.Inject;
-import java.lang.reflect.InvocationTargetException;
+import static dev.nokee.nvm.DefaultNokeeVersionManagementService.SERVICE_NAME;
 
-@SuppressWarnings("UnstableApiUsage")
-abstract class NokeeVersionManagementService implements BuildService<NokeeVersionManagementService.Parameters> {
-	private static final String SERVICE_NAME = "nokeeVersionManagement";
+public interface NokeeVersionManagementService {
+	NokeeVersion getVersion();
 
-	interface Parameters extends BuildServiceParameters {
-		Property<NokeeVersion> getNokeeVersion();
-	}
-
-	@Inject
-	public NokeeVersionManagementService() {}
-
-	public NokeeVersion getVersion() {
-		final NokeeVersion result = getParameters().getNokeeVersion().getOrNull();
-		if (result == null) {
-			throw new RuntimeException("Please add the Nokee version to use in a .nokee-version file.");
-		}
-		return result;
-	}
-
-	public static Provider<NokeeVersionManagementService> registerService(Gradle gradle, Action<? super Parameters> action) {
-		return gradle.getSharedServices().registerIfAbsent(SERVICE_NAME, NokeeVersionManagementService.class, it -> {
-			it.parameters(action);
-		});
-	}
-
-	@SuppressWarnings("unchecked")
-	public static Provider<NokeeVersionManagementService> fromService(Gradle gradle) {
-		return (Provider<NokeeVersionManagementService>) gradle.getSharedServices().getRegistrations().getByName(SERVICE_NAME).getService();
-	}
-
-	@Nullable
-	@SuppressWarnings("unchecked")
-	public static BuildServiceRegistration<NokeeVersionManagementService, NokeeVersionManagementService.Parameters> findServiceRegistration(Gradle gradle) {
-		return (BuildServiceRegistration<NokeeVersionManagementService, NokeeVersionManagementService.Parameters>) gradle.getSharedServices().getRegistrations().findByName(SERVICE_NAME);
-	}
-
-	public static Transformer<NokeeVersion, BuildService<?>> toNokeeVersion() {
-		return service -> {
-			// Not the same class loader so classes don't align, reflection required
-			try {
-				return NokeeVersion.version(service.getClass().getMethod("getVersion").invoke(service).toString());
-			} catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
-				throw new RuntimeException(e);
+	static Provider<NokeeVersionManagementService> fromBuild(Gradle gradle) {
+		return ((GradleInternal) gradle).getServices().get(ProviderFactory.class).provider(() -> {
+			return gradle.getSharedServices().getRegistrations().findByName(SERVICE_NAME);
+		}).flatMap(BuildServiceRegistration::getService).map(it -> new NokeeVersionManagementService() {
+			@Override
+			public NokeeVersion getVersion() {
+				return DefaultNokeeVersionManagementService.asNokeeVersion(it);
 			}
-		};
+		});
 	}
 }


### PR DESCRIPTION
There is one major issue that we can't fix, which is caused by a broken import process from JetBrains in IntelliJ. JetBrains thinks it's a good idea to split the consumption of the host build and the `buildSrc` build as separated invocation, which is completely wrong. `buildSrc` build is not meant to be run outside of a host build. When using Settings plugin like the Nokee Version Management plugin, it requires a version. For the `buildSrc` the plugin is already loaded into the classpath by the host build, causing an exception if a version is included during the apply in `buildSrc` when executing from the host build. However, executing the `buildSrc` as a standalone build requires a version. Catch-22.

The solution should be as simple as converting the `buildSrc` into a full-blown included build to work around the JetBrains broken import process. However, `buildSrc` is special in the sense its JAR is included in the classpath automatically allowing for the plugin DSL Kotlin accessor to be available. This is not true for included builds. True to be told, plugin DSL Kotlin accessors should be avoided given how broken they are in the first place.