### PR TITLE
Use platform-base to back Xcode build adapter entities

### DIFF
--- a/subprojects/build-adapter-xcode/build-adapter-xcode.gradle
+++ b/subprojects/build-adapter-xcode/build-adapter-xcode.gradle
@@ -9,6 +9,7 @@ plugins {
 }
 
 dependencies {
+	implementation project(':platformBase')
 	implementation project(':coreExec') // for build adapter
 	implementation project(':platformNative')
 	implementation project(':runtimeBase')

--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/DefaultXcode13SwiftAppSampleFunctionalTest.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/DefaultXcode13SwiftAppSampleFunctionalTest.java
@@ -51,6 +51,6 @@ class DefaultXcode13SwiftAppSampleFunctionalTest {
 
 	@Test
 	void doesNotFail() {
-		assertThat(executer.build().task(":xcodeSwiftApp").getOutcome(), equalTo(TaskOutcome.SUCCESS));
+		assertThat(executer.build().task(":XcodeSwiftApp").getOutcome(), equalTo(TaskOutcome.SUCCESS));
 	}
 }

--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/DefaultXcode13SwiftAppSampleFunctionalTest.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/DefaultXcode13SwiftAppSampleFunctionalTest.java
@@ -51,6 +51,6 @@ class DefaultXcode13SwiftAppSampleFunctionalTest {
 
 	@Test
 	void doesNotFail() {
-		assertThat(executer.build().task(":XcodeSwiftApp").getOutcome(), equalTo(TaskOutcome.SUCCESS));
+		assertThat(executer.build().task(":xcodeSwiftApp").getOutcome(), equalTo(TaskOutcome.SUCCESS));
 	}
 }

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XCProjectComponent.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XCProjectComponent.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal.plugins;
+
+import dev.nokee.model.internal.core.ModelComponent;
+import dev.nokee.xcode.XCProjectReference;
+
+public final class XCProjectComponent implements ModelComponent {
+	private final XCProjectReference value;
+
+	public XCProjectComponent(XCProjectReference value) {
+		this.value = value;
+	}
+
+	public XCProjectReference get() {
+		return value;
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XCTargetComponent.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XCTargetComponent.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal.plugins;
+
+import dev.nokee.model.internal.core.ModelComponent;
+import dev.nokee.xcode.XCTargetReference;
+
+public final class XCTargetComponent implements ModelComponent {
+	private final XCTargetReference value;
+
+	public XCTargetComponent(XCTargetReference value) {
+		this.value = value;
+	}
+
+	public XCTargetReference get() {
+		return value;
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeImplicitDependenciesService.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeImplicitDependenciesService.java
@@ -68,7 +68,7 @@ public abstract class XcodeImplicitDependenciesService implements BuildService<X
 	@Nullable
 	public XCTarget findTarget(XCFileReference file) {
 		if (file.getType() == XCFileReference.XCFileType.BUILT_PRODUCT) {
-			return targets.stream().filter(it -> it.getOutputFile().equals(file)).findFirst().orElseThrow(RuntimeException::new);
+			return targets.stream().filter(it -> it.getOutputFile() != null && it.getOutputFile().equals(file)).findFirst().orElseThrow(RuntimeException::new);
 		} else {
 			return null;
 		}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCTargetReference.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCTargetReference.java
@@ -65,7 +65,10 @@ public final class XCTargetReference implements Serializable {
 
 			// Assuming PBXFileReference only
 			val inputFiles = findInputFiles(target).map(resolver::get).collect(Collectors.toList());
-			val outputFile = target.getProductReference().map(resolver::get).orElseThrow(() -> new RuntimeException("for target " + target.getName() + " in project " + project.getLocation()));
+
+			// TODO: outputFile here is misleading, it's more about the productFile
+			// TODO: PBXAggregateTarget has no productFile
+			val outputFile = target.getProductReference().map(resolver::get).orElse(null);
 			val dependencies = target.getDependencies().stream().map(it -> XCTargetReference.of(project, it.getTarget().getName())).collect(ImmutableList.toImmutableList());
 
 			return new XCTarget(name, project, inputFiles, dependencies, outputFile);

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/DependencyBucketCapabilityPlugin.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/DependencyBucketCapabilityPlugin.java
@@ -101,7 +101,7 @@ public abstract class DependencyBucketCapabilityPlugin<T extends ExtensionAware 
 
 		// ComponentFromEntity<ParentComponent> read-only self
 		target.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelTags.referenceOf(IsDependencyBucket.class), ModelComponentReference.of(ModelPathComponent.class), ModelComponentReference.of(DisplayNameComponent.class), ModelComponentReference.of(ElementNameComponent.class), (entity, ignored1, path, displayName, elementName) -> {
-			val parentIdentifier = entity.find(ParentComponent.class).map(parent -> parent.get().get(IdentifierComponent.class).get()).orElse(null);
+			val parentIdentifier = entity.find(ParentComponent.class).flatMap(parent -> parent.get().find(IdentifierComponent.class)).map(IdentifierComponent::get).orElse(null);
 			entity.addComponent(new IdentifierComponent(new DefaultDomainObjectIdentifier(elementName.get(), parentIdentifier, displayName.get(), path.get())));
 		}));
 

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/TaskName.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/TaskName.java
@@ -59,9 +59,9 @@ public final class TaskName implements ElementName {
 
 	@Override
 	public String toQualifiedName(QualifyingName qualifyingName) {
-		return StringUtils.uncapitalize(Stream.of(verb, qualifyingName.toString(), object == null ? "" : object)
+		return verb + Stream.of(qualifyingName.toString(), object == null ? "" : object)
 			.map(StringUtils::capitalize)
-			.collect(Collectors.joining()));
+			.collect(Collectors.joining());
 	}
 
 	public static TaskName of(String taskName) {

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/TaskName.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/tasks/TaskName.java
@@ -59,9 +59,13 @@ public final class TaskName implements ElementName {
 
 	@Override
 	public String toQualifiedName(QualifyingName qualifyingName) {
-		return verb + Stream.of(qualifyingName.toString(), object == null ? "" : object)
-			.map(StringUtils::capitalize)
-			.collect(Collectors.joining());
+		if (verb.isEmpty()) {
+			return qualifyingName.toString();
+		} else {
+			return verb + Stream.of(qualifyingName.toString(), object == null ? "" : object)
+				.map(StringUtils::capitalize)
+				.collect(Collectors.joining());
+		}
 	}
 
 	public static TaskName of(String taskName) {

--- a/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/tasks/TaskNameTest.groovy
+++ b/subprojects/platform-base/src/test/groovy/dev/nokee/platform/base/internal/tasks/TaskNameTest.groovy
@@ -15,6 +15,7 @@
  */
 package dev.nokee.platform.base.internal.tasks
 
+import dev.nokee.model.internal.names.QualifyingName
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -161,5 +162,11 @@ class TaskNameTest extends Specification {
 	def "can create task name string using verb and object directly"() {
 		expect:
 		TaskName.taskName('foo', 'bar') == 'fooBar'
+	}
+
+	def "does not capitalize qualifying name on lifecycle tasks"() {
+		expect:
+		TaskName.lifecycle().toQualifiedName(QualifyingName.of('test')) == 'test'
+		TaskName.lifecycle().toQualifiedName(QualifyingName.of('Test')) == 'Test'
 	}
 }

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/project/PBXObjectCoders.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/project/PBXObjectCoders.java
@@ -47,6 +47,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import static com.google.common.collect.Streams.stream;
 import static dev.nokee.xcode.objects.configuration.XCConfigurationList.DefaultConfigurationVisibility.HIDDEN;
@@ -157,7 +159,7 @@ final class PBXObjectCoders {
 			val builder = PBXFileReference.builder();
 			decoder.decodeStringIfPresent("name", builder::name);
 			decoder.decodeStringIfPresent("path", builder::path);
-			decoder.decodeStringIfPresent("sourceTree", it -> builder.sourceTree(PBXSourceTree.of(it).orElseThrow(RuntimeException::new)));
+			decoder.decodeStringIfPresent("sourceTree", it -> builder.sourceTree(PBXSourceTree.of(it).orElseThrow(newUnknownSourceTreeException(it))));
 			return builder.build();
 		}
 
@@ -183,7 +185,7 @@ final class PBXObjectCoders {
 			val builder = PBXGroup.builder();
 			decoder.decodeStringIfPresent("name", builder::name);
 			decoder.decodeStringIfPresent("path", builder::path);
-			decoder.decodeStringIfPresent("sourceTree", it -> builder.sourceTree(PBXSourceTree.of(it).orElseThrow(RuntimeException::new)));
+			decoder.decodeStringIfPresent("sourceTree", it -> builder.sourceTree(PBXSourceTree.of(it).orElseThrow(newUnknownSourceTreeException(it))));
 			decoder.decodeObjectsIfPresent("children", builder::children);
 			return builder.build();
 		}
@@ -214,7 +216,7 @@ final class PBXObjectCoders {
 			val builder = PBXVariantGroup.builder();
 			decoder.decodeStringIfPresent("name", builder::name);
 			decoder.decodeStringIfPresent("path", builder::path);
-			decoder.decodeStringIfPresent("sourceTree", it -> builder.sourceTree(PBXSourceTree.of(it).orElseThrow(RuntimeException::new)));
+			decoder.decodeStringIfPresent("sourceTree", it -> builder.sourceTree(PBXSourceTree.of(it).orElseThrow(newUnknownSourceTreeException(it))));
 			decoder.decodeObjectsIfPresent("children", builder::children);
 			return builder.build();
 		}
@@ -245,7 +247,7 @@ final class PBXObjectCoders {
 			val builder = XCVersionGroup.builder();
 			decoder.decodeStringIfPresent("name", builder::name);
 			decoder.decodeStringIfPresent("path", builder::path);
-			decoder.decodeStringIfPresent("sourceTree", it -> builder.sourceTree(PBXSourceTree.of(it).orElseThrow(RuntimeException::new)));
+			decoder.decodeStringIfPresent("sourceTree", it -> builder.sourceTree(PBXSourceTree.of(it).orElseThrow(newUnknownSourceTreeException(it))));
 			decoder.decodeObjectsIfPresent("children", builder::children);
 			return builder.build();
 		}
@@ -583,5 +585,9 @@ final class PBXObjectCoders {
 				encoder.encodeMap("settings", value.getSettings());
 			}
 		}
+	}
+
+	private static Supplier<RuntimeException> newUnknownSourceTreeException(String value) {
+		return () -> new RuntimeException(String.format("Unknown sourceTree value '%s'. Supported values are %s", value, Arrays.stream(PBXSourceTree.values()).map(s -> "'" + s + "'").collect(Collectors.joining(", "))));
 	}
 }


### PR DESCRIPTION
It also honours the case of lifecycle tasks and fixes a bug with aggregated target. We improved the exception when deserializing the PBXSourceTree value. 