### PR TITLE
Allow any value for source tree and fix file resolve context

### DIFF
--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeBuildAdapterPlugin.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeBuildAdapterPlugin.java
@@ -216,11 +216,6 @@ class XcodeBuildAdapterPlugin implements Plugin<Settings> {
 											}
 											return null;
 										}).get();
-									case "BUILT_PRODUCT_DIR":
-										// TODO: The following is only an approximation of what the BUILT_PRODUCT_DIR would be, use -showBuildSettings
-										// TODO: Guard against the missing derived data path
-										// TODO: We should map derived data path as a collection of build settings via helper method
-										return task.getDerivedDataPath().dir("Build/Products/" + task.getConfiguration().get() + "-" + task.getSdk().get()).get().getAsFile().toPath();
 									case "SOURCE_ROOT":
 										return reference.getLocation().getParent();
 									default:

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCFileReference.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCFileReference.java
@@ -27,37 +27,25 @@ public abstract class XCFileReference {
 	public abstract XCFileType getType();
 
 	public interface ResolveContext {
-		Path getSourceRoot();
-
 		Path getBuiltProductDirectory();
 
-		Path getSdkRoot();
-
-		Path getDeveloperDirectory();
+		Path get(String name);
 	}
 
 	public enum XCFileType {
-		ABSOLUTE, SOURCE_ROOT, BUILT_PRODUCT, SDKROOT, DEVELOPER
+		ABSOLUTE, BUILT_PRODUCT, BUILD_SETTING
 	}
 
 	public static XCFileReference absoluteFile(String path) {
 		return new AbsoluteFileReference(Objects.requireNonNull(path));
 	}
 
-	public static XCFileReference sourceRoot(String path) {
-		return new SourceRootFileReference(Objects.requireNonNull(path));
-	}
-
 	public static XCFileReference builtProduct(String path) {
 		return new BuiltProductReference(Objects.requireNonNull(path));
 	}
 
-	public static XCFileReference sdkRoot(String path) {
-		return new SdkRootFileReference(Objects.requireNonNull(path));
-	}
-
-	public static XCFileReference developer(String path) {
-		return new DeveloperFileReference(Objects.requireNonNull(path));
+	public static XCFileReference fromBuildSetting(String buildSetting, String path) {
+		return new BuildSettingFileReference(Objects.requireNonNull(buildSetting), Objects.requireNonNull(path));
 	}
 
 	@EqualsAndHashCode(callSuper = false)
@@ -81,54 +69,6 @@ public abstract class XCFileReference {
 		@Override
 		public String toString() {
 			return path.toString();
-		}
-	}
-
-	@EqualsAndHashCode(callSuper = false)
-	private static final class SourceRootFileReference extends XCFileReference {
-		private final String path;
-
-		private SourceRootFileReference(String path) {
-			this.path = path;
-		}
-
-		@Override
-		public Path resolve(ResolveContext context) {
-			return context.getSourceRoot().resolve(path);
-		}
-
-		@Override
-		public XCFileType getType() {
-			return XCFileType.SOURCE_ROOT;
-		}
-
-		@Override
-		public String toString() {
-			return "$(SOURCE_ROOT)/" + path;
-		}
-	}
-
-	@EqualsAndHashCode(callSuper = false)
-	private static final class SdkRootFileReference extends XCFileReference {
-		private final String path;
-
-		private SdkRootFileReference(String path) {
-			this.path = path;
-		}
-
-		@Override
-		public Path resolve(ResolveContext context) {
-			return context.getSdkRoot().resolve(path);
-		}
-
-		@Override
-		public XCFileType getType() {
-			return XCFileType.SDKROOT;
-		}
-
-		@Override
-		public String toString() {
-			return "$(SDKROOT)/" + path;
 		}
 	}
 
@@ -157,26 +97,28 @@ public abstract class XCFileReference {
 	}
 
 	@EqualsAndHashCode(callSuper = false)
-	private static final class DeveloperFileReference extends XCFileReference {
+	private static final class BuildSettingFileReference extends XCFileReference {
+		private String buildSetting;
 		private final String path;
 
-		private DeveloperFileReference(String path) {
+		private BuildSettingFileReference(String buildSetting, String path) {
+			this.buildSetting = buildSetting;
 			this.path = path;
 		}
 
 		@Override
 		public Path resolve(ResolveContext context) {
-			return context.getDeveloperDirectory().resolve(path);
+			return context.get(buildSetting).resolve(path);
 		}
 
 		@Override
 		public XCFileType getType() {
-			return XCFileType.DEVELOPER;
+			return XCFileType.BUILD_SETTING;
 		}
 
 		@Override
 		public String toString() {
-			return "$(DEVELOPER_DIR)/" + path;
+			return "$(" + buildSetting + ")/" + path;
 		}
 	}
 }

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCTargetReference.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCTargetReference.java
@@ -36,9 +36,7 @@ import java.util.stream.Stream;
 
 import static dev.nokee.xcode.objects.files.PBXSourceTree.ABSOLUTE;
 import static dev.nokee.xcode.objects.files.PBXSourceTree.BUILT_PRODUCTS_DIR;
-import static dev.nokee.xcode.objects.files.PBXSourceTree.DEVELOPER_DIR;
 import static dev.nokee.xcode.objects.files.PBXSourceTree.GROUP;
-import static dev.nokee.xcode.objects.files.PBXSourceTree.SDKROOT;
 import static dev.nokee.xcode.objects.files.PBXSourceTree.SOURCE_ROOT;
 
 @EqualsAndHashCode
@@ -140,14 +138,8 @@ public final class XCTargetReference implements Serializable {
 				return XCFileReference.absoluteFile(path);
 			} else if (BUILT_PRODUCTS_DIR.equals(node.sourceTree)) {
 				return XCFileReference.builtProduct(path);
-			} else if (SOURCE_ROOT.equals(node.sourceTree)) {
-				return XCFileReference.sourceRoot(path);
-			} else if (SDKROOT.equals(node.sourceTree)) {
-				return XCFileReference.sdkRoot(path);
-			} else if (DEVELOPER_DIR.equals(node.sourceTree)) {
-				return XCFileReference.developer(path);
 			} else {
-				throw new UnsupportedOperationException("Source tree not supported! (" + node.sourceTree + ")");
+				return XCFileReference.fromBuildSetting(node.sourceTree.toString(), path);
 			}
 		} while ((node = node.previous) != null);
 

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCTargetReference.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCTargetReference.java
@@ -34,6 +34,11 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static dev.nokee.xcode.objects.files.PBXSourceTree.ABSOLUTE;
+import static dev.nokee.xcode.objects.files.PBXSourceTree.BUILT_PRODUCTS_DIR;
+import static dev.nokee.xcode.objects.files.PBXSourceTree.DEVELOPER_DIR;
+import static dev.nokee.xcode.objects.files.PBXSourceTree.GROUP;
+import static dev.nokee.xcode.objects.files.PBXSourceTree.SDKROOT;
 import static dev.nokee.xcode.objects.files.PBXSourceTree.SOURCE_ROOT;
 
 @EqualsAndHashCode
@@ -129,14 +134,20 @@ public final class XCTargetReference implements Serializable {
 				}
 			}
 
-			switch (node.sourceTree) {
-				case GROUP: break; // continue looping
-				case ABSOLUTE: return XCFileReference.absoluteFile(path);
-				case BUILT_PRODUCTS_DIR: return XCFileReference.builtProduct(path);
-				case SOURCE_ROOT: return XCFileReference.sourceRoot(path);
-				case SDKROOT: return XCFileReference.sdkRoot(path);
-				case DEVELOPER_DIR: return XCFileReference.developer(path);
-				default: throw new UnsupportedOperationException("Source tree not supported! (" + node.sourceTree + ")");
+			if (GROUP.equals(node.sourceTree)) {
+				// continue looping
+			} else if (ABSOLUTE.equals(node.sourceTree)) {
+				return XCFileReference.absoluteFile(path);
+			} else if (BUILT_PRODUCTS_DIR.equals(node.sourceTree)) {
+				return XCFileReference.builtProduct(path);
+			} else if (SOURCE_ROOT.equals(node.sourceTree)) {
+				return XCFileReference.sourceRoot(path);
+			} else if (SDKROOT.equals(node.sourceTree)) {
+				return XCFileReference.sdkRoot(path);
+			} else if (DEVELOPER_DIR.equals(node.sourceTree)) {
+				return XCFileReference.developer(path);
+			} else {
+				throw new UnsupportedOperationException("Source tree not supported! (" + node.sourceTree + ")");
 			}
 		} while ((node = node.previous) != null);
 

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/configuration/XCBuildConfiguration.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/configuration/XCBuildConfiguration.java
@@ -15,15 +15,27 @@
  */
 package dev.nokee.xcode.objects.configuration;
 
+import dev.nokee.xcode.objects.files.PBXFileReference;
+
+import javax.annotation.Nullable;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 /**
  * Build configuration containing a file reference to a xcconfig file and additional inline settings.
  */
 public final class XCBuildConfiguration extends PBXBuildStyle {
-	private XCBuildConfiguration(String name, BuildSettings buildSettings) {
+	@Nullable
+	private PBXFileReference baseConfigurationReference;
+
+	private XCBuildConfiguration(String name, BuildSettings buildSettings, @Nullable PBXFileReference baseConfigurationReference) {
 		super(name, buildSettings);
+		this.baseConfigurationReference = baseConfigurationReference;
+	}
+
+	public Optional<PBXFileReference> getBaseConfigurationReference() {
+		return Optional.ofNullable(baseConfigurationReference);
 	}
 
 	public static Builder builder() {
@@ -33,6 +45,7 @@ public final class XCBuildConfiguration extends PBXBuildStyle {
 	public static final class Builder {
 		private String name;
 		private BuildSettings buildSettings;
+		private PBXFileReference baseConfigurationReference;
 
 		private Builder() {}
 
@@ -48,6 +61,11 @@ public final class XCBuildConfiguration extends PBXBuildStyle {
 			return this;
 		}
 
+		public Builder baseConfigurationReference(PBXFileReference baseConfigurationReference) {
+			this.baseConfigurationReference = baseConfigurationReference;
+			return this;
+		}
+
 		public Builder buildSettings(BuildSettings buildSettings) {
 			this.buildSettings = Objects.requireNonNull(buildSettings);
 			return this;
@@ -58,7 +76,7 @@ public final class XCBuildConfiguration extends PBXBuildStyle {
 				buildSettings = BuildSettings.empty();
 			}
 
-			return new XCBuildConfiguration(Objects.requireNonNull(name, "'name' must not be null"), buildSettings);
+			return new XCBuildConfiguration(Objects.requireNonNull(name, "'name' must not be null"), buildSettings, baseConfigurationReference);
 		}
 	}
 }

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/files/PBXSourceTree.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/files/PBXSourceTree.java
@@ -16,48 +16,52 @@
 package dev.nokee.xcode.objects.files;
 
 import com.google.common.base.CharMatcher;
+import lombok.EqualsAndHashCode;
 
-import java.util.Arrays;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * Represents the "Location" dropdown in Xcode's File Inspector.
  */
-public enum PBXSourceTree {
+@EqualsAndHashCode
+public final class PBXSourceTree {
+	private static final ConcurrentMap<String, PBXSourceTree> knownValues = new ConcurrentHashMap<>();
+
 	/**
 	 * Relative to the path of the group containing this.
 	 */
-	GROUP("<group>"),
+	public static final PBXSourceTree GROUP = of("<group>");
 
 	/**
 	 * Absolute system path.
 	 */
-	ABSOLUTE("<absolute>"),
+	public static final PBXSourceTree ABSOLUTE = of("<absolute>");
 	/**
 	 * Relative to the build setting {@code BUILT_PRODUCTS_DIR}.
 	 */
-	BUILT_PRODUCTS_DIR("BUILT_PRODUCTS_DIR"),
+	public static final PBXSourceTree BUILT_PRODUCTS_DIR = of("BUILT_PRODUCTS_DIR");
 
 	/**
 	 * Relative to the build setting {@code SDKROOT}.
 	 */
-	SDKROOT("SDKROOT"),
+	public static final PBXSourceTree SDKROOT = of("SDKROOT");
 
 	/**
 	 * Relative to the directory containing the project file {@code SOURCE_ROOT}.
 	 */
-	SOURCE_ROOT("SOURCE_ROOT"),
+	public static final PBXSourceTree SOURCE_ROOT = of("SOURCE_ROOT");
 
 	/**
 	 * Relative to the Developer content directory inside the Xcode application
 	 * (e.g. {@code /Applications/Xcode.app/Contents/Developer}).
 	 */
-	DEVELOPER_DIR("DEVELOPER_DIR"),
-	;
+	public static final PBXSourceTree DEVELOPER_DIR = of("DEVELOPER_DIR");
 
 	private final String rep;
 
-	PBXSourceTree(String str) {
+	private PBXSourceTree(String str) {
 		rep = str;
 	}
 
@@ -85,9 +89,8 @@ public enum PBXSourceTree {
 		}
 	}
 
-	// FIXME
-	public static Optional<PBXSourceTree> of(String name) {
-		return Arrays.stream(values()).filter(it -> it.rep.equals(name)).findFirst();
+	public static PBXSourceTree of(String name) {
+		return knownValues.computeIfAbsent(name, PBXSourceTree::new);
 	}
 
 	@Override

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/project/PBXObjectCoders.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/project/PBXObjectCoders.java
@@ -47,8 +47,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import static com.google.common.collect.Streams.stream;
 import static dev.nokee.xcode.objects.configuration.XCConfigurationList.DefaultConfigurationVisibility.HIDDEN;
@@ -159,7 +157,7 @@ final class PBXObjectCoders {
 			val builder = PBXFileReference.builder();
 			decoder.decodeStringIfPresent("name", builder::name);
 			decoder.decodeStringIfPresent("path", builder::path);
-			decoder.decodeStringIfPresent("sourceTree", it -> builder.sourceTree(PBXSourceTree.of(it).orElseThrow(newUnknownSourceTreeException(it))));
+			decoder.decodeStringIfPresent("sourceTree", it -> builder.sourceTree(PBXSourceTree.of(it)));
 			return builder.build();
 		}
 
@@ -185,7 +183,7 @@ final class PBXObjectCoders {
 			val builder = PBXGroup.builder();
 			decoder.decodeStringIfPresent("name", builder::name);
 			decoder.decodeStringIfPresent("path", builder::path);
-			decoder.decodeStringIfPresent("sourceTree", it -> builder.sourceTree(PBXSourceTree.of(it).orElseThrow(newUnknownSourceTreeException(it))));
+			decoder.decodeStringIfPresent("sourceTree", it -> builder.sourceTree(PBXSourceTree.of(it)));
 			decoder.decodeObjectsIfPresent("children", builder::children);
 			return builder.build();
 		}
@@ -216,7 +214,7 @@ final class PBXObjectCoders {
 			val builder = PBXVariantGroup.builder();
 			decoder.decodeStringIfPresent("name", builder::name);
 			decoder.decodeStringIfPresent("path", builder::path);
-			decoder.decodeStringIfPresent("sourceTree", it -> builder.sourceTree(PBXSourceTree.of(it).orElseThrow(newUnknownSourceTreeException(it))));
+			decoder.decodeStringIfPresent("sourceTree", it -> builder.sourceTree(PBXSourceTree.of(it)));
 			decoder.decodeObjectsIfPresent("children", builder::children);
 			return builder.build();
 		}
@@ -247,7 +245,7 @@ final class PBXObjectCoders {
 			val builder = XCVersionGroup.builder();
 			decoder.decodeStringIfPresent("name", builder::name);
 			decoder.decodeStringIfPresent("path", builder::path);
-			decoder.decodeStringIfPresent("sourceTree", it -> builder.sourceTree(PBXSourceTree.of(it).orElseThrow(newUnknownSourceTreeException(it))));
+			decoder.decodeStringIfPresent("sourceTree", it -> builder.sourceTree(PBXSourceTree.of(it)));
 			decoder.decodeObjectsIfPresent("children", builder::children);
 			return builder.build();
 		}
@@ -585,9 +583,5 @@ final class PBXObjectCoders {
 				encoder.encodeMap("settings", value.getSettings());
 			}
 		}
-	}
-
-	private static Supplier<RuntimeException> newUnknownSourceTreeException(String value) {
-		return () -> new RuntimeException(String.format("Unknown sourceTree value '%s'. Supported values are %s", value, Arrays.stream(PBXSourceTree.values()).map(s -> "'" + s + "'").collect(Collectors.joining(", "))));
 	}
 }

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/project/PBXObjectCoders.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/project/PBXObjectCoders.java
@@ -439,6 +439,7 @@ final class PBXObjectCoders {
 			val builder = XCBuildConfiguration.builder();
 			decoder.decodeStringIfPresent("name", builder::name);
 			decoder.decodeMapIfPresent("buildSettings", it -> builder.buildSettings(BuildSettings.of(it)));
+			decoder.decodeObjectIfPresent("baseConfigurationReference", builder::baseConfigurationReference);
 			return builder.build();
 		}
 

--- a/subprojects/xcode-ide-kit/src/test/java/dev/nokee/xcode/objects/files/PBXSourceTreeTest.java
+++ b/subprojects/xcode-ide-kit/src/test/java/dev/nokee/xcode/objects/files/PBXSourceTreeTest.java
@@ -15,39 +15,61 @@
  */
 package dev.nokee.xcode.objects.files;
 
+import com.google.common.testing.EqualsTester;
 import org.junit.jupiter.api.Test;
 
+import static dev.nokee.xcode.objects.files.PBXSourceTree.ABSOLUTE;
+import static dev.nokee.xcode.objects.files.PBXSourceTree.BUILT_PRODUCTS_DIR;
+import static dev.nokee.xcode.objects.files.PBXSourceTree.DEVELOPER_DIR;
+import static dev.nokee.xcode.objects.files.PBXSourceTree.GROUP;
+import static dev.nokee.xcode.objects.files.PBXSourceTree.SDKROOT;
+import static dev.nokee.xcode.objects.files.PBXSourceTree.SOURCE_ROOT;
+import static dev.nokee.xcode.objects.files.PBXSourceTree.of;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasToString;
 
 class PBXSourceTreeTest {
 	@Test
 	void hasGroupSourceTree() {
-		assertThat(PBXSourceTree.GROUP, hasToString("<group>"));
+		assertThat(GROUP, hasToString("<group>"));
 	}
 
 	@Test
 	void hasAbsoluteSourceTree() {
-		assertThat(PBXSourceTree.ABSOLUTE, hasToString("<absolute>"));
+		assertThat(ABSOLUTE, hasToString("<absolute>"));
 	}
 
 	@Test
 	void hasBuiltProductDirSourceTree() {
-		assertThat(PBXSourceTree.BUILT_PRODUCTS_DIR, hasToString("BUILT_PRODUCTS_DIR"));
+		assertThat(BUILT_PRODUCTS_DIR, hasToString("BUILT_PRODUCTS_DIR"));
 	}
 
 	@Test
 	void hasSdkRootSourceTree() {
-		assertThat(PBXSourceTree.SDKROOT, hasToString("SDKROOT"));
+		assertThat(SDKROOT, hasToString("SDKROOT"));
 	}
 
 	@Test
 	void hasSourceRootSourceTree() {
-		assertThat(PBXSourceTree.SOURCE_ROOT, hasToString("SOURCE_ROOT"));
+		assertThat(SOURCE_ROOT, hasToString("SOURCE_ROOT"));
 	}
 
 	@Test
 	void hasDeveloperDirSourceTree() {
-		assertThat(PBXSourceTree.DEVELOPER_DIR, hasToString("DEVELOPER_DIR"));
+		assertThat(DEVELOPER_DIR, hasToString("DEVELOPER_DIR"));
+	}
+
+	@Test
+	@SuppressWarnings("UnstableApiUsage")
+	void checkEquals() {
+		new EqualsTester()
+			.addEqualityGroup(GROUP, of("<group>"))
+			.addEqualityGroup(ABSOLUTE, of("<absolute>"))
+			.addEqualityGroup(BUILT_PRODUCTS_DIR, of("BUILT_PRODUCTS_DIR"))
+			.addEqualityGroup(SDKROOT, of("SDKROOT"))
+			.addEqualityGroup(SOURCE_ROOT, of("SOURCE_ROOT"))
+			.addEqualityGroup(DEVELOPER_DIR, of("DEVELOPER_DIR"))
+			.addEqualityGroup(of("FOO"), of("FOO"))
+			.testEquals();
 	}
 }


### PR DESCRIPTION
This PR still misses proper handling of build settings which need to be loaded from `pbxproj` before files are correctly resolved.

Fixes https://github.com/nokeedev/gradle-native/issues/701
Fixes https://github.com/nokeedev/gradle-native/issues/702