### PR TITLE
Support building using JDK 11 LTS

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ systemProp.org.gradle.internal.repository.initial.backoff=500
 
 systemProp.dev.gradleplugins.internal.use-text-resource=true
 
-lombokVersion=1.18.22
+lombokVersion=1.18.24
 minimumGradleVersion=6.2.1
 toolboxVersion=1.6.8
 guavaVersion=31.0.1-jre

--- a/gradle/libraries/gradle-build-script/build.gradle
+++ b/gradle/libraries/gradle-build-script/build.gradle
@@ -8,8 +8,8 @@ java {
 }
 
 dependencies {
-	annotationProcessor 'org.projectlombok:lombok:1.18.12'
-	compileOnly 'org.projectlombok:lombok:1.18.12'
+	annotationProcessor 'org.projectlombok:lombok:1.18.24'
+	compileOnly 'org.projectlombok:lombok:1.18.24'
 
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.0'
 	testImplementation 'org.mockito:mockito-core:3.6.0'

--- a/gradle/plugins/documentation-kit-plugins/dsl/build.gradle
+++ b/gradle/plugins/documentation-kit-plugins/dsl/build.gradle
@@ -13,8 +13,8 @@ dependencies {
 	implementation 'org.apache.commons:commons-lang3:3.12.0'
 	implementation 'com.google.guava:guava:31.0.1-jre'
 	api 'com.github.javaparser:javaparser-core:3.15.18'
-	annotationProcessor 'org.projectlombok:lombok:1.18.12'
-	compileOnly 'org.projectlombok:lombok:1.18.12'
+	annotationProcessor 'org.projectlombok:lombok:1.18.24'
+	compileOnly 'org.projectlombok:lombok:1.18.24'
 
 	testImplementation 'org.codehaus.groovy:groovy:3.0.10'
 	testImplementation platform('org.spockframework:spock-bom:2.1-groovy-3.0')

--- a/subprojects/core-utils/src/main/java/dev/nokee/utils/TransformerUtils.java
+++ b/subprojects/core-utils/src/main/java/dev/nokee/utils/TransformerUtils.java
@@ -66,7 +66,7 @@ public final class TransformerUtils {
 		return transformer == NoOpTransformer.INSTANCE || transformer.equals(Transformers.noOpTransformer());
 	}
 
-	public static <OUT, IN extends OUT, T extends Iterable<? extends IN>> Transformer<List<OUT>, T> toListTransformer() {
+	public static <OUT, IN extends OUT, T extends Iterable<IN>> Transformer<List<OUT>, T> toListTransformer() {
 		return ToListTransformer.INSTANCE.withNarrowTypes();
 	}
 
@@ -120,7 +120,7 @@ public final class TransformerUtils {
 		}
 	}
 
-	public static <OUT, IN extends OUT, T extends Iterable<? extends IN>> Transformer<Set<OUT>, T> toSetTransformer() {
+	public static <OutputElementType, InputElementType extends OutputElementType, InputType extends Iterable<InputElementType>> Transformer<Set<OutputElementType>, InputType> toSetTransformer() {
 		return ToSetTransformer.INSTANCE.withNarrowTypes();
 	}
 
@@ -203,12 +203,12 @@ public final class TransformerUtils {
 	 * The result will apply a proper flatMap algorithm to the provided collection.
 	 *
 	 * @param mapper  an element mapper
-	 * @param <OUT>  output element type resulting from the transform
-	 * @param <IN>  input element type to transform
-	 * @param <T>  input iterable type
+	 * @param <OutputElementType>>  output element type resulting from the transform
+	 * @param <InputElementType>>  input element type to transform
+	 * @param <InputType>>  input iterable type
 	 * @return a {@link Transformer} instance to flat transform each the element of an iterable, never null.
 	 */
-	public static <OUT, IN, T extends Iterable<? extends IN>> Transformer<Iterable<OUT>, T> flatTransformEach(org.gradle.api.Transformer<? extends Iterable<OUT>, ? super IN> mapper) {
+	public static <OutputElementType, InputElementType, InputType extends Iterable<? extends InputElementType>> Transformer<Iterable<OutputElementType>, InputType> flatTransformEach(org.gradle.api.Transformer<? extends Iterable<OutputElementType>, ? super InputElementType> mapper) {
 		return new FlatTransformEachAdapter<>(mapper);
 	}
 
@@ -241,12 +241,12 @@ public final class TransformerUtils {
 	 * The result will apply a proper map algorithm to the provided collection.
 	 *
 	 * @param mapper  an element mapper
-	 * @param <OUT>  output element type resulting from the transform
-	 * @param <IN>  input element type to transform
-	 * @param <T>  input iterable type
+	 * @param <OutputElementType>  output element type resulting from the transform
+	 * @param <InputElementType>  input element type to transform
+	 * @param <InputType>  input iterable type
 	 * @return a {@link Transformer} instance to transform each the element of an iterable, never null.
 	 */
-	public static <OUT, IN, T extends Iterable<? extends IN>> Transformer<Iterable<OUT>, T> transformEach(org.gradle.api.Transformer<? extends OUT, ? super IN> mapper) {
+	public static <OutputElementType, InputElementType, InputType extends Iterable<InputElementType>> Transformer<Iterable<OutputElementType>, InputType> transformEach(org.gradle.api.Transformer<OutputElementType, InputElementType> mapper) {
 		if (isNoOpTransformer(mapper)) {
 			return NoOpTransformer.INSTANCE.withNarrowTypes();
 		}

--- a/subprojects/core-utils/src/main/java/dev/nokee/utils/TransformerUtils.java
+++ b/subprojects/core-utils/src/main/java/dev/nokee/utils/TransformerUtils.java
@@ -203,9 +203,9 @@ public final class TransformerUtils {
 	 * The result will apply a proper flatMap algorithm to the provided collection.
 	 *
 	 * @param mapper  an element mapper
-	 * @param <OutputElementType>>  output element type resulting from the transform
-	 * @param <InputElementType>>  input element type to transform
-	 * @param <InputType>>  input iterable type
+	 * @param <OutputElementType>  output element type resulting from the transform
+	 * @param <InputElementType>  input element type to transform
+	 * @param <InputType>  input iterable type
 	 * @return a {@link Transformer} instance to flat transform each the element of an iterable, never null.
 	 */
 	public static <OutputElementType, InputElementType, InputType extends Iterable<? extends InputElementType>> Transformer<Iterable<OutputElementType>, InputType> flatTransformEach(org.gradle.api.Transformer<? extends Iterable<OutputElementType>, ? super InputElementType> mapper) {

--- a/subprojects/core-utils/src/test/groovy/dev/nokee/utils/TransformerUtils_FlatTransformEachTest.java
+++ b/subprojects/core-utils/src/test/groovy/dev/nokee/utils/TransformerUtils_FlatTransformEachTest.java
@@ -21,6 +21,8 @@ import com.google.common.testing.EqualsTester;
 import org.gradle.api.Transformer;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -84,16 +86,16 @@ class TransformerUtils_FlatTransformEachTest {
 
 	@Test
 	void canUseFlatTransformEachFromList() {
-		Transformer<Iterable<Integer>, List<? extends Integer>> transformer1 = flatTransformEach(ImmutableList::of);
+		Transformer<Iterable<Integer>, List<Integer>> transformer1 = flatTransformEach(ImmutableList::of);
 		assertThat(transformer1.transform(asList(1, 2, 3)), iterableWithSize(3));
 
 		Transformer<Iterable<Integer>, List<Integer>> transformer2 = flatTransformEach(ImmutableList::of);
-		assertThat(transformer2.transform(asList(1, 2, 3)), iterableWithSize(3));
+		assertThat(transformer2.transform(new ArrayList<>(asList(1, 2, 3))), iterableWithSize(3));
 	}
 
 	@Test
 	void canUseFlatTransformEachFromIterable() {
-		Transformer<Iterable<Integer>, Iterable<? extends Integer>> transformer1 = flatTransformEach(ImmutableList::of);
+		Transformer<Iterable<Integer>, Iterable<Integer>> transformer1 = flatTransformEach(ImmutableList::of);
 		assertThat(transformer1.transform(asList(1, 2, 3)), iterableWithSize(3));
 
 		Transformer<Iterable<Integer>, Iterable<Integer>> transformer2 = flatTransformEach(ImmutableList::of);
@@ -102,8 +104,8 @@ class TransformerUtils_FlatTransformEachTest {
 
 	@Test
 	void canUseFlatTransformEachFromSet() {
-		Transformer<Iterable<Integer>, Set<? extends Integer>> transformer1 = flatTransformEach(ImmutableList::of);
-		assertThat(transformer1.transform(ImmutableSet.of(1, 2, 3)), iterableWithSize(3));
+		Transformer<Iterable<Integer>, Set<Integer>> transformer1 = flatTransformEach(ImmutableList::of);
+		assertThat(transformer1.transform(new HashSet<>(ImmutableSet.of(1, 2, 3))), iterableWithSize(3));
 
 		Transformer<Iterable<Integer>, Set<Integer>> transformer2 = flatTransformEach(ImmutableList::of);
 		assertThat(transformer2.transform(ImmutableSet.of(1, 2, 3)), iterableWithSize(3));

--- a/subprojects/core-utils/src/test/groovy/dev/nokee/utils/TransformerUtils_ToListTransformerTest.java
+++ b/subprojects/core-utils/src/test/groovy/dev/nokee/utils/TransformerUtils_ToListTransformerTest.java
@@ -87,36 +87,24 @@ class TransformerUtils_ToListTransformerTest {
 
 	@Test
 	void canUseToListTransformerForSameElementTypes() {
-		Transformer<List<String>, Iterable<? extends String>> transformer1 = toListTransformer();
-		Transformer<List<String>, List<? extends String>> transformer2 = toListTransformer();
-		Transformer<List<String>, Set<? extends String>> transformer3 = toListTransformer();
-		Transformer<List<String>, Iterable<String>> transformer4 = toListTransformer();
-		Transformer<List<String>, List<String>> transformer5 = toListTransformer();
-		Transformer<List<String>, Set<String>> transformer6 = toListTransformer();
+		Transformer<List<String>, Iterable<String>> transformer1 = toListTransformer();
+		Transformer<List<String>, List<String>> transformer2 = toListTransformer();
+		Transformer<List<String>, Set<String>> transformer3 = toListTransformer();
 
 		assertThat(transformer1.transform(asList("1", "2")), iterableWithSize(2));
 		assertThat(transformer2.transform(asList("1", "2")), iterableWithSize(2));
 		assertThat(transformer3.transform(of("1", "2")), iterableWithSize(2));
-		assertThat(transformer4.transform(asList("1", "2")), iterableWithSize(2));
-		assertThat(transformer5.transform(asList("1", "2")), iterableWithSize(2));
-		assertThat(transformer6.transform(of("1", "2")), iterableWithSize(2));
 	}
 
 	@Test
 	void canUseToListTransformerForSuperElementTypes() {
-		Transformer<List<Object>, Iterable<? extends String>> transformer1 = toListTransformer();
-		Transformer<List<Object>, List<? extends String>> transformer2 = toListTransformer();
-		Transformer<List<Object>, Set<? extends String>> transformer3 = toListTransformer();
-		Transformer<List<Object>, Iterable<String>> transformer4 = toListTransformer();
-		Transformer<List<Object>, List<String>> transformer5 = toListTransformer();
-		Transformer<List<Object>, Set<String>> transformer6 = toListTransformer();
+		Transformer<List<Object>, Iterable<String>> transformer1 = toListTransformer();
+		Transformer<List<Object>, List<String>> transformer2 = toListTransformer();
+		Transformer<List<Object>, Set<String>> transformer3 = toListTransformer();
 
 		assertThat(transformer1.transform(asList("1", "2")), iterableWithSize(2));
 		assertThat(transformer2.transform(asList("1", "2")), iterableWithSize(2));
 		assertThat(transformer3.transform(of("1", "2")), iterableWithSize(2));
-		assertThat(transformer4.transform(asList("1", "2")), iterableWithSize(2));
-		assertThat(transformer5.transform(asList("1", "2")), iterableWithSize(2));
-		assertThat(transformer6.transform(of("1", "2")), iterableWithSize(2));
 	}
 
 	@Test

--- a/subprojects/core-utils/src/test/groovy/dev/nokee/utils/TransformerUtils_ToSetTransformerTest.java
+++ b/subprojects/core-utils/src/test/groovy/dev/nokee/utils/TransformerUtils_ToSetTransformerTest.java
@@ -86,36 +86,24 @@ class TransformerUtils_ToSetTransformerTest {
 
 	@Test
 	void canUseToSetTransformerForSameElementTypes() {
-		Transformer<Set<String>, Iterable<? extends String>> transformer1 = toSetTransformer();
-		Transformer<Set<String>, List<? extends String>> transformer2 = toSetTransformer();
-		Transformer<Set<String>, Set<? extends String>> transformer3 = toSetTransformer();
-		Transformer<Set<String>, Iterable<String>> transformer4 = toSetTransformer();
-		Transformer<Set<String>, List<String>> transformer5 = toSetTransformer();
-		Transformer<Set<String>, Set<String>> transformer6 = toSetTransformer();
+		Transformer<Set<String>, Iterable<String>> transformer1 = toSetTransformer();
+		Transformer<Set<String>, List<String>> transformer2 = toSetTransformer();
+		Transformer<Set<String>, Set<String>> transformer3 = toSetTransformer();
 
 		assertThat(transformer1.transform(asList("1", "2")), iterableWithSize(2));
 		assertThat(transformer2.transform(asList("1", "2")), iterableWithSize(2));
 		assertThat(transformer3.transform(of("1", "2")), iterableWithSize(2));
-		assertThat(transformer4.transform(asList("1", "2")), iterableWithSize(2));
-		assertThat(transformer5.transform(asList("1", "2")), iterableWithSize(2));
-		assertThat(transformer6.transform(of("1", "2")), iterableWithSize(2));
 	}
 
 	@Test
 	void canUseToSetTransformerForSuperElementTypes() {
-		Transformer<Set<Object>, Iterable<? extends String>> transformer1 = toSetTransformer();
-		Transformer<Set<Object>, List<? extends String>> transformer2 = toSetTransformer();
-		Transformer<Set<Object>, Set<? extends String>> transformer3 = toSetTransformer();
-		Transformer<Set<Object>, Iterable<String>> transformer4 = toSetTransformer();
-		Transformer<Set<Object>, List<String>> transformer5 = toSetTransformer();
-		Transformer<Set<Object>, Set<String>> transformer6 = toSetTransformer();
+		Transformer<Set<Object>, Iterable<String>> transformer1 = toSetTransformer();
+		Transformer<Set<Object>, List<String>> transformer2 = toSetTransformer();
+		Transformer<Set<Object>, Set<String>> transformer3 = toSetTransformer();
 
 		assertThat(transformer1.transform(asList("1", "2")), iterableWithSize(2));
 		assertThat(transformer2.transform(asList("1", "2")), iterableWithSize(2));
 		assertThat(transformer3.transform(of("1", "2")), iterableWithSize(2));
-		assertThat(transformer4.transform(asList("1", "2")), iterableWithSize(2));
-		assertThat(transformer5.transform(asList("1", "2")), iterableWithSize(2));
-		assertThat(transformer6.transform(of("1", "2")), iterableWithSize(2));
 	}
 
 	@Test

--- a/subprojects/core-utils/src/test/groovy/dev/nokee/utils/TransformerUtils_TransformEachTest.java
+++ b/subprojects/core-utils/src/test/groovy/dev/nokee/utils/TransformerUtils_TransformEachTest.java
@@ -77,7 +77,7 @@ class TransformerUtils_TransformEachTest {
 
 	@Test
 	void canUseTransformEachFromIterable() {
-		Transformer<Iterable<Integer>, Iterable<? extends Integer>> transformer1 = transformEach(aTransformer());
+		Transformer<Iterable<Integer>, Iterable<Integer>> transformer1 = transformEach(aTransformer());
 		assertThat(transformer1.transform(asList(1, 2, 3)), iterableWithSize(3));
 
 		Transformer<Iterable<Integer>, Iterable<Integer>> transformer2 = transformEach(anotherTransformer());
@@ -86,7 +86,7 @@ class TransformerUtils_TransformEachTest {
 
 	@Test
 	void canUseTransformEachFromList() {
-		Transformer<Iterable<Integer>, List<? extends Integer>> transformer1 = transformEach(aTransformer());
+		Transformer<Iterable<Integer>, List<Integer>> transformer1 = transformEach(aTransformer());
 		assertThat(transformer1.transform(asList(1, 2, 3)), iterableWithSize(3));
 
 		Transformer<Iterable<Integer>, List<Integer>> transformer2 = transformEach(anotherTransformer());
@@ -95,7 +95,7 @@ class TransformerUtils_TransformEachTest {
 
 	@Test
 	void canUseTransformEachFromSet() {
-		Transformer<Iterable<Integer>, Set<? extends Integer>> transformer1 = transformEach(aTransformer());
+		Transformer<Iterable<Integer>, Set<Integer>> transformer1 = transformEach(aTransformer());
 		assertThat(transformer1.transform(ImmutableSet.of(1, 2, 3)), iterableWithSize(3));
 
 		Transformer<Iterable<Integer>, Set<Integer>> transformer2 = transformEach(anotherTransformer());

--- a/subprojects/docs/documentation-kit/gradle.properties
+++ b/subprojects/docs/documentation-kit/gradle.properties
@@ -1,4 +1,4 @@
-lombokVersion=1.18.12
+lombokVersion=1.18.24
 minimumGradleVersion=6.7.1
 toolboxVersion=1.6.8
 guavaVersion=28.2-jre

--- a/subprojects/gradle-shim/src/test/java/dev/nokee/gradle/internal/util/ClassTestUtils.java
+++ b/subprojects/gradle-shim/src/test/java/dev/nokee/gradle/internal/util/ClassTestUtils.java
@@ -64,7 +64,7 @@ public final class ClassTestUtils {
 			return Object.class;
 		} else if (type.getSimpleName().equals("ExecutionTimeValue")) {
 			try {
-				return Class.forName("org.gradle.api.internal.provider.ValueSupplier$MissingExecutionTimeValue").newInstance();
+				return Class.forName("org.gradle.api.internal.provider.ValueSupplier$MissingExecutionTimeValue").getConstructor().newInstance();
 			} catch (Throwable ex) {
 				return null;
 			}

--- a/subprojects/ide-visual-studio/src/main/java/dev/nokee/ide/visualstudio/internal/rules/CreateNativeComponentVisualStudioIdeProject.java
+++ b/subprojects/ide-visual-studio/src/main/java/dev/nokee/ide/visualstudio/internal/rules/CreateNativeComponentVisualStudioIdeProject.java
@@ -111,8 +111,9 @@ public final class CreateNativeComponentVisualStudioIdeProject implements Action
 				return sourceViewOf(component).getElements().map(transformEach(LanguageSourceSet::getAsFileTree).andThen(toListTransformer()));
 			}
 
-			private Provider<List<? extends FileTree>> componentHeaders(BaseComponent<?> component) {
-				return sourceViewOf(component).filter(this::forHeaderSets).map(transformEach(it -> ((HasHeaders) it).getHeaders().getAsFileTree()).andThen(toListTransformer()));
+			private Provider<List<FileTree>> componentHeaders(BaseComponent<?> component) {
+				return sourceViewOf(component).filter(this::forHeaderSets)
+					.map(transformEach((Transformer<FileTree, LanguageSourceSet>) it -> ((HasHeaders) it).getHeaders().getAsFileTree()).andThen(toListTransformer()));
 			}
 
 			private boolean forHeaderSets(LanguageSourceSet sourceSet) {

--- a/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/ConfigurationMatchers.java
+++ b/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/ConfigurationMatchers.java
@@ -176,7 +176,7 @@ public final class ConfigurationMatchers {
 	 * @param matcher  matcher for all of the configuration's attributes, must not be null
 	 * @return a configuration matcher for its attributes, never null
 	 */
-	public static Matcher<HasAttributes> attributes(Matcher<? super Map<? extends Attribute<?>, ?>> matcher) {
+	public static Matcher<HasAttributes> attributes(Matcher<? super Map<Attribute<?>, ?>> matcher) {
 		return new FeatureMatcher<HasAttributes, Map<Attribute<?>, ?>>(matcher, "a configuration with attribute", "attributes") {
 			@Override
 			protected Map<Attribute<?>, ?> featureValueOf(HasAttributes actual) {

--- a/subprojects/language-native/src/main/java/dev/nokee/language/nativebase/internal/HeaderSearchPathsConfigurationRegistrationAction.java
+++ b/subprojects/language-native/src/main/java/dev/nokee/language/nativebase/internal/HeaderSearchPathsConfigurationRegistrationAction.java
@@ -70,7 +70,7 @@ public final class HeaderSearchPathsConfigurationRegistrationAction extends Mode
 		return configureAttributes(builder -> builder.usage(objects.named(Usage.class, Usage.C_PLUS_PLUS_API)));
 	}
 
-	private static Transformer<Set<Path>, Iterable<? extends Path>> parentFiles() {
+	private static Transformer<Set<Path>, Iterable<Path>> parentFiles() {
 		return transformEach(Path::getParent).andThen(toSetTransformer(Path.class));
 	}
 

--- a/subprojects/language-swift/src/main/java/dev/nokee/language/swift/internal/plugins/ImportModulesConfigurationRegistrationAction.java
+++ b/subprojects/language-swift/src/main/java/dev/nokee/language/swift/internal/plugins/ImportModulesConfigurationRegistrationAction.java
@@ -70,7 +70,7 @@ final class ImportModulesConfigurationRegistrationAction extends ModelActionWith
 		return configureAttributes(builder -> builder.usage(objects.named(Usage.class, Usage.SWIFT_API)));
 	}
 
-	private static Transformer<Set<Path>, Iterable<? extends Path>> parentFiles() {
+	private static Transformer<Set<Path>, Iterable<Path>> parentFiles() {
 		return transformEach(Path::getParent).andThen(toSetTransformer(Path.class));
 	}
 

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ViewAdapter.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ViewAdapter.java
@@ -31,7 +31,10 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
-import static dev.nokee.utils.TransformerUtils.*;
+import static dev.nokee.utils.TransformerUtils.flatTransformEach;
+import static dev.nokee.utils.TransformerUtils.matching;
+import static dev.nokee.utils.TransformerUtils.toListTransformer;
+import static dev.nokee.utils.TransformerUtils.transformEach;
 
 @EqualsAndHashCode
 public final class ViewAdapter<T> implements View<T> {
@@ -91,7 +94,7 @@ public final class ViewAdapter<T> implements View<T> {
 
 	@Override
 	public <S> Provider<List<S>> map(Transformer<? extends S, ? super T> mapper) {
-		return getElements().map(transformEach(mapper).andThen(toListTransformer()));
+		return getElements().map(transformEach((T it) -> mapper.transform(it)).andThen(toListTransformer()));
 	}
 
 	@Override


### PR DESCRIPTION
As part of the modernization of our build, we want to use the latest JDK LTS to build against our lowest supported JDK (8 at the moment). We also want to build tests using the latest JDK LTS, as those don't need to be JDK 8 compatible. As a first step, we experimented with building using JDK 11, which required several changes. We can't use JDK 17 because of our old Groovy/Spock debt. We will clean that up later.