### PR TITLE
Fix Gradle 7.6 specific errors

### DIFF
--- a/gradle/plugins/nokeebuild-plugins/basics/src/main/java/nokeebuild/util/NokeeVersion.java
+++ b/gradle/plugins/nokeebuild-plugins/basics/src/main/java/nokeebuild/util/NokeeVersion.java
@@ -20,7 +20,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
-import org.gradle.util.VersionNumber;
+import org.gradle.util.internal.VersionNumber;
 
 import javax.inject.Inject;
 import java.time.ZonedDateTime;

--- a/gradle/plugins/nokeebuild-plugins/basics/src/main/java/nokeebuild/util/VersionScheme.java
+++ b/gradle/plugins/nokeebuild-plugins/basics/src/main/java/nokeebuild/util/VersionScheme.java
@@ -15,7 +15,7 @@
  */
 package nokeebuild.util;
 
-import org.gradle.util.VersionNumber;
+import org.gradle.util.internal.VersionNumber;
 
 interface VersionScheme {
 	VersionNumber format(NokeeVersionParameters version);

--- a/gradle/plugins/nokeebuild-plugins/basics/src/main/java/nokeebuild/util/VersionSchemeProvider.java
+++ b/gradle/plugins/nokeebuild-plugins/basics/src/main/java/nokeebuild/util/VersionSchemeProvider.java
@@ -19,7 +19,7 @@ import org.gradle.api.Project;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ValueSource;
 import org.gradle.api.provider.ValueSourceParameters;
-import org.gradle.util.VersionNumber;
+import org.gradle.util.internal.VersionNumber;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;

--- a/subprojects/core-exec/src/main/java/dev/nokee/core/exec/internal/CommandLineToolVersionMetadata.java
+++ b/subprojects/core-exec/src/main/java/dev/nokee/core/exec/internal/CommandLineToolVersionMetadata.java
@@ -16,7 +16,7 @@
 package dev.nokee.core.exec.internal;
 
 import dev.nokee.core.exec.CommandLineToolMetadata;
-import org.gradle.util.VersionNumber;
+import dev.nokee.utils.VersionNumber;
 
 public class CommandLineToolVersionMetadata implements CommandLineToolMetadata {
 	private final VersionNumber version;

--- a/subprojects/core-model/src/main/java/dev/nokee/model/DomainObjectProvider.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/DomainObjectProvider.java
@@ -17,10 +17,10 @@ package dev.nokee.model;
 
 import dev.nokee.model.internal.core.ModelElement;
 import dev.nokee.model.internal.type.ModelType;
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
-import org.gradle.util.ConfigureUtil;
 
 import static java.util.Objects.requireNonNull;
 
@@ -36,7 +36,7 @@ public interface DomainObjectProvider<T> extends KnownDomainObject<T>, ModelElem
 	 */
 	@Override
 	default DomainObjectProvider<T> configure(@DelegatesTo(type = "T", strategy = Closure.DELEGATE_FIRST) @SuppressWarnings("rawtypes") Closure closure) {
-		return configure(ConfigureUtil.configureUsing(requireNonNull(closure)));
+		return configure(ConfigureUtils.configureUsing(requireNonNull(closure)));
 	}
 
 	/**

--- a/subprojects/core-model/src/main/java/dev/nokee/model/KnownDomainObject.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/KnownDomainObject.java
@@ -16,13 +16,13 @@
 package dev.nokee.model;
 
 import dev.nokee.provider.ProviderConvertible;
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Transformer;
 import org.gradle.api.provider.Provider;
-import org.gradle.util.ConfigureUtil;
 
 import static java.util.Objects.requireNonNull;
 
@@ -32,7 +32,7 @@ public interface KnownDomainObject<T> extends ProviderConvertible<T> {
 	Class<T> getType();
 
 	default KnownDomainObject<T> configure(@DelegatesTo(type = "T", strategy = Closure.DELEGATE_FIRST) @SuppressWarnings("rawtypes") Closure closure) {
-		return configure(ConfigureUtil.configureUsing(requireNonNull(closure)));
+		return configure(ConfigureUtils.configureUsing(requireNonNull(closure)));
 	}
 	KnownDomainObject<T> configure(Action<? super T> action);
 

--- a/subprojects/core-utils/src/main/java/dev/nokee/utils/CallableUtils.java
+++ b/subprojects/core-utils/src/main/java/dev/nokee/utils/CallableUtils.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.utils;
+
+import lombok.EqualsAndHashCode;
+import org.apache.commons.lang3.SerializationUtils;
+import org.gradle.internal.UncheckedException;
+
+import javax.annotation.Nullable;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+
+public final class CallableUtils {
+	private CallableUtils() {}
+
+	static final ExceptionHandler DEFAULT_EXCEPTION_HANDLER = new ExceptionHandler() {
+		@Override
+		public RuntimeException rethrowAsUncheckedException(Throwable t) {
+			throw UncheckedException.throwAsUncheckedException(t);
+		}
+	};
+	private static final UncheckedCaller UNCHECKED_CALLER = new DefaultUncheckedCaller(DEFAULT_EXCEPTION_HANDLER);
+
+	/**
+	 * Same as {@code unchecked().call(callable)}.
+	 */
+	@Nullable
+	public static <ReturnType> ReturnType uncheckedCall(Callable<ReturnType> self) {
+		return unchecked().call(self);
+	}
+
+	/**
+	 * Returns an unchecked caller service for {@link Callable}.
+	 *
+	 * @return unchecked caller service, never null
+	 */
+	public static UncheckedCaller unchecked() {
+		return UNCHECKED_CALLER;
+	}
+
+	public interface UncheckedCaller {
+		@Nullable
+		<ReturnType> ReturnType call(Callable<ReturnType> callable);
+	}
+
+	public interface ExceptionHandler {
+		RuntimeException rethrowAsUncheckedException(Throwable t);
+	}
+
+	@EqualsAndHashCode
+	public static final class DefaultUncheckedCaller implements UncheckedCaller {
+		private final ExceptionHandler handler;
+
+		public DefaultUncheckedCaller(ExceptionHandler handler) {
+			this.handler = handler;
+		}
+
+		@Override
+		public <ReturnType> ReturnType call(Callable<ReturnType> self) {
+			try {
+				return self.call();
+			} catch (Exception e) {
+				throw handler.rethrowAsUncheckedException(e);
+			}
+		}
+	}
+
+	/**
+	 * Mechanism to create {@link Callable} from Java lambdas that are {@link Serializable}.
+	 *
+	 * <p><b>Note:</b> The returned {@code Callable} will provide an {@link Object#equals(Object)}/{@link Object#hashCode()} implementation based on the serialized bytes.
+	 * The goal is to ensure the Java lambdas can be compared between each other after deserialization.
+	 */
+	public static <ReturnType> Callable<ReturnType> ofSerializableCallable(SerializableCallable<ReturnType> callable) {
+		return new SerializableCallableAdapter<>(callable);
+	}
+
+	/**
+	 * A {@link Serializable} version of {@link Callable}.
+	 */
+	public interface SerializableCallable<V> extends Callable<V>, Serializable {}
+
+	private static final class SerializableCallableAdapter<V> implements Callable<V>, Serializable {
+		private final SerializableCallable<V> delegate;
+
+		public SerializableCallableAdapter(SerializableCallable<V> delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public V call() throws Exception {
+			return delegate.call();
+		}
+
+		// The following equals and hashCode is not the most efficient implementation
+		//   but is a good enough implementation... for now.
+		// When-if these become a measurable bottleneck, we can revisit those implementation.
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (!(o instanceof SerializableCallableAdapter)) {
+				return false;
+			}
+			SerializableCallableAdapter<?> that = (SerializableCallableAdapter<?>) o;
+			return Arrays.equals(SerializationUtils.serialize(delegate), SerializationUtils.serialize(that.delegate));
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hashCode(SerializationUtils.serialize(delegate));
+		}
+	}
+}

--- a/subprojects/core-utils/src/main/java/dev/nokee/utils/ConfigureUtils.java
+++ b/subprojects/core-utils/src/main/java/dev/nokee/utils/ConfigureUtils.java
@@ -15,7 +15,9 @@
  */
 package dev.nokee.utils;
 
+import groovy.lang.Closure;
 import lombok.val;
+import org.gradle.api.Action;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.provider.PropertyInternal;
@@ -25,6 +27,7 @@ import org.gradle.api.provider.SetProperty;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 
+import javax.annotation.Nullable;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Optional;
 import java.util.function.BiConsumer;
@@ -179,6 +182,14 @@ public final class ConfigureUtils {
 			});
 		} catch (NoSuchMethodException | ClassNotFoundException e) {
 			return Optional.empty();
+		}
+	}
+
+	public static <T> Action<T> configureUsing(@Nullable @SuppressWarnings("rawtypes") Closure configureClosure) {
+		if (configureClosure == null) {
+			return ActionUtils.doNothing();
+		} else {
+			return new ClosureWrappedConfigureAction<>(configureClosure);
 		}
 	}
 }

--- a/subprojects/core-utils/src/main/java/dev/nokee/utils/ConfigureUtils.java
+++ b/subprojects/core-utils/src/main/java/dev/nokee/utils/ConfigureUtils.java
@@ -185,6 +185,9 @@ public final class ConfigureUtils {
 		}
 	}
 
+	/**
+	 * Creates an action that uses the given closure to configure objects of type T.
+	 */
 	public static <T> Action<T> configureUsing(@Nullable @SuppressWarnings("rawtypes") Closure configureClosure) {
 		if (configureClosure == null) {
 			return ActionUtils.doNothing();

--- a/subprojects/core-utils/src/main/java/dev/nokee/utils/DeferredUtils.java
+++ b/subprojects/core-utils/src/main/java/dev/nokee/utils/DeferredUtils.java
@@ -36,7 +36,7 @@ import java.util.function.Supplier;
 
 import static com.google.common.base.Predicates.instanceOf;
 import static com.google.common.base.Predicates.not;
-import static org.gradle.util.GUtil.uncheckedCall;
+import static dev.nokee.utils.CallableUtils.uncheckedCall;
 
 public final class DeferredUtils {
 	private static final Optional<Class<?>> KOTLIN_FUNCTION0_CLASS = loadKotlinFunction0Class();

--- a/subprojects/core-utils/src/main/java/dev/nokee/utils/TextCaseUtils.java
+++ b/subprojects/core-utils/src/main/java/dev/nokee/utils/TextCaseUtils.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.utils;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public final class TextCaseUtils {
+	public static String toCamelCase(CharSequence string) {
+		return camel().convert(string);
+	}
+
+	public static CaseConverter camel() {
+		return string -> Stream.of(string).flatMap(new ToCamelCaseSeparator()).map(StringUtils::capitalize).collect(Collectors.joining());
+	}
+
+	public static String toLowerCamelCase(CharSequence string) {
+		return lowerCamel().convert(string);
+	}
+
+	public static CaseConverter lowerCamel() {
+		return string -> Stream.of(string).flatMap(new ToCamelCaseSeparator()).map(new LowerCapitalize()).collect(Collectors.joining());
+	}
+
+	public static String toWords(CharSequence string) {
+		return words().convert(string);
+	}
+
+	public static CaseConverter words() {
+		return string -> Stream.of(string).flatMap(new ToWordSeparator()).collect(Collectors.joining(" "));
+	}
+
+	public static String toSnakeCase(CharSequence string) {
+		return snake().convert(string);
+	}
+
+	public static CaseConverter snake() {
+		return string -> Stream.of(string).flatMap(new ToWordSeparator()).collect(Collectors.joining("_"));
+	}
+
+	public static String toConstant(CharSequence string) {
+		return constant().convert(string);
+	}
+
+	public static CaseConverter constant() {
+		return string -> Stream.of(string).flatMap(new ToWordSeparator()).map(it -> it.toUpperCase(Locale.US)).collect(Collectors.joining("_"));
+	}
+
+	public static String toKebabCase(CharSequence string) {
+		return kebab().convert(string);
+	}
+
+	public static CaseConverter kebab() {
+		return string -> Stream.of(string).flatMap(new ToWordSeparator()).collect(Collectors.joining("-"));
+	}
+
+	// There are three things that are important:
+	//   - word separator (how words are split from each other)
+	//   - each word manipulator (title case, all upper case, all lower case, only first word is not capitalized...)
+	//   - word separator char (how words are joined together)
+	public interface CaseConverter {
+		String convert(CharSequence string);
+	}
+
+	private static final class ToCamelCaseSeparator implements Function<CharSequence, Stream<String>> {
+		private static final Pattern WORD_SEPARATOR = Pattern.compile("\\W+");
+
+		@Override
+		public Stream<String> apply(CharSequence string) {
+			final List<String> result = new ArrayList<>();
+			final Matcher matcher = WORD_SEPARATOR.matcher(string);
+			int pos = 0;
+			while (matcher.find()) {
+				final String chunk = string.subSequence(pos, matcher.start()).toString();
+				pos = matcher.end();
+				if (!chunk.isEmpty()) {
+					result.add(chunk);
+				}
+			}
+			final String rest = string.subSequence(pos, string.length()).toString();
+			result.add(rest);
+			return result.stream();
+		}
+	}
+
+	private static final class ToWordSeparator implements Function<CharSequence, Stream<String>> {
+		private static final Pattern UPPER_LOWER = Pattern.compile("(?m)([A-Z]*)([a-z0-9]*)");
+
+		@Override
+		public Stream<String> apply(CharSequence string) {
+			final List<String> result = new ArrayList<>();
+			final Matcher matcher = UPPER_LOWER.matcher(string);
+			int pos = 0;
+			StringBuilder builder = new StringBuilder();
+			while (pos < string.length()) {
+				matcher.find(pos);
+				if (matcher.end() == pos) {
+					// Not looking at a match
+					pos++;
+					continue;
+				}
+				if (builder.length() > 0) {
+					result.add(builder.toString());
+					builder = new StringBuilder();
+				}
+
+				String group1 = matcher.group(1).toLowerCase();
+				String group2 = matcher.group(2);
+				if (group2.length() == 0) {
+					builder.append(group1);
+				} else {
+					if (group1.length() > 1) {
+						builder.append(group1.substring(0, group1.length() - 1));
+						result.add(builder.toString());
+						builder = new StringBuilder();
+
+						builder.append(group1.substring(group1.length() - 1));
+					} else {
+						builder.append(group1);
+					}
+					builder.append(group2);
+				}
+				pos = matcher.end();
+			}
+
+			if (builder.length() > 0) {
+				result.add(builder.toString());
+			}
+			return result.stream();
+		}
+	}
+
+	private static final class LowerCapitalize implements UnaryOperator<String> {
+		private boolean first = true;
+
+		@Override
+		public String apply(String s) {
+			if (first) {
+				first = false;
+				return StringUtils.uncapitalize(s);
+			} else {
+				return StringUtils.capitalize(s);
+			}
+		}
+	}
+}

--- a/subprojects/core-utils/src/main/java/dev/nokee/utils/VersionNumber.java
+++ b/subprojects/core-utils/src/main/java/dev/nokee/utils/VersionNumber.java
@@ -27,8 +27,8 @@ import java.util.Objects;
  *
  * <p>This class considers missing parts to be 0, so that "1.0" == "1.0.0" == "1.0.0_0".</p>
  *
- * <p>Note that this class considers "1.2.3-something" less than "1.2.3". Qualifiers are compared lexicographically ("1.2.3-alpha" < "1.2.3-beta") and case-insensitive ("1.2.3-alpha" <
- * "1.2.3.RELEASE").
+ * <p>Note that this class considers "1.2.3-something" less than "1.2.3". Qualifiers are compared lexicographically ({@literal "1.2.3-alpha" < "1.2.3-beta"}) and case-insensitive ({@literal "1.2.3-alpha" <
+ * "1.2.3.RELEASE"}).
  *
  * <p>To check if a version number is at least "1.2.3", disregarding a potential qualifier like "beta", use {@code version.getBaseVersion().compareTo(VersionNumber.parse("1.2.3")) >= 0}.
  */

--- a/subprojects/core-utils/src/main/java/dev/nokee/utils/VersionNumber.java
+++ b/subprojects/core-utils/src/main/java/dev/nokee/utils/VersionNumber.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.utils;
+
+import com.google.common.collect.Ordering;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+/**
+ * Represents, parses, and compares version numbers. Supports a couple of different schemes: <ul> <li>MAJOR.MINOR.MICRO-QUALIFIER (the default).</li> <li>MAJOR.MINOR.MICRO.PATCH-QUALIFIER.</li> </ul>
+ *
+ * <p>The {@link #parse} method handles missing parts and allows "." to be used instead of "-", and "_" to be used instead of "." for the patch number.
+ *
+ * <p>This class considers missing parts to be 0, so that "1.0" == "1.0.0" == "1.0.0_0".</p>
+ *
+ * <p>Note that this class considers "1.2.3-something" less than "1.2.3". Qualifiers are compared lexicographically ("1.2.3-alpha" < "1.2.3-beta") and case-insensitive ("1.2.3-alpha" <
+ * "1.2.3.RELEASE").
+ *
+ * <p>To check if a version number is at least "1.2.3", disregarding a potential qualifier like "beta", use {@code version.getBaseVersion().compareTo(VersionNumber.parse("1.2.3")) >= 0}.
+ */
+public final class VersionNumber implements Comparable<VersionNumber> {
+    private static final DefaultScheme DEFAULT_SCHEME = new DefaultScheme();
+    private static final SchemeWithPatchVersion PATCH_SCHEME = new SchemeWithPatchVersion();
+    public static final VersionNumber UNKNOWN = version(0);
+
+    private final int major;
+    private final int minor;
+    private final int micro;
+    private final int patch;
+    private final String qualifier;
+    private final AbstractScheme scheme;
+
+    public VersionNumber(int major, int minor, int micro, @Nullable String qualifier) {
+        this(major, minor, micro, 0, qualifier, DEFAULT_SCHEME);
+    }
+
+    public VersionNumber(int major, int minor, int micro, int patch, @Nullable String qualifier) {
+        this(major, minor, micro, patch, qualifier, PATCH_SCHEME);
+    }
+
+    private VersionNumber(int major, int minor, int micro, int patch, @Nullable String qualifier, AbstractScheme scheme) {
+        this.major = major;
+        this.minor = minor;
+        this.micro = micro;
+        this.patch = patch;
+        this.qualifier = qualifier;
+        this.scheme = scheme;
+    }
+
+    public int getMajor() {
+        return major;
+    }
+
+    public int getMinor() {
+        return minor;
+    }
+
+    public int getMicro() {
+        return micro;
+    }
+
+    public int getPatch() {
+        return patch;
+    }
+
+    public String getQualifier() {
+        return qualifier;
+    }
+
+    public VersionNumber getBaseVersion() {
+        return new VersionNumber(major, minor, micro, patch, null, scheme);
+    }
+
+    @Override
+    public int compareTo(VersionNumber other) {
+        if (major != other.major) {
+            return major - other.major;
+        }
+        if (minor != other.minor) {
+            return minor - other.minor;
+        }
+        if (micro != other.micro) {
+            return micro - other.micro;
+        }
+        if (patch != other.patch) {
+            return patch - other.patch;
+        }
+        return Ordering.natural().nullsLast().compare(toLowerCase(qualifier), toLowerCase(other.qualifier));
+    }
+
+    public boolean equals(Object other) {
+        return other instanceof VersionNumber && compareTo((VersionNumber) other) == 0;
+    }
+
+    public int hashCode() {
+        int result = major;
+        result = 31 * result + minor;
+        result = 31 * result + micro;
+        result = 31 * result + patch;
+        result = 31 * result + Objects.hashCode(qualifier);
+        return result;
+    }
+
+    public String toString() {
+        return scheme.format(this);
+    }
+
+    public static VersionNumber version(int major) {
+        return new VersionNumber(major, 0, 0, 0, null, DEFAULT_SCHEME);
+    }
+
+    /**
+     * Returns the default MAJOR.MINOR.MICRO-QUALIFIER scheme.
+     */
+    public static Scheme scheme() {
+        return DEFAULT_SCHEME;
+    }
+
+    /**
+     * Returns the MAJOR.MINOR.MICRO.PATCH-QUALIFIER scheme.
+     */
+    public static Scheme withPatchNumber() {
+        return PATCH_SCHEME;
+    }
+
+    public static VersionNumber parse(String versionString) {
+        return DEFAULT_SCHEME.parse(versionString);
+    }
+
+    private String toLowerCase(@Nullable String string) {
+        return string == null ? null : string.toLowerCase();
+    }
+
+    public interface Scheme {
+        public VersionNumber parse(String value);
+
+        public String format(VersionNumber versionNumber);
+    }
+
+    private abstract static class AbstractScheme implements Scheme {
+        final int depth;
+
+        protected AbstractScheme(int depth) {
+            this.depth = depth;
+        }
+
+        @Override
+        public VersionNumber parse(String versionString) {
+            if (versionString == null || versionString.length() == 0) {
+                return UNKNOWN;
+            }
+            Scanner scanner = new Scanner(versionString);
+
+            int major = 0;
+            int minor = 0;
+            int micro = 0;
+            int patch = 0;
+
+            if (!scanner.hasDigit()) {
+                return UNKNOWN;
+            }
+            major = scanner.scanDigit();
+            if (scanner.isSeparatorAndDigit('.')) {
+                scanner.skipSeparator();
+                minor = scanner.scanDigit();
+                if (scanner.isSeparatorAndDigit('.')) {
+                    scanner.skipSeparator();
+                    micro = scanner.scanDigit();
+                    if (depth > 3 && scanner.isSeparatorAndDigit('.', '_')) {
+                        scanner.skipSeparator();
+                        patch = scanner.scanDigit();
+                    }
+                }
+            }
+
+            if (scanner.isEnd()) {
+                return new VersionNumber(major, minor, micro, patch, null, this);
+            }
+
+            if (scanner.isQualifier()) {
+                scanner.skipSeparator();
+                return new VersionNumber(major, minor, micro, patch, scanner.remainder(), this);
+            }
+
+            return UNKNOWN;
+        }
+
+        private static class Scanner {
+            int pos;
+            final String str;
+
+            private Scanner(String string) {
+                this.str = string;
+            }
+
+            boolean hasDigit() {
+                return pos < str.length() && Character.isDigit(str.charAt(pos));
+            }
+
+            boolean isSeparatorAndDigit(char... separators) {
+                return pos < str.length() - 1 && oneOf(separators) && Character.isDigit(str.charAt(pos + 1));
+            }
+
+            private boolean oneOf(char... separators) {
+                char current = str.charAt(pos);
+                for (int i = 0; i < separators.length; i++) {
+                    char separator = separators[i];
+                    if (current == separator) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            boolean isQualifier() {
+                return pos < str.length() - 1 && oneOf('.', '-');
+            }
+
+            int scanDigit() {
+                int start = pos;
+                while (hasDigit()) {
+                    pos++;
+                }
+                return Integer.parseInt(str.substring(start, pos));
+            }
+
+            public boolean isEnd() {
+                return pos == str.length();
+            }
+
+            private boolean skip(char ch) {
+                if (pos < str.length() && str.charAt(pos) == ch) {
+                    pos++;
+                    return true;
+                }
+                return false;
+            }
+
+            public void skipSeparator() {
+                pos++;
+            }
+
+            public String remainder() {
+                return pos == str.length() ? null : str.substring(pos);
+            }
+        }
+    }
+
+    private static class DefaultScheme extends AbstractScheme {
+        private static final String VERSION_TEMPLATE = "%d.%d.%d%s";
+
+        public DefaultScheme() {
+            super(3);
+        }
+
+        @Override
+        public String format(VersionNumber versionNumber) {
+            return String.format(VERSION_TEMPLATE, versionNumber.major, versionNumber.minor, versionNumber.micro, versionNumber.qualifier == null ? "" : "-" + versionNumber.qualifier);
+        }
+    }
+
+    private static class SchemeWithPatchVersion extends AbstractScheme {
+        private static final String VERSION_TEMPLATE = "%d.%d.%d.%d%s";
+
+        private SchemeWithPatchVersion() {
+            super(4);
+        }
+
+        @Override
+        public String format(VersionNumber versionNumber) {
+            return String.format(VERSION_TEMPLATE, versionNumber.major, versionNumber.minor, versionNumber.micro, versionNumber.patch, versionNumber.qualifier == null ? "" : "-" + versionNumber.qualifier);
+        }
+    }
+
+}

--- a/subprojects/core-utils/src/test/groovy/dev/nokee/utils/CallableUtils_OfSerializableCallableTests.java
+++ b/subprojects/core-utils/src/test/groovy/dev/nokee/utils/CallableUtils_OfSerializableCallableTests.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.internal.testing.SerializableMatchers.isSerializable;
+import static dev.nokee.utils.CallableUtils.ofSerializableCallable;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class CallableUtils_OfSerializableCallableTests {
+	@Test
+	void returnsSerializableCallable() {
+		assertThat(ofSerializableCallable(() -> "foo"), isSerializable());
+	}
+}

--- a/subprojects/core-utils/src/test/groovy/dev/nokee/utils/CallableUtils_UncheckedCallerTests.java
+++ b/subprojects/core-utils/src/test/groovy/dev/nokee/utils/CallableUtils_UncheckedCallerTests.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.utils;
+
+import org.apache.commons.lang3.function.FailableRunnable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.concurrent.Callable;
+
+import static dev.nokee.utils.CallableUtils.DEFAULT_EXCEPTION_HANDLER;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+@ExtendWith(MockitoExtension.class)
+class CallableUtils_UncheckedCallerTests {
+	@Test
+	void createUncheckedCallerUsingDefaultExceptionHandler() {
+		assertThat(CallableUtils.unchecked(), equalTo(new CallableUtils.DefaultUncheckedCaller(DEFAULT_EXCEPTION_HANDLER)));
+	}
+
+	@Nested
+	class GivenSubject {
+		CallableUtils.ExceptionHandler handler = Mockito.spy(new CallableUtils.ExceptionHandler() {
+			@Override
+			public RuntimeException rethrowAsUncheckedException(Throwable t) {
+				return new RuntimeException(t); // crappy implementation for testing
+			}
+		});
+		@InjectMocks CallableUtils.DefaultUncheckedCaller subject;
+		@Mock Callable<Object> target;
+
+		@Nested
+		class WhenCallableThrowsCheckedException {
+			CheckedException checkedException = new CheckedException();
+
+			@BeforeEach
+			void givenCallThrowsCheckedException() throws Exception {
+				Mockito.when(target.call()).thenThrow(checkedException);
+			}
+
+			@Test
+			void callsExceptionHandlerWithCheckedException() {
+				discardAnyException(() -> subject.call(target));
+				Mockito.verify(handler).rethrowAsUncheckedException(checkedException);
+			}
+		}
+
+		@Nested
+		class WhenCallableThrowsUncheckedException {
+			UncheckedException uncheckedException = new UncheckedException();
+
+			@BeforeEach
+			void givenCallThrowsUncheckedException() throws Exception {
+				Mockito.when(target.call()).thenThrow(uncheckedException);
+			}
+
+			@Test
+			void callsExceptionHandlerWithUncheckedException() {
+				discardAnyException(() -> subject.call(target));
+				Mockito.verify(handler).rethrowAsUncheckedException(uncheckedException);
+			}
+		}
+
+		@Nested
+		class WhenCallableReturnsWithoutException {
+			Object returnValue = new Object();
+
+			@BeforeEach
+			void givenCallThrowsCheckedException() throws Exception {
+				Mockito.when(target.call()).thenReturn(returnValue);
+			}
+
+			@Test
+			void doesNotCallExceptionHandler() throws Exception {
+				ignoresReturnValue(target.call());
+				Mockito.verifyNoInteractions(handler);
+			}
+
+			@Test
+			void returnsCallableValue() throws Exception {
+				assertThat(target.call(), equalTo(returnValue));
+			}
+		}
+	}
+
+	private static <R> void ignoresReturnValue(R returnValue) {
+		// do nothing with value...
+	}
+	private static final class CheckedException extends Exception {}
+	private static final class UncheckedException extends RuntimeException {}
+
+	private static <E extends Throwable> void discardAnyException(FailableRunnable<E> runnable) {
+		try {
+			runnable.run();
+		} catch (Throwable e) {
+			// ignores
+		}
+	}
+}

--- a/subprojects/core-utils/src/test/groovy/dev/nokee/utils/TextCaseUtils_ToCamelCaseTests.java
+++ b/subprojects/core-utils/src/test/groovy/dev/nokee/utils/TextCaseUtils_ToCamelCaseTests.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.utils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static dev.nokee.utils.TextCaseUtils.toCamelCase;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class TextCaseUtils_ToCamelCaseTests {
+	@Test
+	void returnsEmptyStringAsIs() {
+		assertThat(toCamelCase(""), equalTo(""));
+	}
+
+	@Test
+	void capitalizeSingleWorkInputString() {
+		assertThat(toCamelCase("word"), equalTo("Word"));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "twoWords", "TwoWords", "two-words", "two.words", "two words", "two Words", "Two Words" })
+	void capitalizesAndJoinsMultipleWordsInputString(String inputString) {
+		assertThat(toCamelCase(inputString), equalTo("TwoWords"));
+	}
+
+	@Test
+	void ignoresExtraWhitespaces() {
+		assertThat(toCamelCase(" Two  \t words\n"), equalTo("TwoWords"));
+	}
+
+	@Test
+	void canCamelCaseMultipleWords() {
+		assertThat(toCamelCase("four or so Words"), equalTo("FourOrSoWords"));
+	}
+
+	@Test
+	void treatsDigitOnlyAsChunk() {
+		assertThat(toCamelCase("123-project"), equalTo("123Project"));
+	}
+
+	@Test
+	void treatsMixedDigitAndLetterAsChunks() {
+		assertThat(toCamelCase("i18n-admin"), equalTo("I18nAdmin"));
+	}
+
+	@Test
+	void ignoresTailingSeparators() {
+		assertThat(toCamelCase("trailing-"), equalTo("Trailing"));
+	}
+
+	@Test
+	void treatsEachUpperCaseLetterAsSeparateChunks() {
+		assertThat(toCamelCase("ABC"), equalTo("ABC"));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { ".", "-", " " })
+	void ignoresSeparatorsOnlyString(String inputString) {
+		assertThat(toCamelCase(inputString), equalTo(""));
+	}
+}

--- a/subprojects/core-utils/src/test/groovy/dev/nokee/utils/TextCaseUtils_ToConstantTests.java
+++ b/subprojects/core-utils/src/test/groovy/dev/nokee/utils/TextCaseUtils_ToConstantTests.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.utils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static dev.nokee.utils.TextCaseUtils.toConstant;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class TextCaseUtils_ToConstantTests {
+	@Test
+	void returnsEmptyStringAsIs() {
+		assertThat(toConstant(""), equalTo(""));
+	}
+
+	@Test
+	void upperCaseSingleWorkInputString() {
+		assertThat(toConstant("word"), equalTo("WORD"));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "twoWords", "TwoWords", "two-words", "TWO_WORDS", "two.words", "two words", "two Words", "Two Words" })
+	void capitalizesAndJoinsMultipleWordsInputString(String inputString) {
+		assertThat(toConstant(inputString), equalTo("TWO_WORDS"));
+	}
+
+	@Test
+	void ignoresExtraWhitespaces() {
+		assertThat(toConstant(" Two  \t words\n"), equalTo("TWO_WORDS"));
+	}
+
+	@Test
+	void canCamelCaseMultipleWords() {
+		assertThat(toConstant("four or so Words"), equalTo("FOUR_OR_SO_WORDS"));
+	}
+
+	@Test
+	void treatsDigitOnlyAsChunk() {
+		assertThat(toConstant("123-project"), equalTo("123_PROJECT"));
+	}
+
+	@Test
+	void treatsDigitFollowedByLettersSegmentAsChunk() {
+		assertThat(toConstant("123abc-project"), equalTo("123ABC_PROJECT"));
+	}
+
+	@Test
+	void otherTests() {
+		assertThat(toConstant("a"), equalTo("A"));
+		assertThat(toConstant("A"), equalTo("A"));
+		assertThat(toConstant("aB"), equalTo("A_B"));
+		assertThat(toConstant("ABCThing"), equalTo("ABC_THING"));
+		assertThat(toConstant("ABC Thing"), equalTo("ABC_THING"));
+	}
+
+	@Test
+	void treatsMixedDigitAndLetterAsChunks() {
+		assertThat(toConstant("i18n-admin"), equalTo("I18N_ADMIN"));
+	}
+
+	@Test
+	void ignoresTailingSeparators() {
+		assertThat(toConstant("trailing-"), equalTo("TRAILING"));
+	}
+
+	@Test
+	void treatsEachUpperCaseLetterAsSeparateChunks() {
+		assertThat(toConstant("ABC"), equalTo("ABC"));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { ".", "-", " " })
+	void ignoresSeparatorsOnlyString(String inputString) {
+		assertThat(toConstant(inputString), equalTo(""));
+	}
+}

--- a/subprojects/core-utils/src/test/groovy/dev/nokee/utils/TextCaseUtils_ToLowerCamelCaseTests.java
+++ b/subprojects/core-utils/src/test/groovy/dev/nokee/utils/TextCaseUtils_ToLowerCamelCaseTests.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.utils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static dev.nokee.utils.TextCaseUtils.toLowerCamelCase;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class TextCaseUtils_ToLowerCamelCaseTests {
+	@Test
+	void returnsEmptyStringAsIs() {
+		assertThat(toLowerCamelCase(""), equalTo(""));
+	}
+
+	@Test
+	void doesNotCapitalizeSingleWorkInputString() {
+		assertThat(toLowerCamelCase("word"), equalTo("word"));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "twoWords", "TwoWords", "two-words", "two.words", "two words", "two Words", "Two Words" })
+	void capitalizesOnlySecondChunkAndJoinsMultipleWordsInputString(String inputString) {
+		assertThat(toLowerCamelCase(inputString), equalTo("twoWords"));
+	}
+
+	@Test
+	void ignoresExtraWhitespaces() {
+		assertThat(toLowerCamelCase(" Two  \t words\n"), equalTo("twoWords"));
+	}
+
+	@Test
+	void canLowerCamelCaseMultipleWords() {
+		assertThat(toLowerCamelCase("four or so Words"), equalTo("fourOrSoWords"));
+	}
+
+	@Test
+	void treatsDigitOnlyAsChunk() {
+		assertThat(toLowerCamelCase("123-project"), equalTo("123Project"));
+	}
+
+	@Test
+	void treatsMixedDigitAndLetterAsChunks() {
+		assertThat(toLowerCamelCase("i18n-admin"), equalTo("i18nAdmin"));
+	}
+
+	@Test
+	void ignoresTailingSeparators() {
+		assertThat(toLowerCamelCase("trailing-"), equalTo("trailing"));
+	}
+
+	@Test
+	void treatsEachUpperCaseLetterAsSeparateChunks() {
+		assertThat(toLowerCamelCase("ABC"), equalTo("aBC"));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { ".", "-", " " })
+	void ignoresSeparatorsOnlyString(String inputString) {
+		assertThat(toLowerCamelCase(inputString), equalTo(""));
+	}
+}

--- a/subprojects/gradle-repository-shim/gradle-repository-shim.gradle
+++ b/subprojects/gradle-repository-shim/gradle-repository-shim.gradle
@@ -7,14 +7,16 @@ plugins {
 
 sourceSets {
 	'v6.6' {}
+	'v7.6' {}
 }
 
 dependencies {
 	api project(':publishingCore')
 	v66Implementation "commons-io:commons-io:${commonsIoVersion}"
+	v76Implementation "commons-io:commons-io:${commonsIoVersion}"
 }
 
 test {
-	testedGradleVersions.set(['6.6', '6.7', '6.8', '6.9', '7.0', '7.1', '7.2', '7.3', '7.4', '7.5'])
+	testedGradleVersions.set(['6.6', '6.7', '6.8', '6.9', '7.0', '7.1', '7.2', '7.3', '7.4', '7.5', '7.6'])
 	testedOsFamilies.set([it.osFamilies.agnostic])
 }

--- a/subprojects/gradle-repository-shim/src/main/java/dev/nokee/gradle/AdhocArtifactRepositoryFactory.java
+++ b/subprojects/gradle-repository-shim/src/main/java/dev/nokee/gradle/AdhocArtifactRepositoryFactory.java
@@ -39,7 +39,9 @@ public final class AdhocArtifactRepositoryFactory {
 		this.objects = project.getObjects();
 		this.providers = project.getProviders();
 		this.mavenRepositoryFactory = ((ProjectInternal) project).getServices().get(BaseRepositoryFactory.class)::createMavenRepository;
-		if (GradleVersion.current().compareTo(GradleVersion.version("6.6")) >= 0) {
+		if (GradleVersion.current().compareTo(GradleVersion.version("7.6")) >= 0) {
+			this.factory = new ArtifactRepositoryFactory("dev.nokee.gradle.internal.repositories.v76.DefaultAdhocArtifactRepository");
+		} else if (GradleVersion.current().compareTo(GradleVersion.version("6.6")) >= 0) {
 			this.factory = new ArtifactRepositoryFactory("dev.nokee.gradle.internal.repositories.v66.DefaultAdhocArtifactRepository");
 		} else {
 			throw new UnsupportedOperationException("Gradle version lower than 6.5 are not supported. " + GradleVersion.current());

--- a/subprojects/gradle-repository-shim/src/v7.6/java/dev/nokee/gradle/internal/repositories/v76/DefaultAdhocArtifactRepository.java
+++ b/subprojects/gradle-repository-shim/src/v7.6/java/dev/nokee/gradle/internal/repositories/v76/DefaultAdhocArtifactRepository.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.nokee.gradle.internal.repositories.v66;
+package dev.nokee.gradle.internal.repositories.v76;
 
 import dev.nokee.gradle.AdhocArtifactRepository;
 import dev.nokee.gradle.AdhocComponentLister;
@@ -50,12 +50,10 @@ import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
-import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.reflect.Instantiator;
-import org.gradle.internal.resolve.result.BuildableArtifactResolveResult;
+import org.gradle.internal.resolve.result.BuildableArtifactFileResolveResult;
 import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult;
-import org.gradle.internal.resolve.result.BuildableComponentArtifactsResolveResult;
 import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult;
 import org.gradle.internal.resolve.result.BuildableModuleVersionListingResolveResult;
 
@@ -307,18 +305,13 @@ public final class DefaultAdhocArtifactRepository implements AdhocArtifactReposi
 			return id.getGroup().replace('.', '/') + "/" + id.getName();
 		}
 
-		@Override // removed in 7.5
-		public void resolveArtifacts(ComponentResolveMetadata component, ConfigurationMetadata variant, BuildableComponentArtifactsResolveResult result) {
-			delegate.resolveArtifacts(component, variant, result);
-		}
-
 		@Override
 		public void resolveArtifactsWithType(ComponentResolveMetadata component, ArtifactType artifactType, BuildableArtifactSetResolveResult result) {
 			delegate.resolveArtifactsWithType(component, artifactType, result);
 		}
 
 		@Override // changed in 7.6
-		public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSources moduleSources, BuildableArtifactResolveResult result) {
+		public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSources moduleSources, BuildableArtifactFileResolveResult result) {
 			delegate.resolveArtifact(artifact, moduleSources, result);
 		}
 

--- a/subprojects/gradle-shim/gradle-shim.gradle
+++ b/subprojects/gradle-shim/gradle-shim.gradle
@@ -10,10 +10,11 @@ sourceSets {
 	'v6.5' {}
 	'v6.6' {}
 	'v7.0' {}
+	'v7.6' {}
 }
 
 test {
-	testedGradleVersions.set(['6.2', '6.3', '6.4', '6.5', '6.6', '6.7', '6.8', '6.9', '7.0', '7.1', '7.2', '7.3', '7.4', '7.5'])
+	testedGradleVersions.set(['6.2', '6.3', '6.4', '6.5', '6.6', '6.7', '6.8', '6.9', '7.0', '7.1', '7.2', '7.3', '7.4', '7.5', '7.6'])
 	testedOsFamilies.set([it.osFamilies.agnostic])
 }
 
@@ -23,4 +24,5 @@ dependencies {
 	add('v65Implementation', project(':coreUtils'))
 	add('v66Implementation', project(':coreUtils'))
 	add('v70Implementation', project(':coreUtils'))
+	add('v76Implementation', project(':coreUtils'))
 }

--- a/subprojects/gradle-shim/gradle-shim.gradle
+++ b/subprojects/gradle-shim/gradle-shim.gradle
@@ -16,3 +16,11 @@ test {
 	testedGradleVersions.set(['6.2', '6.3', '6.4', '6.5', '6.6', '6.7', '6.8', '6.9', '7.0', '7.1', '7.2', '7.3', '7.4', '7.5'])
 	testedOsFamilies.set([it.osFamilies.agnostic])
 }
+
+dependencies {
+	add('v62Implementation', project(':coreUtils'))
+	add('v64Implementation', project(':coreUtils'))
+	add('v65Implementation', project(':coreUtils'))
+	add('v66Implementation', project(':coreUtils'))
+	add('v70Implementation', project(':coreUtils'))
+}

--- a/subprojects/gradle-shim/src/main/java/dev/nokee/gradle/NamedDomainObjectProviderFactory.java
+++ b/subprojects/gradle-shim/src/main/java/dev/nokee/gradle/NamedDomainObjectProviderFactory.java
@@ -26,7 +26,9 @@ public final class NamedDomainObjectProviderFactory {
 	private final ProviderFactory factory;
 
 	public NamedDomainObjectProviderFactory() {
-		if (GradleVersion.current().compareTo(GradleVersion.version("7.0")) >= 0) {
+		if (GradleVersion.current().compareTo(GradleVersion.version("7.6")) >= 0) {
+			this.factory = new ProviderFactory("dev.nokee.gradle.internal.v76.DefaultNamedDomainObjectProvider");
+		} else if (GradleVersion.current().compareTo(GradleVersion.version("7.0")) >= 0) {
 			this.factory = new ProviderFactory("dev.nokee.gradle.internal.v70.DefaultNamedDomainObjectProvider");
 		} else if (GradleVersion.current().compareTo(GradleVersion.version("6.6")) >= 0) {
 			this.factory = new ProviderFactory("dev.nokee.gradle.internal.v66.DefaultNamedDomainObjectProvider");

--- a/subprojects/gradle-shim/src/main/java/dev/nokee/gradle/TaskProviderFactory.java
+++ b/subprojects/gradle-shim/src/main/java/dev/nokee/gradle/TaskProviderFactory.java
@@ -26,7 +26,9 @@ public final class TaskProviderFactory {
 	private final ProviderFactory factory;
 
 	public TaskProviderFactory() {
-		if (GradleVersion.current().compareTo(GradleVersion.version("7.0")) >= 0) {
+		if (GradleVersion.current().compareTo(GradleVersion.version("7.6")) >= 0) {
+			this.factory = new ProviderFactory("dev.nokee.gradle.internal.v76.DefaultTaskProvider");
+		} else if (GradleVersion.current().compareTo(GradleVersion.version("7.0")) >= 0) {
 			this.factory = new ProviderFactory("dev.nokee.gradle.internal.v70.DefaultTaskProvider");
 		} else if (GradleVersion.current().compareTo(GradleVersion.version("6.6")) >= 0) {
 			this.factory = new ProviderFactory("dev.nokee.gradle.internal.v66.DefaultTaskProvider");

--- a/subprojects/gradle-shim/src/v6.2/java/dev/nokee/gradle/internal/v62/NamedDomainObjectProviderMixIn.java
+++ b/subprojects/gradle-shim/src/v6.2/java/dev/nokee/gradle/internal/v62/NamedDomainObjectProviderMixIn.java
@@ -15,12 +15,12 @@
  */
 package dev.nokee.gradle.internal.v62;
 
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import org.gradle.api.NamedDomainObjectProvider;
-import org.gradle.util.ConfigureUtil;
 
 interface NamedDomainObjectProviderMixIn<T> extends NamedDomainObjectProvider<T> {
 	default void configure(@SuppressWarnings("rawtypes") Closure closure) {
-		configure(ConfigureUtil.configureUsing(closure));
+		configure(ConfigureUtils.configureUsing(closure));
 	}
 }

--- a/subprojects/gradle-shim/src/v6.4/java/dev/nokee/gradle/internal/v64/NamedDomainObjectProviderMixIn.java
+++ b/subprojects/gradle-shim/src/v6.4/java/dev/nokee/gradle/internal/v64/NamedDomainObjectProviderMixIn.java
@@ -15,12 +15,12 @@
  */
 package dev.nokee.gradle.internal.v64;
 
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import org.gradle.api.NamedDomainObjectProvider;
-import org.gradle.util.ConfigureUtil;
 
 interface NamedDomainObjectProviderMixIn<T> extends NamedDomainObjectProvider<T> {
 	default void configure(@SuppressWarnings("rawtypes") Closure closure) {
-		configure(ConfigureUtil.configureUsing(closure));
+		configure(ConfigureUtils.configureUsing(closure));
 	}
 }

--- a/subprojects/gradle-shim/src/v6.5/java/dev/nokee/gradle/internal/v65/NamedDomainObjectProviderMixIn.java
+++ b/subprojects/gradle-shim/src/v6.5/java/dev/nokee/gradle/internal/v65/NamedDomainObjectProviderMixIn.java
@@ -15,12 +15,12 @@
  */
 package dev.nokee.gradle.internal.v65;
 
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import org.gradle.api.NamedDomainObjectProvider;
-import org.gradle.util.ConfigureUtil;
 
 interface NamedDomainObjectProviderMixIn<T> extends NamedDomainObjectProvider<T> {
 	default void configure(@SuppressWarnings("rawtypes") Closure closure) {
-		configure(ConfigureUtil.configureUsing(closure));
+		configure(ConfigureUtils.configureUsing(closure));
 	}
 }

--- a/subprojects/gradle-shim/src/v6.6/java/dev/nokee/gradle/internal/v66/NamedDomainObjectProviderMixIn.java
+++ b/subprojects/gradle-shim/src/v6.6/java/dev/nokee/gradle/internal/v66/NamedDomainObjectProviderMixIn.java
@@ -15,12 +15,12 @@
  */
 package dev.nokee.gradle.internal.v66;
 
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import org.gradle.api.NamedDomainObjectProvider;
-import org.gradle.util.ConfigureUtil;
 
 interface NamedDomainObjectProviderMixIn<T> extends NamedDomainObjectProvider<T> {
 	default void configure(@SuppressWarnings("rawtypes") Closure closure) {
-		configure(ConfigureUtil.configureUsing(closure));
+		configure(ConfigureUtils.configureUsing(closure));
 	}
 }

--- a/subprojects/gradle-shim/src/v7.0/java/dev/nokee/gradle/internal/v70/NamedDomainObjectProviderMixIn.java
+++ b/subprojects/gradle-shim/src/v7.0/java/dev/nokee/gradle/internal/v70/NamedDomainObjectProviderMixIn.java
@@ -15,12 +15,12 @@
  */
 package dev.nokee.gradle.internal.v70;
 
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import org.gradle.api.NamedDomainObjectProvider;
-import org.gradle.util.ConfigureUtil;
 
 interface NamedDomainObjectProviderMixIn<T> extends NamedDomainObjectProvider<T> {
 	default void configure(@SuppressWarnings("rawtypes") Closure closure) {
-		configure(ConfigureUtil.configureUsing(closure));
+		configure(ConfigureUtils.configureUsing(closure));
 	}
 }

--- a/subprojects/gradle-shim/src/v7.6/java/dev/nokee/gradle/internal/v76/DefaultNamedDomainObjectProvider.java
+++ b/subprojects/gradle-shim/src/v7.6/java/dev/nokee/gradle/internal/v76/DefaultNamedDomainObjectProvider.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.gradle.internal.v76;
+
+import dev.nokee.gradle.NamedDomainObjectProviderSpec;
+import org.gradle.api.Action;
+import org.gradle.api.Named;
+import org.gradle.api.internal.provider.ProviderInternal;
+import org.gradle.internal.state.Managed;
+
+import javax.annotation.Nullable;
+
+// Note: Implements Named interface because of DefaultNamedDomainObjectCollection.AbstractNamedDomainObjectProvider implementation
+public final class DefaultNamedDomainObjectProvider<T> implements Named
+	, NamedDomainObjectProviderMixIn<T>
+	, ProviderInternalMixIn<T>
+	, ManagedMixIn
+{
+	private final NamedDomainObjectProviderSpec<T> spec;
+
+	public DefaultNamedDomainObjectProvider(NamedDomainObjectProviderSpec<T> spec) {
+		this.spec = spec;
+	}
+
+	@Override
+	public void configure(Action<? super T> action) {
+		spec.getConfigurer().accept(action);
+	}
+
+	@Override
+	public String getName() {
+		return spec.getName();
+	}
+
+	@Nullable
+	@Override
+	public Class<T> getType() {
+		return spec.getType();
+	}
+
+	@Override
+	public Managed getManaged() {
+		return (Managed) spec.getDelegate();
+	}
+
+	@Override
+	public ProviderInternal<T> getDelegate() {
+		return (ProviderInternal<T>) spec.getDelegate();
+	}
+}

--- a/subprojects/gradle-shim/src/v7.6/java/dev/nokee/gradle/internal/v76/DefaultTaskProvider.java
+++ b/subprojects/gradle-shim/src/v7.6/java/dev/nokee/gradle/internal/v76/DefaultTaskProvider.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.gradle.internal.v76;
+
+import dev.nokee.gradle.NamedDomainObjectProviderSpec;
+import org.gradle.api.Action;
+import org.gradle.api.Named;
+import org.gradle.api.Task;
+import org.gradle.api.internal.provider.ProviderInternal;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.internal.state.Managed;
+
+import javax.annotation.Nullable;
+
+public final class DefaultTaskProvider<T extends Task> implements Named, TaskProvider<T>
+	, NamedDomainObjectProviderMixIn<T>
+	, ProviderInternalMixIn<T>
+	, ManagedMixIn
+{
+	private final NamedDomainObjectProviderSpec<T> spec;
+
+	public DefaultTaskProvider(NamedDomainObjectProviderSpec<T> spec) {
+		this.spec = spec;
+	}
+
+	@Override
+	public Managed getManaged() {
+		return (Managed) spec.getDelegate();
+	}
+
+	@Override
+	public ProviderInternal<T> getDelegate() {
+		return (ProviderInternal<T>) spec.getDelegate();
+	}
+
+	@Nullable
+	@Override
+	public Class<T> getType() {
+		return spec.getType();
+	}
+
+	@Override
+	public void configure(Action<? super T> action) {
+		spec.getConfigurer().accept(action);
+	}
+
+	@Override
+	public String getName() {
+		return spec.getName();
+	}
+}

--- a/subprojects/gradle-shim/src/v7.6/java/dev/nokee/gradle/internal/v76/ManagedMixIn.java
+++ b/subprojects/gradle-shim/src/v7.6/java/dev/nokee/gradle/internal/v76/ManagedMixIn.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.gradle.internal.v76;
+
+import org.gradle.internal.state.Managed;
+
+import javax.annotation.Nullable;
+
+interface ManagedMixIn extends Managed {
+	Managed getManaged();
+
+	@Nullable
+	@Override
+	default Object unpackState() {
+		return getManaged().unpackState();
+	}
+
+	@Override
+	default boolean isImmutable() {
+		return getManaged().isImmutable();
+	}
+
+	@Override
+	default Class<?> publicType() {
+		return getManaged().publicType();
+	}
+
+	@Override
+	default int getFactoryId() {
+		return getManaged().getFactoryId();
+	}
+}

--- a/subprojects/gradle-shim/src/v7.6/java/dev/nokee/gradle/internal/v76/NamedDomainObjectProviderMixIn.java
+++ b/subprojects/gradle-shim/src/v7.6/java/dev/nokee/gradle/internal/v76/NamedDomainObjectProviderMixIn.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.gradle.internal.v76;
+
+import dev.nokee.utils.ConfigureUtils;
+import groovy.lang.Closure;
+import org.gradle.api.NamedDomainObjectProvider;
+
+interface NamedDomainObjectProviderMixIn<T> extends NamedDomainObjectProvider<T> {
+	default void configure(@SuppressWarnings("rawtypes") Closure closure) {
+		configure(ConfigureUtils.configureUsing(closure));
+	}
+}

--- a/subprojects/gradle-shim/src/v7.6/java/dev/nokee/gradle/internal/v76/ProviderInternalMixIn.java
+++ b/subprojects/gradle-shim/src/v7.6/java/dev/nokee/gradle/internal/v76/ProviderInternalMixIn.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.gradle.internal.v76;
+
+import org.gradle.api.Transformer;
+import org.gradle.api.internal.provider.ProviderInternal;
+import org.gradle.api.internal.provider.ValueSanitizer;
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
+import org.gradle.api.provider.Provider;
+import org.gradle.internal.DisplayName;
+
+import javax.annotation.Nullable;
+import java.util.function.BiFunction;
+
+interface ProviderInternalMixIn<T> extends ProviderInternal<T> {
+	ProviderInternal<T> getDelegate();
+
+	@Override
+	default T get() {
+		return getDelegate().get();
+	}
+
+	@Nullable
+	@Override
+	default T getOrNull() {
+		return getDelegate().getOrNull();
+	}
+
+	@Override
+	default T getOrElse(T defaultValue) {
+		return getDelegate().getOrElse(defaultValue);
+	}
+
+	@Override
+	default <S> ProviderInternal<S> map(Transformer<? extends S, ? super T> transformer) {
+		return getDelegate().map(transformer);
+	}
+
+	@Override
+	default Value<? extends T> calculateValue(ValueConsumer consumer) {
+		return getDelegate().calculateValue(consumer);
+	}
+
+	@Override
+	default <S> Provider<S> flatMap(Transformer<? extends Provider<? extends S>, ? super T> transformer) {
+		return getDelegate().flatMap(transformer);
+	}
+
+	@Override
+	default boolean isPresent() {
+		return getDelegate().isPresent();
+	}
+
+	@Override
+	default Provider<T> orElse(T value) {
+		return getDelegate().orElse(value);
+	}
+
+	@Override
+	default Provider<T> orElse(Provider<? extends T> provider) {
+		return getDelegate().orElse(provider);
+	}
+
+	@Override
+	@SuppressWarnings("deprecation")
+	default Provider<T> forUseAtConfigurationTime() {
+		return getDelegate().forUseAtConfigurationTime();
+	}
+
+	@Override
+	default ProviderInternal<T> asSupplier(DisplayName owner, Class<? super T> targetType, ValueSanitizer<? super T> sanitizer) {
+		return getDelegate().asSupplier(owner, targetType, sanitizer);
+	}
+
+	@Override
+	default ProviderInternal<T> withFinalValue(ValueConsumer consumer) {
+		return getDelegate().withFinalValue(consumer);
+	}
+
+	@Override
+	default ExecutionTimeValue<? extends T> calculateExecutionTimeValue() {
+		return getDelegate().calculateExecutionTimeValue();
+	}
+
+	@Override
+	default void visitDependencies(TaskDependencyResolveContext context) {
+		getDelegate().visitDependencies(context);
+	}
+
+	@Override
+	default ValueProducer getProducer() {
+		return getDelegate().getProducer();
+	}
+
+	@Override
+	default boolean calculatePresence(ValueConsumer consumer) {
+		return getDelegate().calculatePresence(consumer);
+	}
+
+	@Override
+	default <U, R> Provider<R> zip(Provider<U> right, BiFunction<? super T, ? super U, ? extends R> combiner) {
+		return getDelegate().zip(right, combiner);
+	}
+
+	@Override
+	default ProviderInternal<T> withSideEffect(@Nullable SideEffect<? super T> sideEffect) {
+		return getDelegate().withSideEffect(sideEffect);
+	}
+}

--- a/subprojects/ide-base/src/main/java/dev/nokee/ide/base/internal/plugins/AbstractIdePlugin.java
+++ b/subprojects/ide-base/src/main/java/dev/nokee/ide/base/internal/plugins/AbstractIdePlugin.java
@@ -18,13 +18,23 @@ package dev.nokee.ide.base.internal.plugins;
 import com.google.common.collect.ImmutableList;
 import dev.nokee.ide.base.IdeProject;
 import dev.nokee.ide.base.IdeProjectReference;
-import dev.nokee.ide.base.internal.*;
+import dev.nokee.ide.base.internal.BaseIdeCleanMetadata;
+import dev.nokee.ide.base.internal.BaseIdeProjectReference;
+import dev.nokee.ide.base.internal.IdeProjectExtension;
+import dev.nokee.ide.base.internal.IdeProjectInternal;
+import dev.nokee.ide.base.internal.IdeWorkspaceExtension;
+import dev.nokee.utils.TextCaseUtils;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
-import org.gradle.api.*;
+import org.gradle.api.Action;
+import org.gradle.api.Describable;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.UncheckedIOException;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.model.ObjectFactory;
@@ -41,19 +51,22 @@ import org.gradle.internal.logging.ConsoleRenderer;
 import org.gradle.plugins.ide.internal.IdeArtifactRegistry;
 import org.gradle.plugins.ide.internal.IdeProjectMetadata;
 import org.gradle.process.ExecOperations;
-import org.gradle.util.GUtil;
 
 import javax.inject.Inject;
 import java.awt.*;
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
 import static dev.nokee.utils.DeferredUtils.realize;
-import static dev.nokee.utils.GradleUtils.*;
+import static dev.nokee.utils.GradleUtils.isCompositeBuild;
+import static dev.nokee.utils.GradleUtils.isHostBuild;
 import static dev.nokee.utils.ProjectUtils.isRootProject;
 import static dev.nokee.utils.TaskNameUtils.getShortestName;
 
@@ -268,7 +281,7 @@ public abstract class AbstractIdePlugin<T extends IdeProject> implements Plugin<
 
 	@Override
 	public String getDisplayName() {
-		return Arrays.stream(GUtil.toWords(getExtensionName()).split(" ")).map(StringUtils::capitalize).collect(Collectors.joining(" ")) + " IDE";
+		return Arrays.stream(TextCaseUtils.toWords(getExtensionName()).split(" ")).map(StringUtils::capitalize).collect(Collectors.joining(" ")) + " IDE";
 	}
 
 	/**

--- a/subprojects/ide-base/src/testFixtures/groovy/dev/nokee/ide/fixtures/IdeCommandLineUtils.groovy
+++ b/subprojects/ide-base/src/testFixtures/groovy/dev/nokee/ide/fixtures/IdeCommandLineUtils.groovy
@@ -17,7 +17,6 @@ package dev.nokee.ide.fixtures
 
 import dev.gradleplugins.test.fixtures.file.TestFile
 import groovy.transform.CompileStatic
-import org.gradle.util.GUtil
 
 @CompileStatic
 abstract class IdeCommandLineUtils {
@@ -92,7 +91,11 @@ Actual: \${actual[key]}
 		Map<String, String> envvars = new HashMap<>()
 		envvars.putAll(System.getenv())
 
-		Properties props = GUtil.loadProperties(testDirectory.file("gradle-environment"))
+		Properties props = (Properties) testDirectory.file('gradle-environment').withInputStream {
+			final Properties properties = new Properties()
+			properties.load(it)
+			return properties
+		}
 		assert !props.isEmpty()
 
 		for (Map.Entry<Object, Object> entry : props.entrySet()) {

--- a/subprojects/ide-xcode/src/main/java/dev/nokee/ide/xcode/internal/plugins/XcodeIdePlugin.java
+++ b/subprojects/ide-xcode/src/main/java/dev/nokee/ide/xcode/internal/plugins/XcodeIdePlugin.java
@@ -31,6 +31,7 @@ import dev.nokee.platform.base.internal.IsComponent;
 import dev.nokee.platform.base.internal.plugins.ComponentModelBasePlugin;
 import dev.nokee.platform.base.internal.plugins.OnDiscover;
 import dev.nokee.platform.ios.tasks.internal.CreateIosApplicationBundleTask;
+import dev.nokee.utils.TextCaseUtils;
 import lombok.val;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -40,7 +41,6 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.file.FileCollection;
-import org.gradle.util.GUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -54,7 +54,7 @@ public abstract class XcodeIdePlugin implements Plugin<Project> {
 
 		project.getPlugins().withType(ComponentModelBasePlugin.class, mapComponentToXcodeIdeProjects(project, (XcodeIdeProjectExtension) project.getExtensions().getByName(XcodeIdeBasePlugin.XCODE_EXTENSION_NAME)));
 		project.getPluginManager().withPlugin("dev.nokee.objective-c-xctest-test-suite", appliedPlugin -> {
-			String moduleName = GUtil.toCamelCase(project.getName());
+			String moduleName = TextCaseUtils.toCamelCase(project.getName());
 
 			// The Xcode IDE model will sync the `.xctest` product but we need the `-Runner.app`.
 			// We can't just sync the `-Runner.app` as Xcode will complain about a missing `.xctest`.

--- a/subprojects/language-base/src/main/java/dev/nokee/language/base/ConfigurableSourceSet.java
+++ b/subprojects/language-base/src/main/java/dev/nokee/language/base/ConfigurableSourceSet.java
@@ -15,13 +15,13 @@
  */
 package dev.nokee.language.base;
 
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import groovy.transform.stc.ClosureParams;
 import groovy.transform.stc.SimpleType;
 import org.gradle.api.Action;
 import org.gradle.api.tasks.util.PatternFilterable;
-import org.gradle.util.ConfigureUtil;
 
 /**
  * Represent a configurable logical grouping of several files or directories.
@@ -47,7 +47,7 @@ public interface ConfigurableSourceSet extends SourceSet {
 	 */
 	ConfigurableSourceSet filter(Action<? super PatternFilterable> action);
 	default ConfigurableSourceSet filter(@ClosureParams(value = SimpleType.class, options = "org.gradle.api.tasks.util.PatternFilterable") @DelegatesTo(value = PatternFilterable.class, strategy = Closure.DELEGATE_FIRST) @SuppressWarnings("rawtypes") Closure closure) {
-		return filter(ConfigureUtil.configureUsing(closure));
+		return filter(ConfigureUtils.configureUsing(closure));
 	}
 
 	/**

--- a/subprojects/language-base/src/main/java/dev/nokee/language/base/FunctionalSourceSet.java
+++ b/subprojects/language-base/src/main/java/dev/nokee/language/base/FunctionalSourceSet.java
@@ -17,11 +17,11 @@ package dev.nokee.language.base;
 
 import dev.nokee.model.KnownDomainObject;
 import dev.nokee.platform.base.View;
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectProvider;
-import org.gradle.util.ConfigureUtil;
 
 /**
  * A view of the language source sets with a similar function (production code, test code, etc.).
@@ -65,7 +65,7 @@ public interface FunctionalSourceSet extends View<LanguageSourceSet> {
 	 * @param <S> The type of the element to configure.
 	 */
 	default <S extends LanguageSourceSet> void configure(String name, Class<S> type, @DelegatesTo(type = "S", strategy = Closure.DELEGATE_FIRST) @SuppressWarnings("rawtypes") Closure closure) {
-		configure(name, type, ConfigureUtil.configureUsing(closure));
+		configure(name, type, ConfigureUtils.configureUsing(closure));
 	}
 
 	<S extends LanguageSourceSet> NamedDomainObjectProvider<S> named(String name, Class<S> type);

--- a/subprojects/language-base/src/main/java/dev/nokee/language/base/internal/ModelBackedLanguageSourceSetLegacyMixIn.java
+++ b/subprojects/language-base/src/main/java/dev/nokee/language/base/internal/ModelBackedLanguageSourceSetLegacyMixIn.java
@@ -21,13 +21,13 @@ import dev.nokee.language.base.SelfAwareLanguageSourceSet;
 import dev.nokee.model.internal.core.ModelNodes;
 import dev.nokee.model.internal.core.ModelProperties;
 import dev.nokee.model.internal.names.FullyQualifiedNameComponent;
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.tasks.util.PatternFilterable;
-import org.gradle.util.ConfigureUtil;
 
 @SuppressWarnings("unchecked")
 public interface ModelBackedLanguageSourceSetLegacyMixIn<SELF extends LanguageSourceSet> extends SelfAwareLanguageSourceSet<SELF> {
@@ -55,7 +55,7 @@ public interface ModelBackedLanguageSourceSetLegacyMixIn<SELF extends LanguageSo
 	}
 
 	default SELF filter(@DelegatesTo(value = PatternFilterable.class, strategy = Closure.DELEGATE_FIRST) @SuppressWarnings("rawtypes") Closure closure) {
-		return filter(ConfigureUtil.configureUsing(closure));
+		return filter(ConfigureUtils.configureUsing(closure));
 	}
 
 	default PatternFilterable getFilter() {

--- a/subprojects/language-swift/src/main/java/dev/nokee/language/swift/internal/plugins/SwiftCompileTaskDefaultConfigurationRule.java
+++ b/subprojects/language-swift/src/main/java/dev/nokee/language/swift/internal/plugins/SwiftCompileTaskDefaultConfigurationRule.java
@@ -32,6 +32,7 @@ import dev.nokee.model.internal.names.ElementName;
 import dev.nokee.model.internal.registry.ModelRegistry;
 import dev.nokee.platform.base.internal.OutputDirectoryPath;
 import dev.nokee.platform.base.internal.util.PropertyUtils;
+import dev.nokee.utils.TextCaseUtils;
 import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.file.Directory;
@@ -39,7 +40,6 @@ import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.language.swift.SwiftVersion;
-import org.gradle.util.GUtil;
 
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
@@ -112,7 +112,7 @@ final class SwiftCompileTaskDefaultConfigurationRule extends ModelActionWithInpu
 	}
 
 	private static String toModuleName(ElementName name) {
-		return GUtil.toCamelCase(name.toString());
+		return TextCaseUtils.toCamelCase(name.toString());
 	}
 	//endregion
 

--- a/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/NokeeVersionManagementVersionPatternSmokeTest.java
+++ b/subprojects/nokee-version-management/src/functionalTest/java/dev/nokee/nvm/NokeeVersionManagementVersionPatternSmokeTest.java
@@ -38,7 +38,7 @@ class NokeeVersionManagementVersionPatternSmokeTest {
 	@GradleAtLeast("6.9")
 	void canLoadVersionFromNokeeServices(GradleRunner runner) {
 		singleNokeeBuild(TestLayout.newBuild(testDirectory)).rootBuild(applyAnyNokeePlugin().andThen(writeVersionFile("0.4.+")));
-		runner/*.publishBuildScans()*/.withTasks("verify").build(); // manually checked, it resolves a nightly version
+		runner/*.publishBuildScans()*/.withTasks("verify").withoutDeprecationChecks()/*until we release a new version*/.build(); // manually checked, it resolves a nightly version
 		// Although it's somewhat fine, we most likely want to use the concept of latest.release and latest.integration.
 		// We could consider supporting 0.4.+ which should mean latest.release under the 0.4 release (latest 0.4 patch release).
 		// In theory, it should not be a nightly version

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/HasApiDependencyBucket.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/HasApiDependencyBucket.java
@@ -15,6 +15,7 @@
  */
 package dev.nokee.platform.base;
 
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import groovy.transform.stc.ClosureParams;
@@ -24,7 +25,6 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ProjectDependency;
-import org.gradle.util.ConfigureUtil;
 
 /**
  * Represents something that carries an API dependency bucket represented by a {@link Configuration}.
@@ -51,7 +51,7 @@ public interface HasApiDependencyBucket {
 		getApi().addDependency(notation, action);
 	}
 	default void api(Object notation, @ClosureParams(value = SimpleType.class, options = "org.gradle.api.artifacts.ModuleDependency") @DelegatesTo(value = ModuleDependency.class, strategy = Closure.DELEGATE_FIRST) @SuppressWarnings("rawtypes") Closure closure) {
-		api(notation, ConfigureUtil.configureUsing(closure));
+		api(notation, ConfigureUtils.configureUsing(closure));
 	}
 
 	/**

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/HasCompileOnlyDependencyBucket.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/HasCompileOnlyDependencyBucket.java
@@ -15,6 +15,7 @@
  */
 package dev.nokee.platform.base;
 
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import groovy.transform.stc.ClosureParams;
@@ -24,7 +25,6 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ProjectDependency;
-import org.gradle.util.ConfigureUtil;
 
 /**
  * Represents something that carries a compile only dependency bucket represented by a {@link Configuration}.
@@ -53,7 +53,7 @@ public interface HasCompileOnlyDependencyBucket {
 		getCompileOnly().addDependency(notation, action);
 	}
 	default void compileOnly(Object notation, @ClosureParams(value = SimpleType.class, options = "org.gradle.api.artifacts.ModuleDependency") @DelegatesTo(value = ModuleDependency.class, strategy = Closure.DELEGATE_FIRST) @SuppressWarnings("rawtypes") Closure closure) {
-		compileOnly(notation, ConfigureUtil.configureUsing(closure));
+		compileOnly(notation, ConfigureUtils.configureUsing(closure));
 	}
 
 	/**

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/HasImplementationDependencyBucket.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/HasImplementationDependencyBucket.java
@@ -15,6 +15,7 @@
  */
 package dev.nokee.platform.base;
 
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import groovy.transform.stc.ClosureParams;
@@ -24,7 +25,6 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ProjectDependency;
-import org.gradle.util.ConfigureUtil;
 
 /**
  * Represents something that carries an implementation dependency bucket represented by a {@link Configuration}.
@@ -53,7 +53,7 @@ public interface HasImplementationDependencyBucket {
 		getImplementation().addDependency(notation, action);
 	}
 	default void implementation(Object notation, @ClosureParams(value = SimpleType.class, options = "org.gradle.api.artifacts.ModuleDependency") @DelegatesTo(value = ModuleDependency.class, strategy = Closure.DELEGATE_FIRST) @SuppressWarnings("rawtypes") Closure closure) {
-		implementation(notation, ConfigureUtil.configureUsing(closure));
+		implementation(notation, ConfigureUtils.configureUsing(closure));
 	}
 
 	/**

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/HasRuntimeOnlyDependencyBucket.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/HasRuntimeOnlyDependencyBucket.java
@@ -15,6 +15,7 @@
  */
 package dev.nokee.platform.base;
 
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import groovy.transform.stc.ClosureParams;
@@ -24,7 +25,6 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ProjectDependency;
-import org.gradle.util.ConfigureUtil;
 
 /**
  * Represents something that carries a runtime only dependency bucket represented by a {@link Configuration}.
@@ -53,7 +53,7 @@ public interface HasRuntimeOnlyDependencyBucket {
 		getRuntimeOnly().addDependency(notation, action);
 	}
 	default void runtimeOnly(Object notation, @ClosureParams(value = SimpleType.class, options = "org.gradle.api.artifacts.ModuleDependency") @DelegatesTo(value = ModuleDependency.class, strategy = Closure.DELEGATE_FIRST) @SuppressWarnings("rawtypes") Closure closure) {
-		runtimeOnly(notation, ConfigureUtil.configureUsing(closure));
+		runtimeOnly(notation, ConfigureUtils.configureUsing(closure));
 	}
 
 	/**

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/View.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/View.java
@@ -15,13 +15,13 @@
  */
 package dev.nokee.platform.base;
 
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.specs.Spec;
-import org.gradle.util.ConfigureUtil;
 
 import java.util.List;
 import java.util.Set;
@@ -50,7 +50,7 @@ public interface View<T> {
 	 * @param closure The closure to execute on each element for configuration.
 	 */
 	default void configureEach(@DelegatesTo(type = "T", strategy = Closure.DELEGATE_FIRST) @SuppressWarnings("rawtypes") Closure closure) {
-		configureEach(ConfigureUtil.configureUsing(closure));
+		configureEach(ConfigureUtils.configureUsing(closure));
 	}
 
 	/**
@@ -78,7 +78,7 @@ public interface View<T> {
 	 * @param closure the closure to execute on each element for configuration.
 	 */
 	default <S extends T> void configureEach(Class<S> type, @DelegatesTo(type = "S", strategy = Closure.DELEGATE_FIRST) @SuppressWarnings("rawtypes") Closure closure) {
-		configureEach(type, ConfigureUtil.configureUsing(closure));
+		configureEach(type, ConfigureUtils.configureUsing(closure));
 	}
 
 	/**
@@ -102,7 +102,7 @@ public interface View<T> {
 	 * @since 0.4
 	 */
 	default void configureEach(Spec<? super T> spec, @DelegatesTo(type = "S", strategy = Closure.DELEGATE_FIRST) @SuppressWarnings("rawtypes") Closure closure) {
-		configureEach(spec, ConfigureUtil.configureUsing(closure));
+		configureEach(spec, ConfigureUtils.configureUsing(closure));
 	}
 
 	/**

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/BaseName.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/BaseName.java
@@ -15,8 +15,8 @@
  */
 package dev.nokee.platform.base.internal;
 
+import dev.nokee.utils.TextCaseUtils;
 import lombok.EqualsAndHashCode;
-import org.gradle.util.GUtil;
 
 @EqualsAndHashCode
 public final class BaseName {
@@ -35,15 +35,15 @@ public final class BaseName {
 	}
 
 	public String getAsKebabCase() {
-		return GUtil.toWords(baseName.replace("_", ""), '-');
+		return TextCaseUtils.toKebabCase(baseName.replace("_", ""));
 	}
 
 	public String getAsCamelCase() {
-		return GUtil.toCamelCase(baseName.replace("_", ""));
+		return TextCaseUtils.toCamelCase(baseName.replace("_", ""));
 	}
 
 	public String getAsLowerCamelCase() {
-		return GUtil.toLowerCamelCase(baseName.replace("_", ""));
+		return TextCaseUtils.toLowerCamelCase(baseName.replace("_", ""));
 	}
 
 	@Override

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ModelBackedBinaryAwareComponentMixIn.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ModelBackedBinaryAwareComponentMixIn.java
@@ -20,9 +20,9 @@ import dev.nokee.model.internal.core.ModelNodes;
 import dev.nokee.platform.base.Binary;
 import dev.nokee.platform.base.BinaryAwareComponent;
 import dev.nokee.platform.base.BinaryView;
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
-import org.gradle.util.ConfigureUtil;
 
 public interface ModelBackedBinaryAwareComponentMixIn extends BinaryAwareComponent {
 	@Override
@@ -38,6 +38,6 @@ public interface ModelBackedBinaryAwareComponentMixIn extends BinaryAwareCompone
 
 	@Override
 	default void binaries(@SuppressWarnings("rawtypes") Closure closure) {
-		binaries(ConfigureUtil.configureUsing(closure));
+		binaries(ConfigureUtils.configureUsing(closure));
 	}
 }

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ModelBackedDependencyAwareComponentMixIn.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ModelBackedDependencyAwareComponentMixIn.java
@@ -19,9 +19,9 @@ import com.google.common.reflect.TypeToken;
 import dev.nokee.model.internal.core.ModelProperties;
 import dev.nokee.platform.base.ComponentDependencies;
 import dev.nokee.platform.base.DependencyAwareComponent;
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
-import org.gradle.util.ConfigureUtil;
 
 public interface ModelBackedDependencyAwareComponentMixIn<T extends ComponentDependencies, S extends T> extends DependencyAwareComponent<T> {
 	@Override
@@ -37,6 +37,6 @@ public interface ModelBackedDependencyAwareComponentMixIn<T extends ComponentDep
 
 	@Override
 	default void dependencies(@SuppressWarnings("rawtypes") Closure closure) {
-		dependencies(ConfigureUtil.configureUsing(closure));
+		dependencies(ConfigureUtils.configureUsing(closure));
 	}
 }

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ModelBackedTaskAwareComponentMixIn.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ModelBackedTaskAwareComponentMixIn.java
@@ -15,14 +15,13 @@
  */
 package dev.nokee.platform.base.internal;
 
-import dev.nokee.model.internal.core.ModelNodeUtils;
-import dev.nokee.model.internal.core.ModelNodes;
 import dev.nokee.model.internal.core.ModelProperties;
-import dev.nokee.platform.base.*;
+import dev.nokee.platform.base.TaskAwareComponent;
+import dev.nokee.platform.base.TaskView;
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.Task;
-import org.gradle.util.ConfigureUtil;
 
 public interface ModelBackedTaskAwareComponentMixIn extends TaskAwareComponent {
 	@Override
@@ -38,6 +37,6 @@ public interface ModelBackedTaskAwareComponentMixIn extends TaskAwareComponent {
 
 	@Override
 	default void tasks(@SuppressWarnings("rawtypes") Closure closure) {
-		tasks(ConfigureUtil.configureUsing(closure));
+		tasks(ConfigureUtils.configureUsing(closure));
 	}
 }

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ModelBackedVariantDimensions.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/ModelBackedVariantDimensions.java
@@ -25,12 +25,12 @@ import dev.nokee.model.internal.registry.ModelRegistry;
 import dev.nokee.platform.base.VariantDimensionBuilder;
 import dev.nokee.platform.base.VariantDimensions;
 import dev.nokee.runtime.core.CoordinateAxis;
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.Action;
 import org.gradle.api.provider.SetProperty;
-import org.gradle.util.ConfigureUtil;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -85,6 +85,6 @@ public final class ModelBackedVariantDimensions implements VariantDimensions, Mo
 	@Override
 	public <T> SetProperty<T> newAxis(Class<T> axisType, @SuppressWarnings("rawtypes") Closure closure) {
 		Objects.requireNonNull(closure);
-		return newAxis(axisType, ConfigureUtil.configureUsing(closure));
+		return newAxis(axisType, ConfigureUtils.configureUsing(closure));
 	}
 }

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/DependencyBuckets.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/DependencyBuckets.java
@@ -16,11 +16,11 @@
 package dev.nokee.platform.base.internal.dependencies;
 
 import dev.nokee.model.internal.names.ElementName;
+import dev.nokee.utils.TextCaseUtils;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.provider.Provider;
-import org.gradle.util.GUtil;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;
@@ -36,7 +36,7 @@ public final class DependencyBuckets {
 	 */
 	public static String defaultDisplayName(ElementName name) {
 		assert name != null;
-		return Arrays.stream(GUtil.toWords(name.toString()).split(" ")).map(it -> {
+		return Arrays.stream(TextCaseUtils.toWords(name.toString()).split(" ")).map(it -> {
 			if (it.equals("api")) {
 				return "API";
 			} else if (it.equals("jvm")) {

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/HasIosResources.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/HasIosResources.java
@@ -15,12 +15,12 @@
  */
 package dev.nokee.platform.ios;
 
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 
 import static dev.nokee.language.base.internal.SourceAwareComponentUtils.sourceViewOf;
-import static org.gradle.util.ConfigureUtil.configureUsing;
 
 /**
  * Represents a component that carries iOS resources.
@@ -57,6 +57,6 @@ public interface HasIosResources {
 	 * @see #getResources()
 	 */
 	default void resources(@DelegatesTo(value = IosResourceSet.class, strategy = Closure.DELEGATE_FIRST) @SuppressWarnings("rawtypes") Closure closure) {
-		resources(configureUsing(closure));
+		resources(ConfigureUtils.configureUsing(closure));
 	}
 }

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationComponent.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/DefaultIosApplicationComponent.java
@@ -63,6 +63,7 @@ import dev.nokee.platform.nativebase.internal.rules.CreateVariantAssembleLifecyc
 import dev.nokee.platform.nativebase.internal.rules.CreateVariantAwareComponentObjectsLifecycleTaskRule;
 import dev.nokee.platform.nativebase.internal.rules.CreateVariantObjectsLifecycleTaskRule;
 import dev.nokee.platform.nativebase.tasks.LinkExecutable;
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import lombok.Getter;
 import lombok.val;
@@ -79,7 +80,6 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.nativeplatform.toolchain.Swiftc;
-import org.gradle.util.ConfigureUtil;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -137,7 +137,7 @@ public /*final*/ class DefaultIosApplicationComponent extends BaseNativeComponen
 
 	@Override
 	public void dependencies(@SuppressWarnings("rawtypes") Closure closure) {
-		dependencies(ConfigureUtil.configureUsing(closure));
+		dependencies(ConfigureUtils.configureUsing(closure));
 	}
 
 	@Override

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/ObjectiveCIosApplicationPlugin.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/ObjectiveCIosApplicationPlugin.java
@@ -54,6 +54,7 @@ import dev.nokee.platform.nativebase.internal.dependencies.ModelBackedNativeComp
 import dev.nokee.runtime.darwin.internal.plugins.DarwinRuntimePlugin;
 import dev.nokee.runtime.nativebase.MachineArchitecture;
 import dev.nokee.runtime.nativebase.OperatingSystemFamily;
+import dev.nokee.utils.TextCaseUtils;
 import lombok.val;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -62,7 +63,6 @@ import org.gradle.model.RuleSource;
 import org.gradle.nativeplatform.toolchain.Clang;
 import org.gradle.nativeplatform.toolchain.NativeToolChainRegistry;
 import org.gradle.nativeplatform.toolchain.internal.gcc.DefaultGccPlatformToolChain;
-import org.gradle.util.GUtil;
 
 import java.util.Arrays;
 
@@ -89,7 +89,7 @@ public class ObjectiveCIosApplicationPlugin implements Plugin<Project> {
 		project.getPluginManager().apply(IosResourcePlugin.class);
 
 		val componentProvider = project.getExtensions().getByType(ModelRegistry.class).register(objectiveCIosApplication("main", project)).as(ObjectiveCIosApplication.class);
-		componentProvider.configure(baseName(convention(GUtil.toCamelCase(project.getName()))));
+		componentProvider.configure(baseName(convention(TextCaseUtils.toCamelCase(project.getName()))));
 		componentProvider.configure(configureUsingProjection(DefaultIosApplicationComponent.class, (t, projection) -> projection.getGroupId().set(GroupId.of(project::getGroup))));
 		project.getExtensions().add(ObjectiveCIosApplication.class, EXTENSION_NAME, componentProvider.get());
 

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/SwiftIosApplicationPlugin.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/SwiftIosApplicationPlugin.java
@@ -51,11 +51,11 @@ import dev.nokee.platform.nativebase.internal.ModelBackedTargetLinkageAwareCompo
 import dev.nokee.platform.nativebase.internal.ModelBackedTargetMachineAwareComponentMixIn;
 import dev.nokee.platform.nativebase.internal.dependencies.ModelBackedNativeComponentDependencies;
 import dev.nokee.runtime.darwin.internal.plugins.DarwinRuntimePlugin;
+import dev.nokee.utils.TextCaseUtils;
 import lombok.val;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.nativeplatform.toolchain.plugins.SwiftCompilerPlugin;
-import org.gradle.util.GUtil;
 
 import static dev.nokee.model.internal.tags.ModelTags.tag;
 import static dev.nokee.platform.base.internal.BaseNameActions.baseName;
@@ -77,7 +77,7 @@ public class SwiftIosApplicationPlugin implements Plugin<Project> {
 		project.getPluginManager().apply(IosResourcePlugin.class);
 
 		val componentProvider = project.getExtensions().getByType(ModelRegistry.class).register(swiftIosApplication("main", project)).as(SwiftIosApplication.class);
-		componentProvider.configure(baseName(convention(GUtil.toCamelCase(project.getName()))));
+		componentProvider.configure(baseName(convention(TextCaseUtils.toCamelCase(project.getName()))));
 		componentProvider.configure(configureUsingProjection(DefaultIosApplicationComponent.class, (t, projection) -> projection.getGroupId().set(GroupId.of(project::getGroup))));
 		project.getExtensions().add(SwiftIosApplication.class, EXTENSION_NAME, componentProvider.get());
 

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/JavaNativeInterfaceLibraryComponentDependencies.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/JavaNativeInterfaceLibraryComponentDependencies.java
@@ -18,13 +18,13 @@ package dev.nokee.platform.jni;
 import dev.nokee.platform.base.ComponentDependencies;
 import dev.nokee.platform.base.DependencyBucket;
 import dev.nokee.platform.base.HasApiDependencyBucket;
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ProjectDependency;
-import org.gradle.util.ConfigureUtil;
 
 /**
  * Allows the API, JVM implementation and native implementation dependencies of a Java Native Interface (JNI) library to be specified.
@@ -57,7 +57,7 @@ public interface JavaNativeInterfaceLibraryComponentDependencies extends JavaNat
 	 * @param closure The closure to run to configure the dependency (project dependencies are {@link ProjectDependency} and external dependencies are {@link ExternalModuleDependency}).
 	 */
 	default void jvmImplementation(Object notation, @DelegatesTo(value = ModuleDependency.class, strategy = Closure.DELEGATE_FIRST) @SuppressWarnings("rawtypes") Closure closure) {
-		jvmImplementation(notation, ConfigureUtil.configureUsing(closure));
+		jvmImplementation(notation, ConfigureUtils.configureUsing(closure));
 	}
 
 	/**
@@ -85,7 +85,7 @@ public interface JavaNativeInterfaceLibraryComponentDependencies extends JavaNat
 	 * @param closure The closure to run to configure the dependency (project dependencies are {@link ProjectDependency} and external dependencies are {@link ExternalModuleDependency}).
 	 */
 	default void jvmRuntimeOnly(Object notation, @DelegatesTo(value = ModuleDependency.class, strategy = Closure.DELEGATE_FIRST) @SuppressWarnings("rawtypes") Closure closure) {
-		jvmRuntimeOnly(notation, ConfigureUtil.configureUsing(closure));
+		jvmRuntimeOnly(notation, ConfigureUtils.configureUsing(closure));
 	}
 
 	/**

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/JavaNativeInterfaceNativeComponentDependencies.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/JavaNativeInterfaceNativeComponentDependencies.java
@@ -17,13 +17,13 @@ package dev.nokee.platform.jni;
 
 import dev.nokee.platform.base.ComponentDependencies;
 import dev.nokee.platform.base.DependencyBucket;
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ProjectDependency;
-import org.gradle.util.ConfigureUtil;
 
 /**
  * Allows the native implementation dependencies of a Java Native Interface (JNI) library to be specified.
@@ -57,7 +57,7 @@ public interface JavaNativeInterfaceNativeComponentDependencies extends Componen
 	 * @param closure The closure to run to configure the dependency (project dependencies are {@link ProjectDependency} and external dependencies are {@link ExternalModuleDependency}).
 	 */
 	default void nativeImplementation(Object notation, @DelegatesTo(value = ModuleDependency.class, strategy = Closure.DELEGATE_FIRST) @SuppressWarnings("rawtypes") Closure closure) {
-		nativeImplementation(notation, ConfigureUtil.configureUsing(closure));
+		nativeImplementation(notation, ConfigureUtils.configureUsing(closure));
 	}
 
 	/**
@@ -87,7 +87,7 @@ public interface JavaNativeInterfaceNativeComponentDependencies extends Componen
 	 * @since 0.4
 	 */
 	default void nativeLinkOnly(Object notation, @DelegatesTo(value = ModuleDependency.class, strategy = Closure.DELEGATE_FIRST) @SuppressWarnings("rawtypes") Closure closure) {
-		nativeLinkOnly(notation, ConfigureUtil.configureUsing(closure));
+		nativeLinkOnly(notation, ConfigureUtils.configureUsing(closure));
 	}
 
 	/**
@@ -115,7 +115,7 @@ public interface JavaNativeInterfaceNativeComponentDependencies extends Componen
 	 * @param closure The closure to run to configure the dependency (project dependencies are {@link ProjectDependency} and external dependencies are {@link ExternalModuleDependency}).
 	 */
 	default void nativeRuntimeOnly(Object notation, @DelegatesTo(value = ModuleDependency.class, strategy = Closure.DELEGATE_FIRST) @SuppressWarnings("rawtypes") Closure closure) {
-		nativeRuntimeOnly(notation, ConfigureUtil.configureUsing(closure));
+		nativeRuntimeOnly(notation, ConfigureUtils.configureUsing(closure));
 	}
 
 	/**

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/JniLibrary.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/JniLibrary.java
@@ -17,7 +17,12 @@ package dev.nokee.platform.jni;
 
 import dev.nokee.language.base.LanguageSourceSet;
 import dev.nokee.language.base.SourceView;
-import dev.nokee.platform.base.*;
+import dev.nokee.platform.base.BinaryAwareComponent;
+import dev.nokee.platform.base.DependencyAwareComponent;
+import dev.nokee.platform.base.HasBaseName;
+import dev.nokee.platform.base.SourceAwareComponent;
+import dev.nokee.platform.base.TaskAwareComponent;
+import dev.nokee.platform.base.Variant;
 import dev.nokee.platform.nativebase.SharedLibraryBinary;
 import dev.nokee.runtime.nativebase.TargetMachine;
 import dev.nokee.utils.ConfigureUtils;
@@ -26,7 +31,6 @@ import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.provider.Property;
-import org.gradle.util.ConfigureUtil;
 
 /**
  * Configuration for a specific Java Native Interface (JNI) library variant, defining the dependencies that make up the library plus other settings.

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/JniLibrary.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/JniLibrary.java
@@ -20,6 +20,7 @@ import dev.nokee.language.base.SourceView;
 import dev.nokee.platform.base.*;
 import dev.nokee.platform.nativebase.SharedLibraryBinary;
 import dev.nokee.runtime.nativebase.TargetMachine;
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
@@ -76,7 +77,7 @@ public interface JniLibrary extends Variant
 	 * @since 0.3
 	 */
 	default void sharedLibrary(@DelegatesTo(value = SharedLibraryBinary.class, strategy = Closure.DELEGATE_FIRST) @SuppressWarnings("rawtypes") Closure closure) {
-		sharedLibrary(ConfigureUtil.configureUsing(closure));
+		sharedLibrary(ConfigureUtils.configureUsing(closure));
 	}
 
 	JniJarBinary getJavaNativeInterfaceJar();

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JavaNativeInterfaceSourcesViewAdapter.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JavaNativeInterfaceSourcesViewAdapter.java
@@ -23,13 +23,13 @@ import dev.nokee.model.KnownDomainObject;
 import dev.nokee.platform.base.View;
 import dev.nokee.platform.base.internal.ViewAdapter;
 import dev.nokee.platform.jni.JavaNativeInterfaceLibrarySources;
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Transformer;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.specs.Spec;
-import org.gradle.util.ConfigureUtil;
 
 import java.util.List;
 import java.util.Set;
@@ -54,7 +54,7 @@ public final class JavaNativeInterfaceSourcesViewAdapter implements JavaNativeIn
 	}
 
 	public void groovy(@SuppressWarnings("rawtypes") Closure closure) {
-		groovy(ConfigureUtil.configureUsing(closure));
+		groovy(ConfigureUtils.configureUsing(closure));
 	}
 
 	public NamedDomainObjectProvider<JavaSourceSet> getJava() {
@@ -70,7 +70,7 @@ public final class JavaNativeInterfaceSourcesViewAdapter implements JavaNativeIn
 	}
 
 	public void java(@SuppressWarnings("rawtypes") Closure closure) {
-		java(ConfigureUtil.configureUsing(closure));
+		java(ConfigureUtils.configureUsing(closure));
 	}
 
 	public NamedDomainObjectProvider<KotlinSourceSet> getKotlin() {
@@ -86,7 +86,7 @@ public final class JavaNativeInterfaceSourcesViewAdapter implements JavaNativeIn
 	}
 
 	public void kotlin(@SuppressWarnings("rawtypes") Closure closure) {
-		kotlin(ConfigureUtil.configureUsing(closure));
+		kotlin(ConfigureUtils.configureUsing(closure));
 	}
 
 	@Override

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryInternal.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryInternal.java
@@ -52,7 +52,6 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.reflect.HasPublicType;
 import org.gradle.api.reflect.TypeOf;
 import org.gradle.api.tasks.TaskProvider;
-import org.gradle.util.ConfigureUtil;
 
 import static dev.nokee.model.internal.type.GradlePropertyTypes.property;
 import static dev.nokee.model.internal.type.ModelType.of;

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryInternal.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/JniLibraryInternal.java
@@ -43,6 +43,7 @@ import dev.nokee.platform.jni.JniJarBinary;
 import dev.nokee.platform.jni.JniLibrary;
 import dev.nokee.platform.nativebase.SharedLibraryBinary;
 import dev.nokee.runtime.nativebase.TargetMachine;
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.Task;
@@ -109,7 +110,7 @@ public /*final*/ class JniLibraryInternal extends BaseVariant implements JniLibr
 
 	@Override
 	public void sharedLibrary(@SuppressWarnings("rawtypes") Closure closure) {
-		sharedLibrary(ConfigureUtil.configureUsing(closure));
+		sharedLibrary(ConfigureUtils.configureUsing(closure));
 	}
 
 	public TargetMachine getTargetMachine() {

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/ModelBackedJavaNativeInterfaceLibraryComponentDependencies.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/ModelBackedJavaNativeInterfaceLibraryComponentDependencies.java
@@ -21,11 +21,11 @@ import dev.nokee.model.internal.core.ModelNodeAware;
 import dev.nokee.model.internal.core.ModelNodeContext;
 import dev.nokee.platform.base.DependencyBucket;
 import dev.nokee.platform.jni.JavaNativeInterfaceLibraryComponentDependencies;
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.provider.MapProperty;
-import org.gradle.util.ConfigureUtil;
 
 public final class ModelBackedJavaNativeInterfaceLibraryComponentDependencies implements JavaNativeInterfaceLibraryComponentDependencies, ModelNodeAware {
 	private final ModelNode node = ModelNodeContext.getCurrentModelNode();
@@ -42,7 +42,7 @@ public final class ModelBackedJavaNativeInterfaceLibraryComponentDependencies im
 
 	@Override
 	public void api(Object notation, @SuppressWarnings("rawtypes") Closure closure) {
-		getApi().addDependency(notation, ConfigureUtil.configureUsing(closure));
+		getApi().addDependency(notation, ConfigureUtils.configureUsing(closure));
 	}
 
 	@Override
@@ -63,7 +63,7 @@ public final class ModelBackedJavaNativeInterfaceLibraryComponentDependencies im
 
 	@Override
 	public void jvmImplementation(Object notation, @SuppressWarnings("rawtypes") Closure closure) {
-		getJvmImplementation().addDependency(notation, ConfigureUtil.configureUsing(closure));
+		getJvmImplementation().addDependency(notation, ConfigureUtils.configureUsing(closure));
 	}
 
 	@Override
@@ -84,7 +84,7 @@ public final class ModelBackedJavaNativeInterfaceLibraryComponentDependencies im
 
 	@Override
 	public void jvmRuntimeOnly(Object notation, @SuppressWarnings("rawtypes") Closure closure) {
-		getJvmRuntimeOnly().addDependency(notation, ConfigureUtil.configureUsing(closure));
+		getJvmRuntimeOnly().addDependency(notation, ConfigureUtils.configureUsing(closure));
 	}
 
 	@Override
@@ -105,7 +105,7 @@ public final class ModelBackedJavaNativeInterfaceLibraryComponentDependencies im
 
 	@Override
 	public void nativeImplementation(Object notation, @SuppressWarnings("rawtypes") Closure closure) {
-		getNativeImplementation().addDependency(notation, ConfigureUtil.configureUsing(closure));
+		getNativeImplementation().addDependency(notation, ConfigureUtils.configureUsing(closure));
 	}
 
 	@Override
@@ -126,7 +126,7 @@ public final class ModelBackedJavaNativeInterfaceLibraryComponentDependencies im
 
 	@Override
 	public void nativeLinkOnly(Object notation, @SuppressWarnings("rawtypes") Closure closure) {
-		getNativeLinkOnly().addDependency(notation, ConfigureUtil.configureUsing(closure));
+		getNativeLinkOnly().addDependency(notation, ConfigureUtils.configureUsing(closure));
 	}
 
 	@Override
@@ -147,7 +147,7 @@ public final class ModelBackedJavaNativeInterfaceLibraryComponentDependencies im
 
 	@Override
 	public void nativeRuntimeOnly(Object notation, @SuppressWarnings("rawtypes") Closure closure) {
-		getNativeRuntimeOnly().addDependency(notation, ConfigureUtil.configureUsing(closure));
+		getNativeRuntimeOnly().addDependency(notation, ConfigureUtils.configureUsing(closure));
 	}
 
 	@Override

--- a/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/ModelBackedJavaNativeInterfaceNativeComponentDependencies.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/platform/jni/internal/ModelBackedJavaNativeInterfaceNativeComponentDependencies.java
@@ -21,11 +21,11 @@ import dev.nokee.model.internal.core.ModelNodeAware;
 import dev.nokee.model.internal.core.ModelNodeContext;
 import dev.nokee.platform.base.DependencyBucket;
 import dev.nokee.platform.jni.JavaNativeInterfaceNativeComponentDependencies;
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.provider.MapProperty;
-import org.gradle.util.ConfigureUtil;
 
 public final class ModelBackedJavaNativeInterfaceNativeComponentDependencies implements JavaNativeInterfaceNativeComponentDependencies, ModelNodeAware {
 	private final ModelNode node = ModelNodeContext.getCurrentModelNode();
@@ -42,7 +42,7 @@ public final class ModelBackedJavaNativeInterfaceNativeComponentDependencies imp
 
 	@Override
 	public void nativeImplementation(Object notation, @SuppressWarnings("rawtypes") Closure closure) {
-		getNativeImplementation().addDependency(notation, ConfigureUtil.configureUsing(closure));
+		getNativeImplementation().addDependency(notation, ConfigureUtils.configureUsing(closure));
 	}
 
 	@Override
@@ -63,7 +63,7 @@ public final class ModelBackedJavaNativeInterfaceNativeComponentDependencies imp
 
 	@Override
 	public void nativeLinkOnly(Object notation, @SuppressWarnings("rawtypes") Closure closure) {
-		getNativeLinkOnly().addDependency(notation, ConfigureUtil.configureUsing(closure));
+		getNativeLinkOnly().addDependency(notation, ConfigureUtils.configureUsing(closure));
 	}
 
 	@Override
@@ -84,7 +84,7 @@ public final class ModelBackedJavaNativeInterfaceNativeComponentDependencies imp
 
 	@Override
 	public void nativeRuntimeOnly(Object notation, @SuppressWarnings("rawtypes") Closure closure) {
-		getNativeRuntimeOnly().addDependency(notation, ConfigureUtil.configureUsing(closure));
+		getNativeRuntimeOnly().addDependency(notation, ConfigureUtils.configureUsing(closure));
 	}
 
 	@Override

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/HasLinkOnlyDependencyBucket.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/HasLinkOnlyDependencyBucket.java
@@ -16,6 +16,7 @@
 package dev.nokee.platform.nativebase;
 
 import dev.nokee.platform.base.DependencyBucket;
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import groovy.transform.stc.ClosureParams;
@@ -25,7 +26,6 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ProjectDependency;
-import org.gradle.util.ConfigureUtil;
 
 /**
  * Represents something that carries a link only dependency bucket represented by a {@link Configuration}.
@@ -54,7 +54,7 @@ public interface HasLinkOnlyDependencyBucket {
 		getLinkOnly().addDependency(notation, action);
 	}
 	default void linkOnly(Object notation, @ClosureParams(value = SimpleType.class, options = "org.gradle.api.artifacts.ModuleDependency") @DelegatesTo(value = ModuleDependency.class, strategy = Closure.DELEGATE_FIRST) @SuppressWarnings("rawtypes") Closure closure) {
-		linkOnly(notation, ConfigureUtil.configureUsing(closure));
+		linkOnly(notation, ConfigureUtils.configureUsing(closure));
 	}
 
 	/**

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeApplicationComponent.java
@@ -43,12 +43,12 @@ import dev.nokee.platform.nativebase.NativeApplicationComponentDependencies;
 import dev.nokee.platform.nativebase.internal.rules.CreateVariantAssembleLifecycleTaskRule;
 import dev.nokee.platform.nativebase.internal.rules.CreateVariantAwareComponentObjectsLifecycleTaskRule;
 import dev.nokee.platform.nativebase.internal.rules.CreateVariantObjectsLifecycleTaskRule;
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
-import org.gradle.util.ConfigureUtil;
 
 import javax.inject.Inject;
 import java.util.Set;
@@ -91,7 +91,7 @@ public /*final*/ class DefaultNativeApplicationComponent extends BaseNativeCompo
 
 	@Override
 	public void dependencies(@SuppressWarnings("rawtypes") Closure closure) {
-		dependencies(ConfigureUtil.configureUsing(closure));
+		dependencies(ConfigureUtils.configureUsing(closure));
 	}
 
 	@Override

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryComponent.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/DefaultNativeLibraryComponent.java
@@ -43,12 +43,12 @@ import dev.nokee.platform.nativebase.NativeLibraryComponentDependencies;
 import dev.nokee.platform.nativebase.internal.rules.CreateVariantAssembleLifecycleTaskRule;
 import dev.nokee.platform.nativebase.internal.rules.CreateVariantAwareComponentObjectsLifecycleTaskRule;
 import dev.nokee.platform.nativebase.internal.rules.CreateVariantObjectsLifecycleTaskRule;
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
-import org.gradle.util.ConfigureUtil;
 
 import javax.inject.Inject;
 import java.util.Set;
@@ -91,7 +91,7 @@ public /*final*/ class DefaultNativeLibraryComponent extends BaseNativeComponent
 
 	@Override
 	public void dependencies(@SuppressWarnings("rawtypes") Closure closure) {
-		dependencies(ConfigureUtil.configureUsing(closure));
+		dependencies(ConfigureUtils.configureUsing(closure));
 	}
 
 	@Override

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/archiving/NativeArchiveTaskRegistrationRule.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/archiving/NativeArchiveTaskRegistrationRule.java
@@ -22,7 +22,6 @@ import dev.nokee.language.base.HasDestinationDirectory;
 import dev.nokee.language.nativebase.internal.NativeToolChainSelector;
 import dev.nokee.model.DomainObjectIdentifier;
 import dev.nokee.model.DomainObjectProvider;
-import dev.nokee.model.internal.core.IdentifierComponent;
 import dev.nokee.model.internal.core.ModelActionWithInputs;
 import dev.nokee.model.internal.core.ModelComponentReference;
 import dev.nokee.model.internal.core.ModelNode;
@@ -33,6 +32,7 @@ import dev.nokee.platform.base.internal.OutputDirectoryPath;
 import dev.nokee.platform.base.internal.util.PropertyUtils;
 import dev.nokee.platform.nativebase.tasks.ObjectLink;
 import dev.nokee.platform.nativebase.tasks.internal.CreateStaticLibraryTask;
+import dev.nokee.utils.TextCaseUtils;
 import lombok.val;
 import org.gradle.api.Action;
 import org.gradle.api.Task;
@@ -50,7 +50,6 @@ import org.gradle.nativeplatform.toolchain.NativeToolChain;
 import org.gradle.nativeplatform.toolchain.Swiftc;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
-import org.gradle.util.GUtil;
 
 import java.util.Objects;
 import java.util.function.BiConsumer;
@@ -61,7 +60,6 @@ import static dev.nokee.platform.base.internal.util.PropertyUtils.CollectionProp
 import static dev.nokee.platform.base.internal.util.PropertyUtils.convention;
 import static dev.nokee.platform.base.internal.util.PropertyUtils.lockProperty;
 import static dev.nokee.platform.base.internal.util.PropertyUtils.wrap;
-import static dev.nokee.utils.TaskUtils.configureDescription;
 
 final class NativeArchiveTaskRegistrationRule extends ModelActionWithInputs.ModelAction1<ModelProjection> {
 	private final ModelRegistry registry;
@@ -143,7 +141,7 @@ final class NativeArchiveTaskRegistrationRule extends ModelActionWithInputs.Mode
 	}
 
 	private static Transformer<String, String> toModuleName() {
-		return GUtil::toCamelCase;
+		return TextCaseUtils::toCamelCase;
 	}
 	//endregion
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/linking/ConfigureLinkTaskFromBaseNameRule.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/linking/ConfigureLinkTaskFromBaseNameRule.java
@@ -26,6 +26,7 @@ import dev.nokee.platform.base.internal.util.PropertyUtils;
 import dev.nokee.platform.nativebase.BundleBinary;
 import dev.nokee.platform.nativebase.ExecutableBinary;
 import dev.nokee.platform.nativebase.tasks.ObjectLink;
+import dev.nokee.utils.TextCaseUtils;
 import lombok.val;
 import org.gradle.api.Action;
 import org.gradle.api.Task;
@@ -42,7 +43,6 @@ import org.gradle.nativeplatform.toolchain.NativeToolChain;
 import org.gradle.nativeplatform.toolchain.Swiftc;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
-import org.gradle.util.GUtil;
 
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -91,7 +91,7 @@ final class ConfigureLinkTaskFromBaseNameRule extends ModelActionWithInputs.Mode
 	}
 
 	private static Transformer<String, String> toModuleName() {
-		return GUtil::toCamelCase;
+		return TextCaseUtils::toCamelCase;
 	}
 	//endregion
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/linking/NativeLinkTaskRegistrationRule.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/linking/NativeLinkTaskRegistrationRule.java
@@ -43,6 +43,7 @@ import dev.nokee.platform.nativebase.tasks.ObjectLink;
 import dev.nokee.platform.nativebase.tasks.internal.LinkBundleTask;
 import dev.nokee.platform.nativebase.tasks.internal.LinkExecutableTask;
 import dev.nokee.platform.nativebase.tasks.internal.LinkSharedLibraryTask;
+import dev.nokee.utils.TextCaseUtils;
 import lombok.val;
 import org.gradle.api.Action;
 import org.gradle.api.Task;
@@ -60,7 +61,6 @@ import org.gradle.nativeplatform.toolchain.NativeToolChain;
 import org.gradle.nativeplatform.toolchain.Swiftc;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
-import org.gradle.util.GUtil;
 
 import java.lang.reflect.ParameterizedType;
 import java.util.Objects;
@@ -189,7 +189,7 @@ final class NativeLinkTaskRegistrationRule extends ModelActionWithInputs.ModelAc
 	}
 
 	private static Transformer<String, String> toModuleName() {
-		return GUtil::toCamelCase;
+		return TextCaseUtils::toCamelCase;
 	}
 	//endregion
 

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeComponentBasePlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeComponentBasePlugin.java
@@ -135,6 +135,7 @@ import dev.nokee.runtime.nativebase.TargetLinkage;
 import dev.nokee.runtime.nativebase.internal.NativeRuntimePlugin;
 import dev.nokee.runtime.nativebase.internal.TargetLinkages;
 import dev.nokee.utils.Optionals;
+import dev.nokee.utils.TextCaseUtils;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.Action;
@@ -148,7 +149,6 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Sync;
-import org.gradle.util.GUtil;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -264,7 +264,7 @@ public class NativeComponentBasePlugin implements Plugin<Project> {
 				}));
 				registry.instantiate(configureEach(descendantOf(entity.getId()), SwiftSourceSetSpec.class, sourceSet -> {
 					sourceSet.getCompileTask().configure(task -> NativePlatformFactory.create(buildVariant).ifPresent(task.getTargetPlatform()::set));
-					sourceSet.getCompileTask().configure(task -> task.getModuleName().set(project.getProviders().provider(() -> GUtil.toCamelCase(ModelStates.finalize(ModelNodes.of(sourceSet).get(ParentComponent.class).get()).get(BaseNameComponent.class).get()))));
+					sourceSet.getCompileTask().configure(task -> task.getModuleName().set(project.getProviders().provider(() -> TextCaseUtils.toCamelCase(ModelStates.finalize(ModelNodes.of(sourceSet).get(ParentComponent.class).get()).get(BaseNameComponent.class).get()))));
 					ModelNodes.of(sourceSet).addComponent(new BuildVariantComponent(buildVariant));
 				}));
 

--- a/subprojects/platform-native/src/testFixtures/groovy/dev/nokee/fixtures/AbstractPluginGroovyDslTest.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/dev/nokee/fixtures/AbstractPluginGroovyDslTest.groovy
@@ -16,10 +16,10 @@
 package dev.nokee.fixtures
 
 import dev.nokee.internal.testing.util.ProjectTestUtils
+import dev.nokee.utils.TextCaseUtils
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
-import org.gradle.util.GUtil
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -50,7 +50,7 @@ abstract class AbstractPluginGroovyDslTest extends Specification {
 	}
 
 	protected String getPluginId() {
-		return 'dev.nokee.' + GUtil.toWords(getClass().simpleName.replace('Plugin_GroovyDslTest', '')).split(' ').collect { it.toLowerCase() }.join('-')
+		return 'dev.nokee.' + TextCaseUtils.toWords(getClass().simpleName.replace('Plugin_GroovyDslTest', '')).split(' ').collect { it.toLowerCase() }.join('-')
 	}
 
 	private List<PropertyGetter> discoverTypes(String pluginId) {

--- a/subprojects/platform-swift/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftApplicationPlugin.java
+++ b/subprojects/platform-swift/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftApplicationPlugin.java
@@ -48,6 +48,7 @@ import dev.nokee.platform.nativebase.internal.NativeApplicationComponentModelReg
 import dev.nokee.platform.nativebase.internal.dependencies.ModelBackedNativeApplicationComponentDependencies;
 import dev.nokee.platform.nativebase.internal.plugins.NativeComponentBasePlugin;
 import dev.nokee.platform.swift.SwiftApplication;
+import dev.nokee.utils.TextCaseUtils;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.val;
@@ -55,7 +56,6 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.nativeplatform.toolchain.plugins.SwiftCompilerPlugin;
-import org.gradle.util.GUtil;
 
 import javax.inject.Inject;
 
@@ -81,7 +81,7 @@ public class SwiftApplicationPlugin implements Plugin<Project> {
 		project.getPluginManager().apply(NativeComponentBasePlugin.class);
 		project.getPluginManager().apply(SwiftLanguageBasePlugin.class);
 		val componentProvider = project.getExtensions().getByType(ModelRegistry.class).register(swiftApplication("main", project)).as(SwiftApplication.class);
-		componentProvider.configure(baseName(convention(GUtil.toCamelCase(project.getName()))));
+		componentProvider.configure(baseName(convention(TextCaseUtils.toCamelCase(project.getName()))));
 		val extension = componentProvider.get();
 
 		// Other configurations

--- a/subprojects/platform-swift/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftLibraryPlugin.java
+++ b/subprojects/platform-swift/src/main/java/dev/nokee/platform/swift/internal/plugins/SwiftLibraryPlugin.java
@@ -48,6 +48,7 @@ import dev.nokee.platform.nativebase.internal.NativeLibraryComponentModelRegistr
 import dev.nokee.platform.nativebase.internal.dependencies.ModelBackedNativeLibraryComponentDependencies;
 import dev.nokee.platform.nativebase.internal.plugins.NativeComponentBasePlugin;
 import dev.nokee.platform.swift.SwiftLibrary;
+import dev.nokee.utils.TextCaseUtils;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.val;
@@ -55,7 +56,6 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.nativeplatform.toolchain.plugins.SwiftCompilerPlugin;
-import org.gradle.util.GUtil;
 
 import javax.inject.Inject;
 
@@ -81,7 +81,7 @@ public class SwiftLibraryPlugin implements Plugin<Project> {
 		project.getPluginManager().apply(NativeComponentBasePlugin.class);
 		project.getPluginManager().apply(SwiftLanguageBasePlugin.class);
 		val componentProvider = project.getExtensions().getByType(ModelRegistry.class).register(swiftLibrary("main", project)).as(SwiftLibrary.class);
-		componentProvider.configure(baseName(convention(GUtil.toCamelCase(project.getName()))));
+		componentProvider.configure(baseName(convention(TextCaseUtils.toCamelCase(project.getName()))));
 		val extension = componentProvider.get();
 
 		// Other configurations

--- a/subprojects/runtime-base/src/main/java/dev/nokee/runtime/core/Coordinates.java
+++ b/subprojects/runtime-base/src/main/java/dev/nokee/runtime/core/Coordinates.java
@@ -20,10 +20,10 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import com.google.common.reflect.TypeToken;
+import dev.nokee.utils.TextCaseUtils;
 import lombok.EqualsAndHashCode;
 import lombok.val;
 import org.gradle.api.reflect.TypeOf;
-import org.gradle.util.GUtil;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -115,11 +115,11 @@ public final class Coordinates {
 	}
 
 	static String inferCoordinateAxisNameFromType(Class<?> type) {
-		return GUtil.toWords(type.getSimpleName(), '-');
+		return TextCaseUtils.toKebabCase(type.getSimpleName());
 	}
 
 	static String inferCoordinateAxisDisplayNameFromType(Class<?> type) {
-		return GUtil.toWords(type.getSimpleName());
+		return TextCaseUtils.toWords(type.getSimpleName());
 	}
 
 	public static <T> Coordinate<T> absentCoordinate(CoordinateAxis<T> axis) {

--- a/subprojects/runtime-darwin/src/main/java/dev/nokee/runtime/darwin/internal/locators/XcodeLocator.java
+++ b/subprojects/runtime-darwin/src/main/java/dev/nokee/runtime/darwin/internal/locators/XcodeLocator.java
@@ -26,7 +26,7 @@ import dev.nokee.core.exec.ProcessBuilderEngine;
 import dev.nokee.runtime.base.internal.tools.CommandLineToolDescriptor;
 import dev.nokee.runtime.base.internal.tools.CommandLineToolLocator;
 import dev.nokee.runtime.base.internal.tools.DefaultCommandLineToolDescriptor;
-import org.gradle.util.VersionNumber;
+import dev.nokee.utils.VersionNumber;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;

--- a/subprojects/runtime-darwin/src/main/java/dev/nokee/runtime/darwin/internal/locators/XcodebuildLocator.java
+++ b/subprojects/runtime-darwin/src/main/java/dev/nokee/runtime/darwin/internal/locators/XcodebuildLocator.java
@@ -22,7 +22,7 @@ import dev.nokee.core.exec.ProcessBuilderEngine;
 import dev.nokee.runtime.base.internal.tools.CommandLineToolDescriptor;
 import dev.nokee.runtime.base.internal.tools.CommandLineToolLocator;
 import dev.nokee.runtime.base.internal.tools.DefaultCommandLineToolDescriptor;
-import org.gradle.util.VersionNumber;
+import dev.nokee.utils.VersionNumber;
 
 import java.io.File;
 import java.util.Set;

--- a/subprojects/runtime-darwin/src/main/java/dev/nokee/runtime/darwin/internal/locators/XcrunLocator.java
+++ b/subprojects/runtime-darwin/src/main/java/dev/nokee/runtime/darwin/internal/locators/XcrunLocator.java
@@ -23,8 +23,8 @@ import dev.nokee.core.exec.ProcessBuilderEngine;
 import dev.nokee.runtime.base.internal.tools.CommandLineToolDescriptor;
 import dev.nokee.runtime.base.internal.tools.CommandLineToolLocator;
 import dev.nokee.runtime.base.internal.tools.DefaultCommandLineToolDescriptor;
+import dev.nokee.utils.VersionNumber;
 import org.gradle.internal.os.OperatingSystem;
-import org.gradle.util.VersionNumber;
 
 import java.io.File;
 import java.util.Set;

--- a/subprojects/runtime-native/src/main/java/dev/nokee/runtime/nativebase/internal/locators/CmakeLocator.java
+++ b/subprojects/runtime-native/src/main/java/dev/nokee/runtime/nativebase/internal/locators/CmakeLocator.java
@@ -21,8 +21,8 @@ import dev.nokee.core.exec.ProcessBuilderEngine;
 import dev.nokee.runtime.base.internal.tools.CommandLineToolDescriptor;
 import dev.nokee.runtime.base.internal.tools.CommandLineToolLocator;
 import dev.nokee.runtime.base.internal.tools.DefaultCommandLineToolDescriptor;
+import dev.nokee.utils.VersionNumber;
 import org.gradle.internal.os.OperatingSystem;
-import org.gradle.util.VersionNumber;
 
 import java.io.File;
 import java.util.Collections;

--- a/subprojects/runtime-native/src/main/java/dev/nokee/runtime/nativebase/internal/locators/MakeLocator.java
+++ b/subprojects/runtime-native/src/main/java/dev/nokee/runtime/nativebase/internal/locators/MakeLocator.java
@@ -21,8 +21,8 @@ import dev.nokee.core.exec.ProcessBuilderEngine;
 import dev.nokee.runtime.base.internal.tools.CommandLineToolDescriptor;
 import dev.nokee.runtime.base.internal.tools.CommandLineToolLocator;
 import dev.nokee.runtime.base.internal.tools.DefaultCommandLineToolDescriptor;
+import dev.nokee.utils.VersionNumber;
 import org.gradle.internal.os.OperatingSystem;
-import org.gradle.util.VersionNumber;
 
 import java.io.File;
 import java.util.Collections;

--- a/subprojects/runtime-windows/src/main/java/dev/nokee/runtime/nativebase/internal/locators/MSBuildLocator.java
+++ b/subprojects/runtime-windows/src/main/java/dev/nokee/runtime/nativebase/internal/locators/MSBuildLocator.java
@@ -21,9 +21,9 @@ import dev.nokee.core.exec.ProcessBuilderEngine;
 import dev.nokee.runtime.base.internal.tools.CommandLineToolDescriptor;
 import dev.nokee.runtime.base.internal.tools.CommandLineToolLocator;
 import dev.nokee.runtime.base.internal.tools.DefaultCommandLineToolDescriptor;
+import dev.nokee.utils.VersionNumber;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
-import org.gradle.util.VersionNumber;
 
 import java.io.File;
 import java.util.Collections;

--- a/subprojects/runtime-windows/src/main/java/dev/nokee/runtime/nativebase/internal/locators/VswhereLocator.java
+++ b/subprojects/runtime-windows/src/main/java/dev/nokee/runtime/nativebase/internal/locators/VswhereLocator.java
@@ -21,8 +21,8 @@ import dev.nokee.core.exec.ProcessBuilderEngine;
 import dev.nokee.runtime.base.internal.tools.CommandLineToolDescriptor;
 import dev.nokee.runtime.base.internal.tools.CommandLineToolLocator;
 import dev.nokee.runtime.base.internal.tools.DefaultCommandLineToolDescriptor;
+import dev.nokee.utils.VersionNumber;
 import lombok.val;
-import org.gradle.util.VersionNumber;
 
 import java.io.File;
 import java.util.Collections;

--- a/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteComponent.java
+++ b/subprojects/testing-native/src/main/java/dev/nokee/testing/nativebase/internal/DefaultNativeTestSuiteComponent.java
@@ -83,6 +83,7 @@ import dev.nokee.platform.nativebase.tasks.internal.LinkExecutableTask;
 import dev.nokee.testing.base.TestSuiteComponent;
 import dev.nokee.testing.nativebase.NativeTestSuite;
 import dev.nokee.testing.nativebase.NativeTestSuiteVariant;
+import dev.nokee.utils.ConfigureUtils;
 import groovy.lang.Closure;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
@@ -98,7 +99,6 @@ import org.gradle.language.nativeplatform.tasks.AbstractNativeSourceCompileTask;
 import org.gradle.language.nativeplatform.tasks.UnexportMainSymbol;
 import org.gradle.language.swift.tasks.SwiftCompile;
 import org.gradle.nativeplatform.test.tasks.RunTestExecutable;
-import org.gradle.util.ConfigureUtil;
 
 import javax.inject.Inject;
 import java.util.List;
@@ -162,7 +162,7 @@ public /*final*/ class DefaultNativeTestSuiteComponent extends BaseNativeCompone
 
 	@Override
 	public void dependencies(@SuppressWarnings("rawtypes") Closure closure) {
-		dependencies(ConfigureUtil.configureUsing(closure));
+		dependencies(ConfigureUtils.configureUsing(closure));
 	}
 
 	@Override

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/BaseXCTestTestSuiteComponent.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/BaseXCTestTestSuiteComponent.java
@@ -42,6 +42,7 @@ import dev.nokee.platform.nativebase.internal.rules.CreateVariantAwareComponentO
 import dev.nokee.platform.nativebase.internal.rules.CreateVariantObjectsLifecycleTaskRule;
 import dev.nokee.testing.base.TestSuiteComponent;
 import dev.nokee.utils.Cast;
+import dev.nokee.utils.TextCaseUtils;
 import lombok.Getter;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
@@ -51,7 +52,6 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.nativeplatform.toolchain.Swiftc;
-import org.gradle.util.GUtil;
 
 import java.util.Set;
 
@@ -152,7 +152,7 @@ public abstract class BaseXCTestTestSuiteComponent extends BaseNativeComponent<D
 		// TODO: Use component binary view instead once finish cleanup, it remove one level of indirection
 		getVariants().configureEach(variant -> {
 			variant.getBinaries().configureEach(BaseNativeBinary.class, binary -> {
-				((HasBaseName) binary).getBaseName().convention(GUtil.toCamelCase(project.getName()));
+				((HasBaseName) binary).getBaseName().convention(TextCaseUtils.toCamelCase(project.getName()));
 			});
 		});
 		whenElementKnown(this.getNode(), this::onEachVariant);

--- a/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/plugins/ObjectiveCXCTestTestSuitePlugin.java
+++ b/subprojects/testing-xctest/src/main/java/dev/nokee/testing/xctest/internal/plugins/ObjectiveCXCTestTestSuitePlugin.java
@@ -84,6 +84,7 @@ import dev.nokee.testing.xctest.internal.DefaultUiTestXCTestTestSuiteComponent;
 import dev.nokee.testing.xctest.internal.DefaultUnitTestXCTestTestSuiteComponent;
 import dev.nokee.testing.xctest.internal.DefaultXCTestTestSuiteVariant;
 import dev.nokee.testing.xctest.internal.XCTestTestSuiteComponentTag;
+import dev.nokee.utils.TextCaseUtils;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.Plugin;
@@ -92,7 +93,6 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.SetProperty;
-import org.gradle.util.GUtil;
 
 import javax.inject.Inject;
 import java.util.Collections;
@@ -205,9 +205,9 @@ public class ObjectiveCXCTestTestSuitePlugin implements Plugin<Project> {
 			val unitTestComponentProvider = testSuites.register("unitTest", DefaultUnitTestXCTestTestSuiteComponent.class, component -> {
 				component.getTestedComponent().value(application).disallowChanges();
 				component.getGroupId().set(GroupId.of(project::getGroup));
-				component.getBaseName().set(GUtil.toCamelCase(project.getName()) + StringUtils.capitalize(component.getIdentifier().getName().get()));
-				component.getModuleName().set(GUtil.toCamelCase(project.getName()) + StringUtils.capitalize(component.getIdentifier().getName().get()));
-				component.getProductBundleIdentifier().set(project.getGroup().toString() + "." + GUtil.toCamelCase(project.getName()) + StringUtils.capitalize(component.getIdentifier().getName().get()));
+				component.getBaseName().set(TextCaseUtils.toCamelCase(project.getName()) + StringUtils.capitalize(component.getIdentifier().getName().get()));
+				component.getModuleName().set(TextCaseUtils.toCamelCase(project.getName()) + StringUtils.capitalize(component.getIdentifier().getName().get()));
+				component.getProductBundleIdentifier().set(project.getGroup().toString() + "." + TextCaseUtils.toCamelCase(project.getName()) + StringUtils.capitalize(component.getIdentifier().getName().get()));
 			});
 			val unitTestComponent = unitTestComponentProvider.get();
 			project.afterEvaluate(finalizeModelNodeOf(unitTestComponent));
@@ -215,9 +215,9 @@ public class ObjectiveCXCTestTestSuitePlugin implements Plugin<Project> {
 			val uiTestComponentProvider = testSuites.register("uiTest", DefaultUiTestXCTestTestSuiteComponent.class, component -> {
 				component.getTestedComponent().value(application).disallowChanges();
 				component.getGroupId().set(GroupId.of(project::getGroup));
-				component.getBaseName().set(GUtil.toCamelCase(project.getName()) + StringUtils.capitalize(component.getIdentifier().getName().get()));
-				component.getModuleName().set(GUtil.toCamelCase(project.getName()) + StringUtils.capitalize(component.getIdentifier().getName().get()));
-				component.getProductBundleIdentifier().set(project.getGroup().toString() + "." + GUtil.toCamelCase(project.getName()) + StringUtils.capitalize(component.getIdentifier().getName().get()));
+				component.getBaseName().set(TextCaseUtils.toCamelCase(project.getName()) + StringUtils.capitalize(component.getIdentifier().getName().get()));
+				component.getModuleName().set(TextCaseUtils.toCamelCase(project.getName()) + StringUtils.capitalize(component.getIdentifier().getName().get()));
+				component.getProductBundleIdentifier().set(project.getGroup().toString() + "." + TextCaseUtils.toCamelCase(project.getName()) + StringUtils.capitalize(component.getIdentifier().getName().get()));
 			});
 			val uiTestComponent = uiTestComponentProvider.get();
 			project.afterEvaluate(finalizeModelNodeOf(uiTestComponent));


### PR DESCRIPTION
Those probably were triggered on the `master` branch but were ignored due to time. Fixing them now since Gradle 7.6 breaks everything. By breaking, we mean it causes a bunch of our tests to fail, which fails on deprecation warning by design.