### PR TITLE
Detect when shell script build phase are obviously out-of-date

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+                os: ['ubuntu-20.04', 'windows-latest', 'macos-latest']
         steps:
             -   uses: actions/checkout@v2
                 with:
@@ -75,7 +75,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+                os: ['ubuntu-20.04', 'windows-latest', 'macos-latest']
         steps:
             -   uses: actions/checkout@v2
                 with:
@@ -91,7 +91,7 @@ jobs:
                     github-token: ${{ secrets.GITHUB_TOKEN }}
 
     check-baked-documentation:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         steps:
             -   uses: actions/checkout@v2
                 with:
@@ -111,7 +111,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+                os: ['ubuntu-20.04', 'windows-latest', 'macos-latest']
         steps:
             -   uses: actions/checkout@v2
                 with:

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/HasXcodeTargetReference.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/HasXcodeTargetReference.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal.plugins;
+
+import dev.nokee.xcode.XCTargetReference;
+import org.gradle.api.provider.Provider;
+
+public interface HasXcodeTargetReference {
+	Provider<XCTargetReference> getTargetReference();
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeTargetExecTask.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeTargetExecTask.java
@@ -101,6 +101,7 @@ public abstract class XcodeTargetExecTask extends DefaultTask implements Xcodebu
 	public abstract MapProperty<String, String> getAllBuildSettings();
 
 	@Override
+	@Internal
 	public Provider<XCTargetReference> getTargetReference() {
 		return targetReference;
 	}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeTargetExecTaskOutOfDateSpec.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeTargetExecTaskOutOfDateSpec.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal.plugins;
+
+import dev.nokee.xcode.XCLoader;
+import dev.nokee.xcode.XCTargetReference;
+import dev.nokee.xcode.objects.buildphase.PBXShellScriptBuildPhase;
+import dev.nokee.xcode.objects.targets.PBXTarget;
+import lombok.EqualsAndHashCode;
+import org.gradle.api.specs.Spec;
+
+import java.util.function.Predicate;
+
+@EqualsAndHashCode
+public final class XcodeTargetExecTaskOutOfDateSpec implements Spec<HasXcodeTargetReference> {
+	private final XCLoader<PBXTarget, XCTargetReference> loader;
+	private final AlwaysOutOfDateShellScriptBuildPhasePredicate outOfDatePredicate;
+
+	public XcodeTargetExecTaskOutOfDateSpec(XCLoader<PBXTarget, XCTargetReference> loader, AlwaysOutOfDateShellScriptBuildPhasePredicate outOfDatePredicate) {
+		this.loader = loader;
+		this.outOfDatePredicate = outOfDatePredicate;
+	}
+
+	@Override
+	public boolean isSatisfiedBy(HasXcodeTargetReference o) {
+		return o.getTargetReference().map(ref -> ref.load(loader)
+				.getBuildPhases()
+				.stream()
+				.filter(PBXShellScriptBuildPhase.class::isInstance)
+				.map(PBXShellScriptBuildPhase.class::cast)
+				.noneMatch(outOfDatePredicate)
+			).getOrElse(false);
+		// WHAT-IF: there is one xcfilelist (as input and/or output) but is empty?
+	}
+
+	public interface AlwaysOutOfDateShellScriptBuildPhasePredicate extends Predicate<PBXShellScriptBuildPhase> {}
+
+	@EqualsAndHashCode
+	public static final class DefaultPredicate implements AlwaysOutOfDateShellScriptBuildPhasePredicate {
+		@Override
+		public boolean test(PBXShellScriptBuildPhase buildPhase) {
+			return !hasAtLeastOneInputFile(buildPhase) || !hasAtLeastOneOutputFile(buildPhase) || useXCFileList(buildPhase);
+		}
+
+		private boolean hasAtLeastOneInputFile(PBXShellScriptBuildPhase buildPhase) {
+			return !buildPhase.getInputPaths().isEmpty() || !buildPhase.getInputFileListPaths().isEmpty();
+		}
+
+		private boolean hasAtLeastOneOutputFile(PBXShellScriptBuildPhase buildPhase) {
+			return !buildPhase.getOutputPaths().isEmpty() || !buildPhase.getOutputFileListPaths().isEmpty();
+		}
+
+		private boolean useXCFileList(PBXShellScriptBuildPhase buildPhase) {
+			return !buildPhase.getInputFileListPaths().isEmpty() || !buildPhase.getOutputFileListPaths().isEmpty();
+		}
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/ConfigurationsLoader.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/ConfigurationsLoader.java
@@ -19,11 +19,13 @@ import com.google.common.collect.ImmutableSet;
 import dev.nokee.xcode.objects.PBXProject;
 import dev.nokee.xcode.objects.configuration.XCBuildConfiguration;
 import dev.nokee.xcode.objects.configuration.XCConfigurationList;
+import lombok.EqualsAndHashCode;
 
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Set;
 
+@EqualsAndHashCode
 public final class ConfigurationsLoader implements XCLoader<Set<String>, XCTargetReference>, Serializable {
 	private final XCLoader<PBXProject, XCProjectReference> loader;
 

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/ConfigurationsLoader.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/ConfigurationsLoader.java
@@ -22,10 +22,10 @@ import dev.nokee.xcode.objects.configuration.XCBuildConfiguration;
 import java.io.Serializable;
 import java.util.Set;
 
-public final class ConfigurationLoader implements XCLoader<Set<String>, XCTargetReference>, Serializable {
+public final class ConfigurationsLoader implements XCLoader<Set<String>, XCTargetReference>, Serializable {
 	private final XCLoader<PBXProject, XCProjectReference> loader;
 
-	public ConfigurationLoader(XCLoader<PBXProject, XCProjectReference> loader) {
+	public ConfigurationsLoader(XCLoader<PBXProject, XCProjectReference> loader) {
 		this.loader = loader;
 	}
 

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/ConfigurationsLoader.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/ConfigurationsLoader.java
@@ -18,8 +18,10 @@ package dev.nokee.xcode;
 import com.google.common.collect.ImmutableSet;
 import dev.nokee.xcode.objects.PBXProject;
 import dev.nokee.xcode.objects.configuration.XCBuildConfiguration;
+import dev.nokee.xcode.objects.configuration.XCConfigurationList;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.Set;
 
 public final class ConfigurationsLoader implements XCLoader<Set<String>, XCTargetReference>, Serializable {
@@ -31,6 +33,11 @@ public final class ConfigurationsLoader implements XCLoader<Set<String>, XCTarge
 
 	@Override
 	public Set<String> load(XCTargetReference reference) {
-		return reference.getProject().load(loader).getBuildConfigurationList().getBuildConfigurations().stream().map(XCBuildConfiguration::getName).collect(ImmutableSet.toImmutableSet());
+		final XCConfigurationList configurationList = reference.getProject().load(loader).getBuildConfigurationList();
+		if (configurationList == null) {
+			return Collections.emptySet();
+		} else {
+			return configurationList.getBuildConfigurations().stream().map(XCBuildConfiguration::getName).collect(ImmutableSet.toImmutableSet());
+		}
 	}
 }

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/PBXTargetLoader.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/PBXTargetLoader.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.xcode;
+
+import dev.nokee.xcode.objects.PBXProject;
+import dev.nokee.xcode.objects.targets.PBXTarget;
+
+import static com.google.common.collect.MoreCollectors.onlyElement;
+
+public final class PBXTargetLoader implements XCLoader<PBXTarget, XCTargetReference> {
+	private final XCLoader<PBXProject, XCProjectReference> loader;
+
+	public PBXTargetLoader(XCLoader<PBXProject, XCProjectReference> loader) {
+		this.loader = loader;
+	}
+
+	@Override
+	public PBXTarget load(XCTargetReference reference) {
+		return reference.getProject().load(loader).getTargets().stream().filter(it -> reference.getName().equals(it.getName())).collect(onlyElement());
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCLoaders.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCLoaders.java
@@ -16,12 +16,14 @@
 package dev.nokee.xcode;
 
 import dev.nokee.xcode.objects.PBXProject;
+import dev.nokee.xcode.objects.targets.PBXTarget;
 import dev.nokee.xcode.workspace.XCWorkspaceData;
 
 import java.util.Set;
 
 public final class XCLoaders {
 	private static final XCLoader<PBXProject, XCProjectReference> PBXPROJECT_LOADER = new XCCacheLoader<>(new PBXProjectLoader());
+	private static final XCLoader<PBXTarget, XCTargetReference> PBXTARGET_LOADER = new XCCacheLoader<>(new PBXTargetLoader(PBXPROJECT_LOADER));
 	private static final XCLoader<XCFileReferencesLoader.XCFileReferences, XCProjectReference> FILE_REFERENCES_LOADER = new XCCacheLoader<>(new XCFileReferencesLoader(PBXPROJECT_LOADER));
 	private static final XCLoader<XCWorkspaceData, XCWorkspaceReference> WORKSPACE_DATA_LOADER = new XCCacheLoader<>(new XCWorkspaceDataLoader());
 	private static final XCLoader<Iterable<XCProjectReference>, XCWorkspaceReference> WORKSPACE_PROJECT_REFERENCES_LOADER = new XCCacheLoader<>(new WorkspaceProjectReferencesLoader(WORKSPACE_DATA_LOADER, new DefaultXCProjectReferenceFactory()));
@@ -43,6 +45,10 @@ public final class XCLoaders {
 
 	public static XCLoader<XCProject, XCProjectReference> projectLoader() {
 		return PROJECT_LOADER;
+	}
+
+	public static XCLoader<PBXTarget, XCTargetReference> pbxtargetLoader() {
+		return PBXTARGET_LOADER;
 	}
 
 	public static XCLoader<XCTarget, XCTargetReference> targetLoader() {

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCLoaders.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCLoaders.java
@@ -29,7 +29,7 @@ public final class XCLoaders {
 	private static final XCLoader<XCProject, XCProjectReference> PROJECT_LOADER = new XCCacheLoader<>(new XCProjectLoader(PBXPROJECT_LOADER, FILE_REFERENCES_LOADER));
 	private static final XCLoader<XCTarget, XCTargetReference> TARGET_LOADER = new XCCacheLoader<>(new XCTargetLoader(PBXPROJECT_LOADER, FILE_REFERENCES_LOADER));
 	private static final XCLoader<Set<XCTargetReference>, XCProjectReference> ALL_TARGETS_LOADER = new XCCacheLoader<>(new XCTargetsLoader(PBXPROJECT_LOADER));
-	private static final XCLoader<Set<String>, XCTargetReference> TARGET_CONFIGURATION_LOADER = new XCCacheLoader<>(new ConfigurationLoader(PBXPROJECT_LOADER));
+	private static final XCLoader<Set<String>, XCTargetReference> TARGET_CONFIGURATION_LOADER = new XCCacheLoader<>(new ConfigurationsLoader(PBXPROJECT_LOADER));
 
 	private static final XCLoader<String, XCTargetReference> DEFAULT_TARGET_CONFIGURATION_LOADER = new XCCacheLoader<>(new DefaultTargetConfigurationLoader(PBXPROJECT_LOADER));
 

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCTargetsLoader.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/xcode/XCTargetsLoader.java
@@ -18,10 +18,12 @@ package dev.nokee.xcode;
 import com.google.common.collect.ImmutableSet;
 import dev.nokee.xcode.objects.PBXProject;
 import dev.nokee.xcode.objects.targets.PBXTarget;
+import lombok.EqualsAndHashCode;
 
 import java.io.Serializable;
 import java.util.Set;
 
+@EqualsAndHashCode
 public final class XCTargetsLoader implements XCLoader<Set<XCTargetReference>, XCProjectReference>, Serializable {
 	private final XCLoader<PBXProject, XCProjectReference> pbxprojectLoader;
 

--- a/subprojects/build-adapter-xcode/src/test/java/dev/nokee/buildadapter/xcode/XcodeTargetExecTaskOutOfDateSpecDefaultPredicateTests.java
+++ b/subprojects/build-adapter-xcode/src/test/java/dev/nokee/buildadapter/xcode/XcodeTargetExecTaskOutOfDateSpecDefaultPredicateTests.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
+import dev.nokee.buildadapter.xcode.internal.plugins.XcodeTargetExecTaskOutOfDateSpec;
+import dev.nokee.xcode.objects.buildphase.PBXShellScriptBuildPhase;
+import lombok.val;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.aggregator.AggregateWith;
+import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
+import org.junit.jupiter.params.aggregator.ArgumentsAggregationException;
+import org.junit.jupiter.params.aggregator.ArgumentsAggregator;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.mockito.Mockito;
+
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.ImmutableSet.of;
+import static dev.nokee.buildadapter.xcode.XcodeTargetExecTaskOutOfDateSpecDefaultPredicateTests.GivenSpec.hasEmptyInputFileListPaths;
+import static dev.nokee.buildadapter.xcode.XcodeTargetExecTaskOutOfDateSpecDefaultPredicateTests.GivenSpec.hasEmptyOutputFileListPaths;
+import static dev.nokee.buildadapter.xcode.XcodeTargetExecTaskOutOfDateSpecDefaultPredicateTests.GivenSpec.hasInputPaths;
+import static dev.nokee.buildadapter.xcode.XcodeTargetExecTaskOutOfDateSpecDefaultPredicateTests.GivenSpec.hasNonEmptyInputFileListPaths;
+import static dev.nokee.buildadapter.xcode.XcodeTargetExecTaskOutOfDateSpecDefaultPredicateTests.GivenSpec.hasNonEmptyOutputFileListPaths;
+import static dev.nokee.buildadapter.xcode.XcodeTargetExecTaskOutOfDateSpecDefaultPredicateTests.GivenSpec.hasOutputPaths;
+import static dev.nokee.buildadapter.xcode.XcodeTargetExecTaskOutOfDateSpecDefaultPredicateTests.GivenSpec.noInputFileListPaths;
+import static dev.nokee.buildadapter.xcode.XcodeTargetExecTaskOutOfDateSpecDefaultPredicateTests.GivenSpec.noInputPaths;
+import static dev.nokee.buildadapter.xcode.XcodeTargetExecTaskOutOfDateSpecDefaultPredicateTests.GivenSpec.noOutputFileListPaths;
+import static dev.nokee.buildadapter.xcode.XcodeTargetExecTaskOutOfDateSpecDefaultPredicateTests.GivenSpec.noOutputPaths;
+import static dev.nokee.util.internal.ToOnlyInstanceOfFunction.toOnlyInstanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class XcodeTargetExecTaskOutOfDateSpecDefaultPredicateTests {
+	XcodeTargetExecTaskOutOfDateSpec.DefaultPredicate subject = new XcodeTargetExecTaskOutOfDateSpec.DefaultPredicate();
+
+	@ParameterizedTest
+	@ArgumentsSource(BuildPhaseProvider.class)
+	void testsShellScriptBuildPhaseIncrementalConditions(boolean expectedResult, @AggregateWith(ToBuildPhase.class) PBXShellScriptBuildPhase buildPhase) {
+		assertThat(subject.test(buildPhase), is(expectedResult));
+	}
+
+	static final class ToBuildPhase implements ArgumentsAggregator {
+		@Override
+		public Object aggregateArguments(ArgumentsAccessor accessor, ParameterContext context) throws ArgumentsAggregationException {
+			val result = Mockito.mock(PBXShellScriptBuildPhase.class);
+
+			val inputPaths = ImmutableList.<String>builder();
+			val outputPaths = ImmutableList.<String>builder();
+			val inputFileListPaths = ImmutableList.<String>builder();
+			val outputFileListPaths = ImmutableList.<String>builder();
+			accessor.toList().stream().flatMap(toOnlyInstanceOf(GivenSpec.class)).forEach(it -> {
+				inputPaths.addAll(it.inputPaths());
+				outputPaths.addAll(it.outputPaths());
+				inputFileListPaths.addAll(it.inputFileListPaths());
+				outputFileListPaths.addAll(it.outputFileListPaths());
+			});
+
+			Mockito.when(result.getInputPaths()).thenReturn(inputPaths.build());
+			Mockito.when(result.getOutputPaths()).thenReturn(outputPaths.build());
+			Mockito.when(result.getInputFileListPaths()).thenReturn(inputFileListPaths.build());
+			Mockito.when(result.getOutputFileListPaths()).thenReturn(outputFileListPaths.build());
+			return result;
+		}
+	}
+
+	static final class BuildPhaseProvider implements ArgumentsProvider {
+		@Override
+		public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+			return Sets.cartesianProduct(
+				of(noInputPaths, hasInputPaths),
+				of(noOutputPaths, hasOutputPaths),
+				of(noInputFileListPaths, hasEmptyInputFileListPaths, hasNonEmptyInputFileListPaths),
+				of(noOutputFileListPaths, hasEmptyOutputFileListPaths, hasNonEmptyOutputFileListPaths)
+			).stream().map(specs -> arguments(ImmutableList.builder()
+				.add(specs.stream().anyMatch(xcFileListSpec()) || !(specs.contains(hasInputPaths) && specs.contains(hasOutputPaths)))
+				.addAll(specs)
+				.build().toArray(new Object[0])
+			));
+		}
+	}
+
+	static Predicate<GivenSpec> xcFileListSpec() {
+		return of(hasEmptyInputFileListPaths, hasNonEmptyInputFileListPaths, hasEmptyOutputFileListPaths, hasNonEmptyOutputFileListPaths)::contains;
+	}
+
+	enum GivenSpec {
+		noInputPaths,
+		hasInputPaths {
+			@Override
+			public List<String> inputPaths() {
+				return ImmutableList.of("$(SRCROOT)/my-input.txt");
+			}
+		},
+
+		noOutputPaths,
+		hasOutputPaths {
+			@Override
+			public List<String> outputPaths() {
+				return ImmutableList.of("$(DERIVED_FILES_DIR)/my-output.txt");
+			}
+		},
+
+		noInputFileListPaths,
+		hasEmptyInputFileListPaths {
+			@Override
+			public List<String> inputFileListPaths() {
+				return ImmutableList.of("$(SRCROOT)/my-empty-inputs.xcfilelist");
+			}
+		},
+		hasNonEmptyInputFileListPaths {
+			@Override
+			public List<String> inputFileListPaths() {
+				return ImmutableList.of("$(SRCROOT)/my-non-empty-inputs.xcfilelist");
+			}
+		},
+
+		noOutputFileListPaths,
+		hasEmptyOutputFileListPaths {
+			@Override
+			public List<String> outputFileListPaths() {
+				return ImmutableList.of("$(SRCROOT)/my-empty-outputs.xcfilelist");
+			}
+		},
+		hasNonEmptyOutputFileListPaths {
+			@Override
+			public List<String> outputFileListPaths() {
+				return ImmutableList.of("$(SRCROOT)/my-non-empty-outputs.xcfilelist");
+			}
+		},
+		;
+
+		public List<String> inputPaths() {
+			return ImmutableList.of();
+		}
+
+		public List<String> outputPaths() {
+			return ImmutableList.of();
+		}
+
+		public List<String> inputFileListPaths() {
+			return ImmutableList.of();
+		}
+
+		public List<String> outputFileListPaths() {
+			return ImmutableList.of();
+		}
+	}
+}

--- a/subprojects/build-adapter-xcode/src/test/java/dev/nokee/buildadapter/xcode/XcodeTargetExecTaskOutOfDateSpecTests.java
+++ b/subprojects/build-adapter-xcode/src/test/java/dev/nokee/buildadapter/xcode/XcodeTargetExecTaskOutOfDateSpecTests.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode;
+
+import dev.nokee.buildadapter.xcode.internal.plugins.HasXcodeTargetReference;
+import dev.nokee.buildadapter.xcode.internal.plugins.XcodeTargetExecTaskOutOfDateSpec;
+import dev.nokee.xcode.XCLoader;
+import dev.nokee.xcode.XCTargetReference;
+import dev.nokee.xcode.objects.buildphase.PBXBuildPhase;
+import dev.nokee.xcode.objects.buildphase.PBXShellScriptBuildPhase;
+import dev.nokee.xcode.objects.configuration.XCConfigurationList;
+import dev.nokee.xcode.objects.targets.BuildPhaseAwareBuilder;
+import dev.nokee.xcode.objects.targets.PBXAggregateTarget;
+import dev.nokee.xcode.objects.targets.PBXTarget;
+import lombok.val;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.function.Consumer;
+
+import static dev.nokee.buildadapter.xcode.TestTargetReference.target;
+import static dev.nokee.internal.testing.GradleSpecMatchers.satisfiedBy;
+import static dev.nokee.internal.testing.GradleSpecMatchers.unsatisfiedBy;
+import static dev.nokee.internal.testing.util.ProjectTestUtils.providerFactory;
+import static dev.nokee.util.internal.DoNothingConsumer.doNothing;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class XcodeTargetExecTaskOutOfDateSpecTests {
+	@Mock XCLoader<PBXTarget, XCTargetReference> loader;
+	@Mock XcodeTargetExecTaskOutOfDateSpec.AlwaysOutOfDateShellScriptBuildPhasePredicate outOfDatePredicate;
+	XcodeTargetExecTaskOutOfDateSpec subject;
+
+	@BeforeEach
+	void givenSubject() {
+		subject = new XcodeTargetExecTaskOutOfDateSpec(loader, outOfDatePredicate);
+	}
+
+	@Nested
+	class WhenNoTargetSpecified {
+		HasXcodeTargetReference target = () -> providerFactory().provider(() -> null);
+
+		@Test
+		void isUnsatisfied() {
+			assertThat(subject, unsatisfiedBy(target));
+		}
+	}
+
+	@Nested
+	class WhenTargetSpecified {
+		XCTargetReference reference = target("Test");
+		HasXcodeTargetReference target = () -> providerFactory().provider(() -> reference);
+
+		@Nested
+		class HasNoBuildPhases {
+			@BeforeEach
+			void givenTargetWithoutBuildPhases() {
+				Mockito.when(loader.load(reference)).thenReturn(newTarget(doNothing()));
+			}
+
+			@Test
+			void isSatisfied() {
+				assertThat(subject, satisfiedBy(target));
+			}
+		}
+
+		@Nested
+		class HasNoShellScriptBuildPhases {
+			@Mock
+			PBXBuildPhase aBuildPhase;
+			@Mock
+			PBXBuildPhase anotherBuildPhase;
+
+			@BeforeEach
+			void givenTargetWithNoShellScriptBuildPhases() {
+				Mockito.when(loader.load(reference)).thenReturn(newTarget(it -> it.buildPhase(aBuildPhase).buildPhase(anotherBuildPhase)));
+			}
+
+			@Test
+			void isSatisfied() {
+				assertThat(subject, satisfiedBy(target));
+			}
+		}
+
+		@Nested
+		class HasAlwaysOutOfDateShellScriptBuildPhases {
+			@Mock
+			PBXShellScriptBuildPhase shellScriptBuildPhase;
+
+			@BeforeEach
+			void givenTargetWithAlwaysOutOfDateShellScriptBuildPhase() {
+				Mockito.when(outOfDatePredicate.test(shellScriptBuildPhase)).thenReturn(true);
+				Mockito.when(loader.load(reference)).thenReturn(newTarget(it -> it.buildPhase(shellScriptBuildPhase)));
+			}
+
+			@Test
+			void isUnsatisfied() {
+				assertThat(subject, unsatisfiedBy(target));
+			}
+		}
+
+		@Nested
+		class HasIncrementalShellScriptBuildPhases {
+			@Mock
+			PBXShellScriptBuildPhase shellScriptBuildPhase;
+
+			@BeforeEach
+			void givenTargetWithIncrementalShellScriptBuildPhase() {
+				Mockito.when(outOfDatePredicate.test(shellScriptBuildPhase)).thenReturn(false);
+				Mockito.when(loader.load(reference)).thenReturn(newTarget(it -> it.buildPhase(shellScriptBuildPhase)));
+			}
+
+			@Test
+			void isSatisfied() {
+				assertThat(subject, satisfiedBy(target));
+			}
+		}
+	}
+
+	static PBXTarget newTarget(Consumer<? super BuildPhaseAwareBuilder<?>> action) {
+		val builder = PBXAggregateTarget.builder().name("Test").buildConfigurations(defaultConfigurations());
+		action.accept(builder);
+		return builder.build();
+	}
+
+	private static XCConfigurationList defaultConfigurations() {
+		return XCConfigurationList.builder().buildConfiguration(it -> it.name("Debug")).buildConfiguration(it -> it.name("Release")).build();
+	}
+}

--- a/subprojects/build-adapter-xcode/src/test/java/dev/nokee/xcode/ConfigurationsLoaderTests.java
+++ b/subprojects/build-adapter-xcode/src/test/java/dev/nokee/xcode/ConfigurationsLoaderTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.xcode;
+
+import dev.nokee.xcode.objects.PBXProject;
+import dev.nokee.xcode.objects.configuration.XCBuildConfiguration;
+import dev.nokee.xcode.objects.configuration.XCConfigurationList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static dev.nokee.buildadapter.xcode.TestProjectReference.project;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+class ConfigurationsLoaderTests {
+	@Mock XCLoader<PBXProject, XCProjectReference> loader;
+	@InjectMocks ConfigurationsLoader subject;
+
+	@Nested
+	class WhenPBXProjectHasConfigurations {
+		Iterable<String> result;
+		XCBuildConfiguration debug = XCBuildConfiguration.builder().name("Debug").build();
+		XCBuildConfiguration release = XCBuildConfiguration.builder().name("Release").build();
+
+		@BeforeEach
+		void givenPBXProjectWithRequestedTarget() {
+			Mockito.when(loader.load(any())).thenReturn(PBXProject.builder()
+				.buildConfigurations(it -> it.buildConfiguration(debug).buildConfiguration(release)).build());
+			result = subject.load(project("MyProject").ofTarget("Bar"));
+		}
+
+		@Test
+		void returnsProjectConfigurations() {
+			assertThat(result, contains("Debug", "Release"));
+		}
+	}
+
+	@Nested
+	class WhenPBXProjectHasNoConfigurations {
+		Iterable<String> result;
+
+		@BeforeEach
+		void givenPBXProjectWithNoTarget() {
+			Mockito.when(loader.load(any())).thenReturn(PBXProject.builder().build());
+			result = subject.load(project("MyProject").ofTarget("Foo"));
+		}
+
+		@Test
+		void returnsEmptyList() {
+			assertThat(result, emptyIterable());
+		}
+	}
+
+	@Nested
+	class WhenPBXProjectHasEmptyConfigurationList {
+		Iterable<String> result;
+
+		@BeforeEach
+		void givenPBXProjectWithTargetsWithoutRequestedTarget() {
+			Mockito.when(loader.load(any())).thenReturn(PBXProject.builder().buildConfigurations(XCConfigurationList.builder().build()).build());
+			result = subject.load(project("MyProject").ofTarget("Foo"));
+		}
+
+		@Test
+		void returnsEmptyList() {
+			assertThat(result, emptyIterable());
+		}
+	}
+}

--- a/subprojects/build-adapter-xcode/src/test/java/dev/nokee/xcode/DefaultTargetConfigurationLoaderTests.java
+++ b/subprojects/build-adapter-xcode/src/test/java/dev/nokee/xcode/DefaultTargetConfigurationLoaderTests.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.xcode;
+
+import dev.nokee.buildadapter.xcode.TestProjectReference;
+import dev.nokee.xcode.objects.PBXProject;
+import dev.nokee.xcode.objects.configuration.XCConfigurationList;
+import dev.nokee.xcode.objects.targets.PBXAggregateTarget;
+import dev.nokee.xcode.objects.targets.PBXTarget;
+import dev.nokee.xcode.project.DefaultKeyedObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
+
+import static dev.nokee.buildadapter.xcode.TestProjectReference.project;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultTargetConfigurationLoaderTests {
+	XCTargetReference reference = project("MyProject").ofTarget("Test");
+
+	static abstract class GivenPBXProjectLoading {
+		@Mock XCLoader<PBXProject, XCProjectReference> loader;
+		@InjectMocks DefaultTargetConfigurationLoader subject;
+
+		@BeforeEach
+		void givenPBXProjectLoading() {
+			Mockito.when(loader.load(TestProjectReference.project("MyProject"))).thenReturn(project());
+		}
+
+		public abstract PBXProject project();
+	}
+
+	private static PBXTarget newTarget(String name) {
+		return PBXAggregateTarget.builder().lenient().name(name).build();
+	}
+
+	private static PBXTarget newTarget(String name, Consumer<? super XCConfigurationList.Builder> action) {
+		return PBXAggregateTarget.builder().name(name).buildConfigurations(action).build();
+	}
+
+	private static Consumer<XCConfigurationList.Builder> withoutDefaultBuildConfiguration() {
+		return builder -> builder.buildConfiguration(it -> it.name("Debug")).buildConfiguration(it -> it.name("Release"));
+	}
+
+	private static Consumer<XCConfigurationList.Builder> withDefaultBuildConfiguration(String defaultBuildConfigurationName) {
+		return builder -> builder.buildConfiguration(it -> it.name("Debug")).buildConfiguration(it -> it.name("Release")).defaultConfigurationName(defaultBuildConfigurationName);
+	}
+
+	private static UnaryOperator<PBXProject.Builder> targets() {
+		return builder -> builder.target(newTarget("Foo")) //
+			.target(newTarget("Bar")) //
+			.target(newTarget("Far"));
+	}
+
+	private static UnaryOperator<PBXProject.Builder> noTargets() {
+		return builder -> builder.targets(Collections.emptyList());
+	}
+
+
+	private static UnaryOperator<PBXProject.Builder> testTargetWithoutBuildConfigurations() {
+		return builder -> builder.target(newTarget("Foo")) //
+			.target(newTarget("Test")) //
+			.target(newTarget("Far"));
+	}
+
+	private static UnaryOperator<PBXProject.Builder> testTarget(Consumer<? super XCConfigurationList.Builder> action) {
+		return builder -> builder.target(newTarget("Foo")) //
+			.target(newTarget("Test", action)) //
+			.target(newTarget("Far"));
+	}
+
+	@Nested
+	class WhenProjectWithoutTargets extends GivenPBXProjectLoading {
+		public PBXProject project() {
+			return PBXProject.builder() //
+				.with(noTargets()) //
+				.build();
+		}
+
+		@Test
+		void throwsExceptionBecauseReferenceIsInvalid() {
+			assertThrows(RuntimeException.class, () -> subject.load(reference));
+		}
+	}
+
+	@Nested
+	class WhenProjectWithoutTargetsButNoneMatchTargetReference extends GivenPBXProjectLoading {
+		public PBXProject project() {
+			return PBXProject.builder() //
+				.with(targets()) //
+				.build();
+		}
+
+		@Test
+		void throwsExceptionBecauseReferenceIsInvalid() {
+			assertThrows(RuntimeException.class, () -> subject.load(reference));
+		}
+	}
+
+
+	//region: PBXProject without build configurations
+	@Nested
+	class WhenProjectWithoutBuildConfigurationsHasTestTargetWithoutBuildConfigurations extends GivenPBXProjectLoading {
+		public PBXProject project() {
+			return PBXProject.builder()
+				.with(testTargetWithoutBuildConfigurations())
+				.build();
+		}
+
+		@Test
+		void returnNullBecauseNeitherTargetOrProjectHaveBuildConfigurations() {
+			assertThat(subject.load(reference), nullValue());
+		}
+	}
+
+	@Nested
+	class WhenProjectWithoutBuildConfigurationsHasTestTargetWithoutDefaultBuildConfiguration extends GivenPBXProjectLoading {
+		public PBXProject project() {
+			return PBXProject.builder() //
+				.with(testTarget(withoutDefaultBuildConfiguration())) //
+				.build();
+		}
+
+		@Test
+		void returnNullBecauseTargetDoesNotHaveDefaultBuildConfigurationAndProjectHasNoBuildConfigurations() {
+			assertThat(subject.load(reference), nullValue());
+		}
+	}
+
+	@Nested
+	class WhenProjectWithoutBuildConfigurationsHasTestTargetWithDefaultBuildConfiguration extends GivenPBXProjectLoading {
+		public PBXProject project() {
+			return PBXProject.builder() //
+				.with(testTarget(withDefaultBuildConfiguration("Release"))) //
+				.build();
+		}
+
+		@Test
+		void returnsDefaultBuildConfigurationOfTarget() {
+			assertThat(subject.load(reference), equalTo("Release"));
+		}
+	}
+	//endregion
+
+	//region: PBXProject without default build configuration
+	@Nested
+	class WhenProjectWithoutDefaultBuildConfigurationHasTestTargetWithoutBuildConfigurations extends GivenPBXProjectLoading {
+		public PBXProject project() {
+			return PBXProject.builder() //
+				.buildConfigurations(withoutDefaultBuildConfiguration()) //
+				.with(testTargetWithoutBuildConfigurations()) //
+				.build();
+		}
+
+		@Test
+		void returnNullBecauseProjectConfigurationDoesNotHaveDefaultBuildConfiguration() {
+			assertThat(subject.load(reference), nullValue());
+		}
+	}
+
+	@Nested
+	class WhenProjectWithoutDefaultBuildConfigurationHasTestTargetWithoutDefaultBuildConfiguration extends GivenPBXProjectLoading {
+		public PBXProject project() {
+			return PBXProject.builder() //
+				.buildConfigurations(withoutDefaultBuildConfiguration()) //
+				.with(testTarget(withoutDefaultBuildConfiguration())) //
+				.build();
+		}
+
+		@Test
+		void returnsNullBecauseNeitherTargetOrProjectHasDefaultBuildConfiguration() {
+			assertThat(subject.load(reference), nullValue());
+		}
+	}
+
+	@Nested
+	class WhenProjectWithoutDefaultBuildConfigurationHasTestTargetWithDefaultBuildConfiguration extends GivenPBXProjectLoading {
+		public PBXProject project() {
+			return PBXProject.builder() //
+				.buildConfigurations(withoutDefaultBuildConfiguration()) //
+				.with(testTarget(withDefaultBuildConfiguration("Release"))) //
+				.build();
+		}
+
+		@Test
+		void returnsDefaultBuildConfigurationOfTarget() {
+			assertThat(subject.load(reference), equalTo("Release"));
+		}
+	}
+	//endregion
+
+	//region: PBXProject with default configuration (debug)
+	@Nested
+	class WhenProjectWithDefaultBuildConfigurationHasTestTargetWithoutBuildConfiguration extends GivenPBXProjectLoading {
+		public PBXProject project() {
+			return PBXProject.builder() //
+				.buildConfigurations(withDefaultBuildConfiguration("Debug")) //
+				.with(testTargetWithoutBuildConfigurations()) //
+				.build();
+		}
+
+		@Test
+		void returnsProjectDefaultBuildConfigurationBecauseTargetHasNoBuildConfigurations() {
+			assertThat(subject.load(reference), equalTo("Debug"));
+		}
+	}
+
+	@Nested
+	class WhenProjectWithDefaultBuildConfigurationHasTestTargetWithoutDefaultBuildConfiguration extends GivenPBXProjectLoading {
+		public PBXProject project() {
+			return PBXProject.builder() //
+				.buildConfigurations(withDefaultBuildConfiguration("Debug")) //
+				.with(testTarget(withoutDefaultBuildConfiguration())) //
+				.build();
+		}
+
+		@Test
+		void returnsProjectDefaultBuildConfigurationBecauseTargetDoesNotHaveDefaultBuildConfiguration() {
+			assertThat(subject.load(reference), equalTo("Debug"));
+		}
+	}
+
+	@Nested
+	class WhenProjectWithDefaultBuildConfigurationHasTestTargetWithDefaultBuildConfiguration extends GivenPBXProjectLoading {
+		public PBXProject project() {
+			return PBXProject.builder() //
+				.buildConfigurations(withDefaultBuildConfiguration("Debug")) //
+				.with(testTarget(withDefaultBuildConfiguration("Release"))) //
+				.build();
+		}
+
+		@Test
+		void returnsProjectDefaultBuildConfigurationBecauseTargetDoesNotHaveDefaultBuildConfiguration() {
+			assertThat(subject.load(reference), equalTo("Release"));
+		}
+	}
+	//endregion
+}

--- a/subprojects/build-adapter-xcode/src/test/java/dev/nokee/xcode/PBXTargetLoaderTests.java
+++ b/subprojects/build-adapter-xcode/src/test/java/dev/nokee/xcode/PBXTargetLoaderTests.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.xcode;
+
+import dev.nokee.xcode.objects.PBXProject;
+import dev.nokee.xcode.objects.targets.PBXAggregateTarget;
+import dev.nokee.xcode.objects.targets.PBXTarget;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static dev.nokee.buildadapter.xcode.TestProjectReference.project;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+class PBXTargetLoaderTests {
+	@Mock XCLoader<PBXProject, XCProjectReference> loader;
+	@InjectMocks PBXTargetLoader subject;
+
+	@Nested
+	class WhenPBXProjectHasTargetsWithRequestedReference {
+		PBXTarget result;
+		PBXTarget target0 = PBXAggregateTarget.builder().lenient().name("Foo").build();
+		PBXTarget target1 = PBXAggregateTarget.builder().lenient().name("Bar").build();
+		PBXTarget target2 = PBXAggregateTarget.builder().lenient().name("Far").build();
+
+		@BeforeEach
+		void givenPBXProjectWithRequestedTarget() {
+			Mockito.when(loader.load(any())).thenReturn(PBXProject.builder().targets(target0, target1, target2).build());
+			result = subject.load(project("MyProject").ofTarget("Bar"));
+		}
+
+		@Test
+		void returnsTargetMatchingTargetReferenceName() {
+			assertThat(result, is(target1));
+		}
+	}
+
+	@Nested
+	class WhenPBXProjectHasNoTarget {
+		@BeforeEach
+		void givenPBXProjectWithNoTarget() {
+			Mockito.when(loader.load(any())).thenReturn(PBXProject.builder().build());
+		}
+
+		@Test
+		void throwsException() {
+			assertThrows(RuntimeException.class, () -> subject.load(project("MyProject").ofTarget("Bar")));
+		}
+	}
+
+	@Nested
+	class WhenPBXProjectHasTargetsButNoneMatchReference {
+		PBXTarget target0 = PBXAggregateTarget.builder().lenient().name("Foo").build();
+		PBXTarget target1 = PBXAggregateTarget.builder().lenient().name("Far").build();
+
+
+		@BeforeEach
+		void givenPBXProjectWithTargetsWithoutRequestedTarget() {
+			Mockito.when(loader.load(any())).thenReturn(PBXProject.builder().targets(target0, target1).build());
+		}
+
+		@Test
+		void throwsException() {
+			assertThrows(RuntimeException.class, () -> subject.load(project("MyProject").ofTarget("Bar")));
+		}
+	}
+}

--- a/subprojects/build-adapter-xcode/src/test/java/dev/nokee/xcode/XCLoadersIntegrationTests.java
+++ b/subprojects/build-adapter-xcode/src/test/java/dev/nokee/xcode/XCLoadersIntegrationTests.java
@@ -18,6 +18,8 @@ package dev.nokee.xcode;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.Set;
+
 import static dev.nokee.internal.testing.SerializableMatchers.isSerializable;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -35,6 +37,36 @@ class XCLoadersIntegrationTests {
 	@Nested
 	class WhenCrossProjectReferencesLoader {
 		XCLoader<Iterable<XCProjectReference>, XCProjectReference> subject = XCLoaders.crossProjectReferencesLoader();
+
+		@Test
+		void canSerialize() {
+			assertThat(subject, isSerializable());
+		}
+	}
+
+	@Nested
+	class WhenTargetConfigurationsLoader {
+		XCLoader<Set<String>, XCTargetReference> subject = XCLoaders.targetConfigurationsLoader();
+
+		@Test
+		void canSerialize() {
+			assertThat(subject, isSerializable());
+		}
+	}
+
+	@Nested
+	class WhenDefaultTargetConfigurationLoader {
+		XCLoader<String, XCTargetReference> subject = XCLoaders.defaultTargetConfigurationLoader();
+
+		@Test
+		void canSerialize() {
+			assertThat(subject, isSerializable());
+		}
+	}
+
+	@Nested
+	class WhenAllTargetsLoader {
+		XCLoader<Set<XCTargetReference>, XCProjectReference> subject = XCLoaders.allTargetsLoader();
 
 		@Test
 		void canSerialize() {

--- a/subprojects/core-utils/src/main/java/dev/nokee/util/internal/DoNothingConsumer.java
+++ b/subprojects/core-utils/src/main/java/dev/nokee/util/internal/DoNothingConsumer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.util.internal;
+
+import lombok.EqualsAndHashCode;
+
+import java.io.Serializable;
+import java.util.function.Consumer;
+
+@EqualsAndHashCode
+public final class DoNothingConsumer implements Consumer<Object>, Serializable {
+	private static final DoNothingConsumer INSTANCE = new DoNothingConsumer();
+
+	@Override
+	public void accept(Object t) {
+		// do nothing...
+	}
+
+	@SuppressWarnings("unchecked")
+	public <T> Consumer<T> withNarrowType() {
+		return (Consumer<T>) this;
+	}
+
+	public static <T> Consumer<T> doNothing() {
+		return INSTANCE.withNarrowType();
+	}
+}

--- a/subprojects/core-utils/src/main/java/dev/nokee/util/internal/OutOfDateReasonSpec.java
+++ b/subprojects/core-utils/src/main/java/dev/nokee/util/internal/OutOfDateReasonSpec.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.util.internal;
+
+import org.gradle.api.Task;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.specs.Spec;
+
+public final class OutOfDateReasonSpec<T extends Task> implements Spec<Task> {
+	private static final Logger LOGGER = Logging.getLogger(OutOfDateReasonSpec.class);
+	private final String outOfDateReason;
+	private final Spec<? super T> delegate;
+	private final InformationLogger logger;
+
+	public OutOfDateReasonSpec(String outOfDateReason, Spec<? super T> delegate) {
+		this(outOfDateReason, delegate, LOGGER::info);
+	}
+
+	// visible for testing
+	public OutOfDateReasonSpec(String outOfDateReason, Spec<? super T> delegate, InformationLogger logger) {
+		this.outOfDateReason = outOfDateReason;
+		this.delegate = delegate;
+		this.logger = logger;
+	}
+
+	// Returning {@literal true} means can be up-to-date while returning {@literal false} means out-of-date.
+	@Override
+	public boolean isSatisfiedBy(Task task) {
+		assert task != null : "'task' must not be null";
+		@SuppressWarnings("unchecked")
+		T castedTask = (T) task;
+		boolean result = delegate.isSatisfiedBy(castedTask);
+		if (isOutOfDate(result)) {
+			logger.log(String.format("Task outputs are out-of-date because %s.", outOfDateReason));
+		}
+		return result;
+	}
+
+	private static boolean isOutOfDate(boolean specResult) {
+		return !specResult;
+	}
+
+	public static <TaskType extends Task> Spec<Task> because(String outOfDateReason, Spec<? super TaskType> spec) {
+		return new OutOfDateReasonSpec<>(outOfDateReason, spec);
+	}
+
+	public interface InformationLogger {
+		void log(String message);
+	}
+}

--- a/subprojects/core-utils/src/main/java/dev/nokee/util/internal/ToOnlyInstanceOfFunction.java
+++ b/subprojects/core-utils/src/main/java/dev/nokee/util/internal/ToOnlyInstanceOfFunction.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.util.internal;
+
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+public final class ToOnlyInstanceOfFunction<T> implements Function<Object, Stream<T>> {
+	private final Class<T> baseType;
+
+	public ToOnlyInstanceOfFunction(Class<T> baseType) {
+		this.baseType = baseType;
+	}
+
+	@Override
+	public Stream<T> apply(Object o) {
+		if (baseType.isInstance(o)) {
+			return Stream.of(baseType.cast(o));
+		} else {
+			return Stream.empty();
+		}
+	}
+
+	public static <T> Function<Object, Stream<T>> toOnlyInstanceOf(Class<T> baseType) {
+		return new ToOnlyInstanceOfFunction<>(baseType);
+	}
+}

--- a/subprojects/core-utils/src/main/java/dev/nokee/util/internal/UncheckedCastTransformer.java
+++ b/subprojects/core-utils/src/main/java/dev/nokee/util/internal/UncheckedCastTransformer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.util.internal;
+
+import org.gradle.api.Transformer;
+
+public final class UncheckedCastTransformer<OUT, IN> implements Transformer<OUT, IN> {
+	@Override
+	@SuppressWarnings("unchecked")
+	public OUT transform(IN in) {
+		return (OUT) in;
+	}
+
+	public static <CastType, InputType> Transformer<CastType, InputType> uncheckedCast() {
+		return new UncheckedCastTransformer<>();
+	}
+}

--- a/subprojects/core-utils/src/main/java/dev/nokee/utils/SpecUtils.java
+++ b/subprojects/core-utils/src/main/java/dev/nokee/utils/SpecUtils.java
@@ -15,6 +15,7 @@
  */
 package dev.nokee.utils;
 
+import dev.nokee.util.internal.UncheckedCastTransformer;
 import lombok.EqualsAndHashCode;
 import lombok.val;
 import org.gradle.api.Transformer;
@@ -37,6 +38,10 @@ public final class SpecUtils {
 			return Cast.uncheckedCast("no op transformer implies the output type is the same", spec);
 		}
 		return new ComposeSpec<>(spec, transformer);
+	}
+
+	public static <CastedType, InputType> Spec<InputType> uncheckedCast(org.gradle.api.specs.Spec<? super CastedType> delegate) {
+		return compose(delegate, UncheckedCastTransformer.uncheckedCast());
 	}
 
 	@EqualsAndHashCode

--- a/subprojects/core-utils/src/test/groovy/dev/nokee/util/internal/DoNothingConsumerTests.java
+++ b/subprojects/core-utils/src/test/groovy/dev/nokee/util/internal/DoNothingConsumerTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.util.internal;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static dev.nokee.internal.testing.MockitoMatchers.noInteractions;
+import static dev.nokee.internal.testing.SerializableMatchers.isSerializable;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class DoNothingConsumerTests {
+	DoNothingConsumer subject = new DoNothingConsumer();
+
+	@Test
+	void doesNotInteractWithArgument() {
+		Object argument = Mockito.mock(Object.class);
+		subject.accept(argument);
+		assertThat(argument, noInteractions());
+	}
+
+	@Test
+	void canSerialize() {
+		assertThat(subject, isSerializable());
+	}
+
+	@Test
+	@SuppressWarnings("UnstableApiUsage")
+	void checkEquals() {
+		new EqualsTester().addEqualityGroup(new DoNothingConsumer(), new DoNothingConsumer()).testEquals();
+	}
+}

--- a/subprojects/core-utils/src/test/groovy/dev/nokee/util/internal/OutOfDateReasonSpecTests.java
+++ b/subprojects/core-utils/src/test/groovy/dev/nokee/util/internal/OutOfDateReasonSpecTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.util.internal;
+
+import org.gradle.api.Task;
+import org.gradle.api.specs.Spec;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static dev.nokee.internal.testing.MockitoMethodWrapper.method;
+import static dev.nokee.internal.testing.invocations.InvocationMatchers.calledOnceWith;
+import static dev.nokee.internal.testing.invocations.InvocationMatchers.neverCalled;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+class OutOfDateReasonSpecTests {
+	@Mock Spec<Task> delegate;
+	@Mock OutOfDateReasonSpec.InformationLogger logger;
+	OutOfDateReasonSpec<Task> subject;
+	@Mock Task task;
+
+	@BeforeEach
+	void givenSubject() {
+		subject = new OutOfDateReasonSpec<>("some reason", delegate, logger);
+	}
+
+	@Nested
+	class WhenDelegateIsSatisfied {
+		boolean result;
+
+		@BeforeEach
+		void givenDelegateReturnsTrue() {
+			Mockito.when(delegate.isSatisfiedBy(any())).thenReturn(true);
+			result = subject.isSatisfiedBy(task);
+		}
+
+		@Test
+		void doesNotLogAnything() {
+			assertThat(method(logger, OutOfDateReasonSpec.InformationLogger::log), neverCalled());
+		}
+
+		@Test
+		void forwardsIsSatisfiedToDelegate() {
+			assertThat(method(delegate, Spec::isSatisfiedBy), calledOnceWith(task));
+			assertThat(result, is(true));
+		}
+	}
+
+	@Nested
+	class WhenDelegateIsUnsatisfied {
+		boolean result;
+
+		@BeforeEach
+		void givenDelegateReturnsFalse() {
+			Mockito.when(delegate.isSatisfiedBy(any())).thenReturn(false);
+			result = subject.isSatisfiedBy(task);
+		}
+
+		@Test
+		void logsReason() {
+			assertThat(method(logger, OutOfDateReasonSpec.InformationLogger::log),
+				calledOnceWith("Task outputs are out-of-date because some reason."));
+		}
+
+		@Test
+		void forwardsIsSatisfiedToDelegate() {
+			assertThat(method(delegate, Spec::isSatisfiedBy), calledOnceWith(task));
+			assertThat(result, is(false));
+		}
+	}
+}

--- a/subprojects/core-utils/src/test/groovy/dev/nokee/util/internal/ToOnlyInstanceOfFunctionTests.java
+++ b/subprojects/core-utils/src/test/groovy/dev/nokee/util/internal/ToOnlyInstanceOfFunctionTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.util.internal;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.emptyIterable;
+
+@ExtendWith(MockitoExtension.class)
+class ToOnlyInstanceOfFunctionTests {
+	ToOnlyInstanceOfFunction<Number> subject = new ToOnlyInstanceOfFunction<>(Number.class);
+
+	@Nested
+	class WhenInputIsNotBaseType {
+		@Test
+		void returnEmptyStream() {
+			assertThat(subject.apply(new Object()).collect(toList()), emptyIterable());
+		}
+	}
+
+	@Nested
+	class WhenInputIsChildType {
+		@Test
+		void returnStreamWithOnlyInputValue() {
+			assertThat(subject.apply(Integer.valueOf("42")).collect(toList()), contains(42));
+		}
+	}
+}

--- a/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/GradleSpecMatchers.java
+++ b/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/GradleSpecMatchers.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.internal.testing;
+
+import org.gradle.api.specs.Spec;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+
+import static org.hamcrest.Matchers.is;
+
+public final class GradleSpecMatchers {
+	private GradleSpecMatchers() {}
+
+	public static <T> Matcher<Spec<T>> unsatisfiedBy(T target) {
+		return new FeatureMatcher<Spec<T>, Boolean>(is(false), "", "") {
+			@Override
+			protected Boolean featureValueOf(Spec<T> actual) {
+				return actual.isSatisfiedBy(target);
+			}
+		};
+	}
+
+	public static <T> Matcher<Spec<T>> satisfiedBy(T target) {
+		return new FeatureMatcher<Spec<T>, Boolean>(is(true), "", "") {
+			@Override
+			protected Boolean featureValueOf(Spec<T> actual) {
+				return actual.isSatisfiedBy(target);
+			}
+		};
+	}
+}

--- a/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/JDK8PredicateMatchers.java
+++ b/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/JDK8PredicateMatchers.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.internal.testing;
+
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+
+import java.util.function.Predicate;
+
+import static org.hamcrest.Matchers.is;
+
+public final class JDK8PredicateMatchers {
+	private JDK8PredicateMatchers() {}
+
+	public static <T> Matcher<Predicate<T>> rejects(T target) {
+		return new FeatureMatcher<Predicate<T>, Boolean>(is(false), "", "") {
+			@Override
+			protected Boolean featureValueOf(Predicate<T> actual) {
+				return actual.test(target);
+			}
+		};
+	}
+
+	public static <T> Matcher<Predicate<T>> accepts(T target) {
+		return new FeatureMatcher<Predicate<T>, Boolean>(is(true), "", "") {
+			@Override
+			protected Boolean featureValueOf(Predicate<T> actual) {
+				return actual.test(target);
+			}
+		};
+	}
+}

--- a/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/MockitoMatchers.java
+++ b/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/MockitoMatchers.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.internal.testing;
+
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+import org.mockito.Mockito;
+
+import static org.hamcrest.Matchers.nullValue;
+
+public final class MockitoMatchers {
+	private MockitoMatchers() {}
+
+	public static <T> Matcher<T> noInteractions() {
+		return new FeatureMatcher<T, Void>(nullValue(), "", "") {
+			@Override
+			protected Void featureValueOf(T actual) {
+				Mockito.verifyNoInteractions(actual);
+				return null;
+			}
+		};
+	}
+}

--- a/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/MockitoMethodWrapper.java
+++ b/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/MockitoMethodWrapper.java
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.nokee.xcode.project;
+package dev.nokee.internal.testing;
 
 import com.google.common.collect.Iterators;
-import dev.nokee.xcode.project.invocations.HasInvocationResults;
-import dev.nokee.xcode.project.invocations.InvocationResult;
-import dev.nokee.xcode.project.invocations.InvocationResult0;
-import dev.nokee.xcode.project.invocations.InvocationResult1;
-import dev.nokee.xcode.project.invocations.InvocationResult2;
+import dev.nokee.internal.testing.invocations.HasInvocationResults;
+import dev.nokee.internal.testing.invocations.InvocationResult;
+import dev.nokee.internal.testing.invocations.InvocationResult0;
+import dev.nokee.internal.testing.invocations.InvocationResult1;
+import dev.nokee.internal.testing.invocations.InvocationResult2;
 import org.mockito.Mockito;
 import org.mockito.invocation.Invocation;
 

--- a/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/invocations/HasInvocationResults.java
+++ b/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/invocations/HasInvocationResults.java
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.nokee.xcode.project.invocations;
+package dev.nokee.internal.testing.invocations;
 
-public interface InvocationResult0 extends InvocationResult {
+import java.util.List;
 
+public interface HasInvocationResults<A extends InvocationResult> {
+	List<A> getAllInvocations();
 }

--- a/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/invocations/InvocationMatchers.java
+++ b/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/invocations/InvocationMatchers.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.nokee.xcode.project.invocations;
+package dev.nokee.internal.testing.invocations;
 
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
@@ -40,6 +40,10 @@ public final class InvocationMatchers {
 
 	public static <T extends HasInvocationResults<?>> Matcher<T> neverCalled() {
 		return called(equalTo(0L));
+	}
+
+	public static <T extends HasInvocationResults<A>, A extends InvocationResult1<A0>, A0> Matcher<T> calledOnceWith(A0 expectedValue) {
+		return calledOnceWith(equalTo(expectedValue));
 	}
 
 	@SuppressWarnings("unchecked")

--- a/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/invocations/InvocationResult.java
+++ b/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/invocations/InvocationResult.java
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.nokee.xcode.project.invocations;
+package dev.nokee.internal.testing.invocations;
 
-import dev.nokee.xcode.project.invocations.InvocationResult;
+public interface InvocationResult extends Iterable<Object> {
+	<A> A getArgument(int index);
 
-public interface InvocationResult1<A0> extends InvocationResult {
-	A0 getFirstArgument();
+	<A> A getArgument(int index, Class<A> argumentType);
 }

--- a/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/invocations/InvocationResult0.java
+++ b/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/invocations/InvocationResult0.java
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.nokee.xcode.project.invocations;
+package dev.nokee.internal.testing.invocations;
 
-import java.util.List;
+public interface InvocationResult0 extends InvocationResult {
 
-public interface HasInvocationResults<A extends InvocationResult> {
-	List<A> getAllInvocations();
 }

--- a/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/invocations/InvocationResult1.java
+++ b/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/invocations/InvocationResult1.java
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.nokee.xcode.project.invocations;
+package dev.nokee.internal.testing.invocations;
 
-public interface InvocationResult2<A0, A1> extends InvocationResult {
+public interface InvocationResult1<A0> extends InvocationResult {
 	A0 getFirstArgument();
-
-	A1 getSecondArgument();
 }

--- a/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/invocations/InvocationResult2.java
+++ b/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/invocations/InvocationResult2.java
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.nokee.xcode.project.invocations;
+package dev.nokee.internal.testing.invocations;
 
-public interface InvocationResult extends Iterable<Object> {
-	<A> A getArgument(int index);
+public interface InvocationResult2<A0, A1> extends InvocationResult {
+	A0 getFirstArgument();
 
-	<A> A getArgument(int index, Class<A> argumentType);
+	A1 getSecondArgument();
 }

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/PBXProject.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/PBXProject.java
@@ -33,6 +33,7 @@ import lombok.val;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -123,6 +124,10 @@ public interface PBXProject extends PBXContainer, PBXContainerItemProxy.Containe
 			}
 			targets.add(target);
 			return this;
+		}
+
+		public Builder targets(PBXTarget... targets) {
+			return targets(Arrays.asList(targets));
 		}
 
 		public Builder targets(Iterable<? extends PBXTarget> targets) {

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/PBXProject.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/PBXProject.java
@@ -21,7 +21,9 @@ import dev.nokee.xcode.objects.files.PBXFileReference;
 import dev.nokee.xcode.objects.files.PBXGroup;
 import dev.nokee.xcode.objects.files.PBXSourceTree;
 import dev.nokee.xcode.objects.swiftpackage.XCRemoteSwiftPackageReference;
+import dev.nokee.xcode.objects.targets.BuildConfigurationsAwareBuilder;
 import dev.nokee.xcode.objects.targets.PBXTarget;
+import dev.nokee.xcode.objects.targets.SelfConfigurationAwareBuilder;
 import dev.nokee.xcode.project.CodeablePBXProject;
 import dev.nokee.xcode.project.CodeableProjectReference;
 import dev.nokee.xcode.project.DefaultKeyedObject;
@@ -34,6 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
 
 /**
  * The root object representing the project itself.
@@ -91,7 +94,7 @@ public interface PBXProject extends PBXContainer, PBXContainerItemProxy.Containe
 		return new Builder();
 	}
 
-	final class Builder {
+	final class Builder implements BuildConfigurationsAwareBuilder<Builder>, SelfConfigurationAwareBuilder<Builder> {
 		@Nullable private final KeyedObject parent;
 		private List<PBXTarget> targets;
 		private XCConfigurationList buildConfigurations;
@@ -106,6 +109,11 @@ public interface PBXProject extends PBXContainer, PBXContainerItemProxy.Containe
 
 		public Builder(KeyedObject parent) {
 			this.parent = parent;
+		}
+
+		@Override
+		public Builder with(UnaryOperator<Builder> action) {
+			return action.apply(this);
 		}
 
 		public Builder target(PBXTarget target) {
@@ -123,13 +131,7 @@ public interface PBXProject extends PBXContainer, PBXContainerItemProxy.Containe
 			return this;
 		}
 
-		public Builder buildConfigurations(Consumer<? super XCConfigurationList.Builder> builderConsumer) {
-			final XCConfigurationList.Builder builder = XCConfigurationList.builder();
-			builderConsumer.accept(builder);
-			this.buildConfigurations = builder.build();
-			return this;
-		}
-
+		@Override
 		public Builder buildConfigurations(XCConfigurationList buildConfigurations) {
 			this.buildConfigurations = Objects.requireNonNull(buildConfigurations);
 			return this;

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/buildphase/PBXShellScriptBuildPhase.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/buildphase/PBXShellScriptBuildPhase.java
@@ -116,9 +116,21 @@ public interface PBXShellScriptBuildPhase extends PBXBuildPhase {
 			return this;
 		}
 
+		public Builder outputPath(String outputPath) {
+			Objects.requireNonNull(outputPath);
+			outputPaths.add(outputPath);
+			return this;
+		}
+
 		public Builder inputPaths(Iterable<String> inputPaths) {
 			this.inputPaths.clear();
 			stream(inputPaths).map(Objects::requireNonNull).forEach(this.inputPaths::add);
+			return this;
+		}
+
+		public Builder inputPath(String inputPath) {
+			Objects.requireNonNull(inputPath);
+			inputPaths.add(inputPath);
 			return this;
 		}
 

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/configuration/XCConfigurationList.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/configuration/XCConfigurationList.java
@@ -67,7 +67,11 @@ public interface XCConfigurationList extends PBXProjectItem {
 		public Builder buildConfiguration(Consumer<? super XCBuildConfiguration.Builder> builderConsumer) {
 			final XCBuildConfiguration.Builder builder = XCBuildConfiguration.builder();
 			builderConsumer.accept(builder);
-			final XCBuildConfiguration buildConfiguration = builder.build();
+			return buildConfiguration(builder.build());
+		}
+
+		public Builder buildConfiguration(XCBuildConfiguration buildConfiguration) {
+			final XCBuildConfiguration.Builder builder = XCBuildConfiguration.builder();
 			if (this.buildConfigurations == null) {
 				this.buildConfigurations = new LinkedHashSet<>();
 			}

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/targets/BuildConfigurationsAwareBuilder.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/targets/BuildConfigurationsAwareBuilder.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.xcode.objects.targets;
+
+import dev.nokee.xcode.objects.configuration.XCConfigurationList;
+
+import java.util.function.Consumer;
+
+public interface BuildConfigurationsAwareBuilder<SELF> {
+	SELF buildConfigurations(XCConfigurationList buildConfigurations);
+
+	default SELF buildConfigurations(Consumer<? super XCConfigurationList.Builder> action) {
+		final XCConfigurationList.Builder builder = XCConfigurationList.builder();
+		action.accept(builder);
+		return buildConfigurations(builder.build());
+	}
+}

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/targets/BuildPhaseAwareBuilder.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/targets/BuildPhaseAwareBuilder.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.xcode.objects.targets;
+
+import dev.nokee.xcode.objects.buildphase.PBXBuildPhase;
+
+public interface BuildPhaseAwareBuilder<SELF extends BuildPhaseAwareBuilder<SELF>> {
+	SELF buildPhase(PBXBuildPhase buildPhase);
+
+	SELF buildPhases(Iterable<? extends PBXBuildPhase> buildPhases);
+}

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/targets/LenientAwareBuilder.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/targets/LenientAwareBuilder.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.xcode.objects.targets;
+
+public interface LenientAwareBuilder<SELF> {
+	SELF lenient();
+}

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/targets/PBXLegacyTarget.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/targets/PBXLegacyTarget.java
@@ -16,6 +16,7 @@
 package dev.nokee.xcode.objects.targets;
 
 import com.google.common.collect.ImmutableList;
+import dev.nokee.xcode.objects.buildphase.PBXBuildPhase;
 import dev.nokee.xcode.objects.configuration.XCConfigurationList;
 import dev.nokee.xcode.objects.files.PBXFileReference;
 import dev.nokee.xcode.project.KeyedCoders;
@@ -45,7 +46,7 @@ public interface PBXLegacyTarget extends PBXTarget {
 		return new Builder();
 	}
 
-	final class Builder {
+	final class Builder implements BuildConfigurationsAwareBuilder<Builder> {
 		private String name;
 		private ProductType productType;
 		private String buildArgumentsString = "$(ACTION)";
@@ -67,13 +68,7 @@ public interface PBXLegacyTarget extends PBXTarget {
 			return this;
 		}
 
-		public Builder buildConfigurations(Consumer<? super XCConfigurationList.Builder> builderConsumer) {
-			final XCConfigurationList.Builder builder = XCConfigurationList.builder();
-			builderConsumer.accept(builder);
-			this.buildConfigurationList = builder.build();
-			return this;
-		}
-
+		@Override
 		public Builder buildConfigurations(XCConfigurationList buildConfigurationList) {
 			this.buildConfigurationList = Objects.requireNonNull(buildConfigurationList);
 			return this;

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/targets/PBXNativeTarget.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/targets/PBXNativeTarget.java
@@ -42,7 +42,7 @@ public interface PBXNativeTarget extends PBXTarget {
 		return new Builder();
 	}
 
-	final class Builder {
+	final class Builder implements BuildPhaseAwareBuilder<Builder>, BuildConfigurationsAwareBuilder<Builder> {
 		private String name;
 		private ProductType productType;
 		private final List<PBXBuildPhase> buildPhases = new ArrayList<>();
@@ -62,24 +62,20 @@ public interface PBXNativeTarget extends PBXTarget {
 			return this;
 		}
 
+		@Override
 		public Builder buildPhase(PBXBuildPhase buildPhase) {
 			this.buildPhases.add(requireNonNull(buildPhase));
 			return this;
 		}
 
+		@Override
 		public Builder buildPhases(Iterable<? extends PBXBuildPhase> buildPhases) {
 			this.buildPhases.clear();
 			stream(buildPhases).map(Objects::requireNonNull).forEach(this.buildPhases::add);
 			return this;
 		}
 
-		public Builder buildConfigurations(Consumer<? super XCConfigurationList.Builder> builderConsumer) {
-			final XCConfigurationList.Builder builder = XCConfigurationList.builder();
-			builderConsumer.accept(builder);
-			this.buildConfigurationList = builder.build();
-			return this;
-		}
-
+		@Override
 		public Builder buildConfigurations(XCConfigurationList buildConfigurationList) {
 			this.buildConfigurationList = requireNonNull(buildConfigurationList);
 			return this;

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/targets/SelfConfigurationAwareBuilder.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/targets/SelfConfigurationAwareBuilder.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.xcode.objects.targets;
+
+import java.util.function.UnaryOperator;
+
+public interface SelfConfigurationAwareBuilder<SELF> {
+	SELF with(UnaryOperator<SELF> action);
+}

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/project/Codeable.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/project/Codeable.java
@@ -32,6 +32,10 @@ public interface Codeable {
 
 	void encode(EncodeContext context);
 
+	default boolean has(CodingKey key) {
+		return tryDecode(key) != null;
+	}
+
 	interface EncodeContext {
 
 		void base(Map<String, ?> fields);

--- a/subprojects/xcode-ide-kit/src/test/java/dev/nokee/xcode/project/RecodeableKeyedObjectEncodingTests.java
+++ b/subprojects/xcode-ide-kit/src/test/java/dev/nokee/xcode/project/RecodeableKeyedObjectEncodingTests.java
@@ -24,8 +24,8 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static dev.nokee.xcode.project.MockitoMethodWrapper.method;
-import static dev.nokee.xcode.project.invocations.InvocationMatchers.calledOnceWith;
+import static dev.nokee.internal.testing.MockitoMethodWrapper.method;
+import static dev.nokee.internal.testing.invocations.InvocationMatchers.calledOnceWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;


### PR DESCRIPTION
If any PBXShellScriptBuildPhase doesn't declare any inputs/outputs, the whole target should be considered out-of-date (from Gradle's perspective). Note that we don't support xcfilelist yet so declaring any of these files as input or output will also consider the whole target out-of-date.