### PR TITLE
Various improvement to core execution framework

### DIFF
--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/DefaultXcodeSelect.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/DefaultXcodeSelect.java
@@ -18,9 +18,12 @@ package dev.nokee.buildadapter.xcode.internal.plugins;
 import dev.nokee.core.exec.CommandLine;
 import dev.nokee.core.exec.CommandLineToolExecutionEngine;
 import dev.nokee.core.exec.CommandLineToolExecutionHandle;
+import dev.nokee.core.exec.CommandLineToolInvocationEnvironmentVariables;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+
+import static dev.nokee.core.exec.CommandLineToolInvocationEnvironmentVariables.inherit;
 
 public final class DefaultXcodeSelect implements XcodeSelect {
 	private final CommandLineToolExecutionEngine<? extends CommandLineToolExecutionHandle.Waitable> engine;
@@ -31,7 +34,7 @@ public final class DefaultXcodeSelect implements XcodeSelect {
 
 	@Override
 	public Path developerDirectory() {
-		return CommandLine.of("xcode-select", "--print-path").execute(engine).waitFor().getOutput()
+		return CommandLine.of("xcode-select", "--print-path").newInvocation().withEnvironmentVariables(inherit("PATH", "DEVELOPER_DIR")).buildAndSubmit(engine).waitFor().getOutput()
 			.parse(this::parsePrintedPath);
 	}
 

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/DefaultXcodebuild.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/DefaultXcodebuild.java
@@ -18,10 +18,13 @@ package dev.nokee.buildadapter.xcode.internal.plugins;
 import dev.nokee.core.exec.CommandLineTool;
 import dev.nokee.core.exec.CommandLineToolExecutionEngine;
 import dev.nokee.core.exec.CommandLineToolExecutionHandle;
+import dev.nokee.core.exec.CommandLineToolInvocationEnvironmentVariables;
 import dev.nokee.core.exec.CommandLineToolOutputParser;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static dev.nokee.core.exec.CommandLineToolInvocationEnvironmentVariables.inherit;
 
 public final class DefaultXcodebuild implements Xcodebuild {
 	private final CommandLineToolExecutionEngine<? extends CommandLineToolExecutionHandle.Waitable> engine;
@@ -32,7 +35,7 @@ public final class DefaultXcodebuild implements Xcodebuild {
 
 	@Override
 	public String version() {
-		return CommandLineTool.of("xcodebuild").withArguments("-version").execute(engine).waitFor().getOutput().parse(asXcodeRunVersion());
+		return CommandLineTool.of("xcodebuild").withArguments("-version").newInvocation().withEnvironmentVariables(inherit("PATH", "DEVELOPER_DIR")).buildAndSubmit(engine).waitFor().getOutput().parse(asXcodeRunVersion());
 	}
 
 	private static final Pattern XCODEBUILD_VERSION_PATTERN = Pattern.compile("(\\d+.\\d+(.\\d+)?)");

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeTargetExecTask.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeTargetExecTask.java
@@ -127,7 +127,7 @@ public abstract class XcodeTargetExecTask extends DefaultTask implements Xcodebu
 				it.args(allArguments);
 				it.args("-showBuildSettings", "-json");
 			}).newInvocation(it -> {
-				it.withEnvironmentVariables(inherit().putOrReplace("DEVELOPER_DIR", getXcodeInstallation().get().getDeveloperDirectory()));
+				it.withEnvironmentVariables(inherit("PATH").putOrReplace("DEVELOPER_DIR", getXcodeInstallation().get().getDeveloperDirectory()));
 				ifPresent(getWorkingDirectory(), it::workingDirectory);
 			}).submitTo(execOperations(getExecOperations())).result()
 				.getStandardOutput().parse(output -> {
@@ -159,7 +159,7 @@ public abstract class XcodeTargetExecTask extends DefaultTask implements Xcodebu
 		val invocation = CommandLineTool.of("xcodebuild").withArguments(it -> {
 			it.args(getAllArguments().map(allArguments -> concat(of("-project", isolatedProjectLocation.getAbsolutePath()), skip(allArguments, 2))));
 		}).newInvocation(it -> {
-			it.withEnvironmentVariables(inherit().putOrReplace("DEVELOPER_DIR", getXcodeInstallation().get().getDeveloperDirectory()));
+			it.withEnvironmentVariables(inherit("PATH").putOrReplace("DEVELOPER_DIR", getXcodeInstallation().get().getDeveloperDirectory()));
 			ifPresent(getWorkingDirectory(), it::workingDirectory);
 			it.redirectStandardOutput(toFile(new File(getTemporaryDir(), "outputs.txt")));
 			it.redirectErrorOutput(toStandardStream());

--- a/subprojects/core-exec/src/main/java/dev/nokee/core/exec/CommandLineToolExecutionEngine.java
+++ b/subprojects/core-exec/src/main/java/dev/nokee/core/exec/CommandLineToolExecutionEngine.java
@@ -51,6 +51,6 @@ public interface CommandLineToolExecutionEngine<T extends CommandLineToolExecuti
 	}
 
 	static ProcessBuilderEngine processBuilder() {
-		return new ProcessBuilderEngine();
+		return CommandLineUtils.PROCESS_BUILDER_ENGINE;
 	}
 }

--- a/subprojects/core-exec/src/main/java/dev/nokee/core/exec/CommandLineToolExecutionEngine.java
+++ b/subprojects/core-exec/src/main/java/dev/nokee/core/exec/CommandLineToolExecutionEngine.java
@@ -49,4 +49,8 @@ public interface CommandLineToolExecutionEngine<T extends CommandLineToolExecuti
 	static GradleWorkerExecutorEngine newWorkerQueue(WorkerExecutor workerExecutor) {
 		return new GradleWorkerExecutorEngine(workerExecutor);
 	}
+
+	static ProcessBuilderEngine processBuilder() {
+		return new ProcessBuilderEngine();
+	}
 }

--- a/subprojects/core-exec/src/main/java/dev/nokee/core/exec/CommandLineToolInvocation.java
+++ b/subprojects/core-exec/src/main/java/dev/nokee/core/exec/CommandLineToolInvocation.java
@@ -136,7 +136,7 @@ public final class CommandLineToolInvocation implements Serializable {
 		private Object workingDirectory = null;
 		private CommandLineToolInvocationStandardOutputRedirect standardOutputRedirect = CommandLineToolInvocationOutputRedirection.toNullStream();
 		private CommandLineToolInvocationErrorOutputRedirect errorOutputRedirect = CommandLineToolInvocationOutputRedirection.toNullStream();
-		private CommandLineToolInvocationEnvironmentVariables environmentVariables = CommandLineToolInvocationEnvironmentVariables.inherit();
+		private CommandLineToolInvocationEnvironmentVariables environmentVariables = null;
 
 		public Builder commandLine(CommandLine commandLine) {
 			this.executable = commandLine.getTool();
@@ -168,6 +168,8 @@ public final class CommandLineToolInvocation implements Serializable {
 
 			Objects.requireNonNull(executable, "'commandLine' must not be null");
 
+			final CommandLineToolInvocationEnvironmentVariables environmentVariables = resolveEnvironmentVariables();
+
 			CommandLineToolExecutable executable = null;
 			if (this.executable instanceof CommandLineTool) {
 				executable = ((CommandLineToolExecutableResolvable) this.executable).resolve(new CommandLineToolExecutableResolvable.Context() {
@@ -195,6 +197,15 @@ public final class CommandLineToolInvocation implements Serializable {
 			} else {
 				return result;
 			}
+		}
+
+		private CommandLineToolInvocationEnvironmentVariables resolveEnvironmentVariables() {
+			CommandLineToolInvocationEnvironmentVariables result = this.environmentVariables;
+			if (result == null) {
+				result = CommandLineToolInvocationEnvironmentVariables.inherit();
+			}
+
+			return result;
 		}
 
 		public <T extends CommandLineToolExecutionHandle> T buildAndSubmit(CommandLineToolExecutionEngine<T> engine) {

--- a/subprojects/core-exec/src/main/java/dev/nokee/core/exec/CommandLineToolInvocationEnvironmentVariables.java
+++ b/subprojects/core-exec/src/main/java/dev/nokee/core/exec/CommandLineToolInvocationEnvironmentVariables.java
@@ -136,7 +136,7 @@ public final class CommandLineToolInvocationEnvironmentVariables implements Seri
 	/**
 	 * Creates the invocation environment variables from the current process.
 	 *
-	 * @return a instance representing the environment variables to use, never null.
+	 * @return an instance representing the environment variables to use, never null.
 	 */
 	public static CommandLineToolInvocationEnvironmentVariables inherit() {
 		return new CommandLineToolInvocationEnvironmentVariables(System.getenv());

--- a/subprojects/core-exec/src/main/java/dev/nokee/core/exec/CommandLineToolInvocationEnvironmentVariables.java
+++ b/subprojects/core-exec/src/main/java/dev/nokee/core/exec/CommandLineToolInvocationEnvironmentVariables.java
@@ -143,6 +143,20 @@ public final class CommandLineToolInvocationEnvironmentVariables implements Seri
 	}
 
 	/**
+	 * Creates the invocation environment variables from the current process of only the specified environment variable names.
+	 *
+	 * @param keys  the environment variable names to inherit, must not be empty
+	 * @return an instance representing the environment variables to use from the current process, never null.
+	 */
+	public static CommandLineToolInvocationEnvironmentVariables inherit(String... keys) {
+		final ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+		for (String key : keys) {
+			builder.put(key, System.getenv(key));
+		}
+		return new CommandLineToolInvocationEnvironmentVariables(builder.build());
+	}
+
+	/**
 	 * Creates the empty invocation environment variables.
 	 *
 	 * @return a instance representing the environment variables to use, never null.

--- a/subprojects/core-exec/src/main/java/dev/nokee/core/exec/CommandLineToolInvocationEnvironmentVariables.java
+++ b/subprojects/core-exec/src/main/java/dev/nokee/core/exec/CommandLineToolInvocationEnvironmentVariables.java
@@ -151,7 +151,10 @@ public final class CommandLineToolInvocationEnvironmentVariables implements Seri
 	public static CommandLineToolInvocationEnvironmentVariables inherit(String... keys) {
 		final ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
 		for (String key : keys) {
-			builder.put(key, System.getenv(key));
+			final String value = System.getenv(key);
+			if (value != null) {
+				builder.put(key, value);
+			}
 		}
 		return new CommandLineToolInvocationEnvironmentVariables(builder.build());
 	}

--- a/subprojects/core-exec/src/main/java/dev/nokee/core/exec/CommandLineUtils.java
+++ b/subprojects/core-exec/src/main/java/dev/nokee/core/exec/CommandLineUtils.java
@@ -29,6 +29,8 @@ import static org.apache.commons.lang3.SystemUtils.IS_OS_FREE_BSD;
 import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
 
 final class CommandLineUtils {
+	public static final ProcessBuilderEngine PROCESS_BUILDER_ENGINE = new ProcessBuilderEngine();
+
 	private CommandLineUtils() {}
 
 	public static List<Object> getScriptCommandLine() {

--- a/subprojects/core-exec/src/main/java/dev/nokee/core/exec/IgnoreJavaPathFlattener.java
+++ b/subprojects/core-exec/src/main/java/dev/nokee/core/exec/IgnoreJavaPathFlattener.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.core.exec;
+
+import com.google.common.collect.ImmutableList;
+import dev.nokee.utils.DeferredUtils;
+
+import javax.annotation.Nullable;
+import java.nio.file.Path;
+import java.util.List;
+
+final class IgnoreJavaPathFlattener implements DeferredUtils.Flattener {
+	private final DeferredUtils.Flattener delegate;
+
+	public IgnoreJavaPathFlattener(DeferredUtils.Flattener delegate) {
+		this.delegate = delegate;
+	}
+
+	@Override
+	public List<Object> flatten(@Nullable Object target) {
+		if (target instanceof Path) { // Give a free pass to Path
+			return ImmutableList.of(target);
+		} else {
+			return delegate.flatten(target);
+		}
+	}
+}

--- a/subprojects/core-exec/src/main/java/dev/nokee/core/exec/ProcessBuilderEngine.java
+++ b/subprojects/core-exec/src/main/java/dev/nokee/core/exec/ProcessBuilderEngine.java
@@ -31,7 +31,7 @@ import java.util.function.Supplier;
 import static dev.nokee.core.exec.CommandLineToolOutputStreams.execute;
 
 @EqualsAndHashCode
-public class ProcessBuilderEngine implements CommandLineToolExecutionEngine<ProcessBuilderEngine.Handle> {
+public final class ProcessBuilderEngine implements CommandLineToolExecutionEngine<ProcessBuilderEngine.Handle> {
 	@Override
 	public Handle submit(CommandLineToolInvocation invocation) {
 		ProcessBuilder processBuilder = new ProcessBuilder();

--- a/subprojects/core-exec/src/main/java/dev/nokee/core/exec/ProcessBuilderEngine.java
+++ b/subprojects/core-exec/src/main/java/dev/nokee/core/exec/ProcessBuilderEngine.java
@@ -17,6 +17,7 @@ package dev.nokee.core.exec;
 
 import com.google.common.collect.ImmutableList;
 import dev.nokee.core.exec.internal.DefaultCommandLineToolExecutionResult;
+import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.apache.commons.exec.PumpStreamHandler;
@@ -29,6 +30,7 @@ import java.util.function.Supplier;
 
 import static dev.nokee.core.exec.CommandLineToolOutputStreams.execute;
 
+@EqualsAndHashCode
 public class ProcessBuilderEngine implements CommandLineToolExecutionEngine<ProcessBuilderEngine.Handle> {
 	@Override
 	public Handle submit(CommandLineToolInvocation invocation) {

--- a/subprojects/core-exec/src/main/java/dev/nokee/core/exec/UnpackStrategies.java
+++ b/subprojects/core-exec/src/main/java/dev/nokee/core/exec/UnpackStrategies.java
@@ -18,9 +18,11 @@ package dev.nokee.core.exec;
 import com.google.common.collect.ImmutableList;
 import dev.nokee.utils.DeferredUtils;
 
+import java.nio.file.Path;
 import java.util.Objects;
 
-import static dev.nokee.utils.DeferredUtils.flatUnpackWhile;
+import static dev.nokee.utils.DeferredUtils.DEFAULT_FLATTENER;
+import static dev.nokee.utils.DeferredUtils.flat;
 import static dev.nokee.utils.DeferredUtils.isDeferred;
 import static dev.nokee.utils.DeferredUtils.isFlattenableType;
 
@@ -29,7 +31,9 @@ enum UnpackStrategies implements UnpackStrategy {
 		@Override
 		public <R> R unpack(Object value) {
 			@SuppressWarnings("unchecked")
-			R result = (R) flatUnpackWhile(it -> isDeferred(it) || isFlattenableType(it)).execute(value).stream()
+			R result = (R) flat(new IgnoreJavaPathFlattener(DEFAULT_FLATTENER)).unpack()
+				.whileTrue(it -> isDeferred(it) || (isFlattenableType(it) && !(it instanceof Path)))
+				.execute(value).stream()
 				.map(Object::toString).collect(ImmutableList.toImmutableList());
 			return result;
 		}

--- a/subprojects/core-exec/src/test/groovy/dev/nokee/core/exec/CommandLineToolInvocationEnvironmentVariablesInheritFactoryTests.java
+++ b/subprojects/core-exec/src/test/groovy/dev/nokee/core/exec/CommandLineToolInvocationEnvironmentVariablesInheritFactoryTests.java
@@ -16,11 +16,13 @@
 package dev.nokee.core.exec;
 
 import com.google.common.collect.ImmutableMap;
+import lombok.val;
 import org.junit.jupiter.api.Test;
 
 import static dev.nokee.core.exec.CommandLineToolInvocationEnvironmentVariables.inherit;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 class CommandLineToolInvocationEnvironmentVariablesInheritFactoryTests {
 	@Test
@@ -32,5 +34,11 @@ class CommandLineToolInvocationEnvironmentVariablesInheritFactoryTests {
 	void returnsOnlySpecifiedInheritedEnvironmentVariables() {
 		assertThat(inherit("PATH"),
 			equalTo(new CommandLineToolInvocationEnvironmentVariables(ImmutableMap.of("PATH", System.getenv("PATH")))));
+	}
+
+	@Test
+	void doesNotThrowExceptionWhenInheritingNonExistingEnvironmentVariables() {
+		val envVars = assertDoesNotThrow(() -> inherit("NON_EXISTENT"));
+		assertThat("resulting environment variables is empty", envVars, equalTo(new CommandLineToolInvocationEnvironmentVariables(ImmutableMap.of())));
 	}
 }

--- a/subprojects/core-exec/src/test/groovy/dev/nokee/core/exec/CommandLineToolInvocationEnvironmentVariablesInheritFactoryTests.java
+++ b/subprojects/core-exec/src/test/groovy/dev/nokee/core/exec/CommandLineToolInvocationEnvironmentVariablesInheritFactoryTests.java
@@ -15,6 +15,7 @@
  */
 package dev.nokee.core.exec;
 
+import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 
 import static dev.nokee.core.exec.CommandLineToolInvocationEnvironmentVariables.inherit;
@@ -25,5 +26,11 @@ class CommandLineToolInvocationEnvironmentVariablesInheritFactoryTests {
 	@Test
 	void returnsInheritedEnvironmentVariables() {
 		assertThat(inherit(), equalTo(new CommandLineToolInvocationEnvironmentVariables(System.getenv())));
+	}
+
+	@Test
+	void returnsOnlySpecifiedInheritedEnvironmentVariables() {
+		assertThat(inherit("PATH"),
+			equalTo(new CommandLineToolInvocationEnvironmentVariables(ImmutableMap.of("PATH", System.getenv("PATH")))));
 	}
 }

--- a/subprojects/core-exec/src/test/groovy/dev/nokee/core/exec/FlatUnpackToStringUnpackStrategyTests.java
+++ b/subprojects/core-exec/src/test/groovy/dev/nokee/core/exec/FlatUnpackToStringUnpackStrategyTests.java
@@ -15,16 +15,18 @@
  */
 package dev.nokee.core.exec;
 
+import org.apache.commons.io.FilenameUtils;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Paths;
 
+import static org.apache.commons.io.FilenameUtils.separatorsToSystem;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 
 class FlatUnpackToStringUnpackStrategyTests {
 	@Test
 	void doesNotFlattenJavaPath() {
-		assertThat(UnpackStrategies.FLAT_UNPACK_TO_STRING.unpack(Paths.get("/some/path")), contains("/some/path"));
+		assertThat(UnpackStrategies.FLAT_UNPACK_TO_STRING.unpack(Paths.get("/some/path")), contains(separatorsToSystem("/some/path")));
 	}
 }

--- a/subprojects/core-exec/src/test/groovy/dev/nokee/core/exec/FlatUnpackToStringUnpackStrategyTests.java
+++ b/subprojects/core-exec/src/test/groovy/dev/nokee/core/exec/FlatUnpackToStringUnpackStrategyTests.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.core.exec;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Paths;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+class FlatUnpackToStringUnpackStrategyTests {
+	@Test
+	void doesNotFlattenJavaPath() {
+		assertThat(UnpackStrategies.FLAT_UNPACK_TO_STRING.unpack(Paths.get("/some/path")), contains("/some/path"));
+	}
+}

--- a/subprojects/core-exec/src/test/groovy/dev/nokee/core/exec/ProcessBuilderExecutionEngineFactoryTests.java
+++ b/subprojects/core-exec/src/test/groovy/dev/nokee/core/exec/ProcessBuilderExecutionEngineFactoryTests.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.core.exec;
+
+import org.junit.jupiter.api.Test;
+
+import static dev.nokee.core.exec.CommandLineToolExecutionEngine.processBuilder;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class ProcessBuilderExecutionEngineFactoryTests {
+	@Test
+	void returnsProcessBuilder() {
+		assertThat(processBuilder(), equalTo(new ProcessBuilderEngine()));
+	}
+}

--- a/subprojects/core-exec/src/test/groovy/dev/nokee/core/exec/ProcessBuilderExecutionEngineFactoryTests.java
+++ b/subprojects/core-exec/src/test/groovy/dev/nokee/core/exec/ProcessBuilderExecutionEngineFactoryTests.java
@@ -20,8 +20,14 @@ import org.junit.jupiter.api.Test;
 import static dev.nokee.core.exec.CommandLineToolExecutionEngine.processBuilder;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.sameInstance;
 
 class ProcessBuilderExecutionEngineFactoryTests {
+	@Test
+	void alwaysReturnsSameProcessBuilderInstance() {
+		assertThat(processBuilder(), sameInstance(processBuilder()));
+	}
+
 	@Test
 	void returnsProcessBuilder() {
 		assertThat(processBuilder(), equalTo(new ProcessBuilderEngine()));


### PR DESCRIPTION
Java Path can now be used as command line arguments and environment variable values. Invocation building delays any reference to inherited environment variables to avoid triggering all variables as build inputs in later Gradle. It's now possible to cherry-pick which environment variable to inherit from the current process.