### PR TITLE
Enable build cache on Xcode target build task

### DIFF
--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/PBXProjectTestUtils.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/PBXProjectTestUtils.java
@@ -63,6 +63,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 
+import static com.google.common.base.Predicates.instanceOf;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 
 public final class PBXProjectTestUtils {
@@ -358,5 +359,29 @@ public final class PBXProjectTestUtils {
 
 	public static BiFunction<PBXProject, Boolean, Boolean> toggle() {
 		return (self, value) -> !value;
+	}
+
+	public static BiFunction<PBXProject, PBXTarget, PBXTarget> copyFilesBuildPhases(BiFunction<? super PBXProject, ? super PBXCopyFilesBuildPhase, ? extends PBXCopyFilesBuildPhase> action) {
+		return buildPhases(matching(instanceOf(PBXCopyFilesBuildPhase.class), asCopyFiles(action)));
+	}
+
+	public static BiFunction<PBXProject, PBXTarget, PBXTarget> frameworksBuildPhases(BiFunction<? super PBXProject, ? super PBXFrameworksBuildPhase, ? extends PBXFrameworksBuildPhase> action) {
+		return buildPhases(matching(instanceOf(PBXFrameworksBuildPhase.class), asFrameworks(action)));
+	}
+
+	public static BiFunction<PBXProject, PBXTarget, PBXTarget> headersBuildPhases(BiFunction<? super PBXProject, ? super PBXHeadersBuildPhase, ? extends PBXHeadersBuildPhase> action) {
+		return buildPhases(matching(instanceOf(PBXHeadersBuildPhase.class), asHeaders(action)));
+	}
+
+	public static BiFunction<PBXProject, PBXTarget, PBXTarget> resourcesBuildPhases(BiFunction<? super PBXProject, ? super PBXResourcesBuildPhase, ? extends PBXResourcesBuildPhase> action) {
+		return buildPhases(matching(instanceOf(PBXResourcesBuildPhase.class), asResources(action)));
+	}
+
+	public static BiFunction<PBXProject, PBXTarget, PBXTarget> sourcesBuildPhases(BiFunction<? super PBXProject, ? super PBXSourcesBuildPhase, ? extends PBXSourcesBuildPhase> action) {
+		return buildPhases(matching(instanceOf(PBXSourcesBuildPhase.class), asSources(action)));
+	}
+
+	public static BiFunction<PBXProject, PBXTarget, PBXTarget> shellScriptBuildPhases(BiFunction<? super PBXProject, ? super PBXShellScriptBuildPhase, ? extends PBXShellScriptBuildPhase> action) {
+		return buildPhases(matching(instanceOf(PBXShellScriptBuildPhase.class), asShellScript(action)));
 	}
 }

--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/buildcache/BuildCacheFunctionalTests.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/buildcache/BuildCacheFunctionalTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.buildcache;
+
+import dev.gradleplugins.runnerkit.GradleRunner;
+import dev.gradleplugins.runnerkit.TaskOutcome;
+import dev.nokee.UpToDateCheck;
+import dev.nokee.internal.testing.junit.jupiter.ContextualGradleRunnerParameterResolver;
+import lombok.val;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static dev.gradleplugins.buildscript.blocks.PluginsBlock.plugins;
+import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.add;
+import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.buildFileToProduct;
+import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.copyFilesBuildPhases;
+import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.dependencies;
+import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.files;
+import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.mutateProject;
+import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.targetDependencyTo;
+import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.targetNamed;
+import static dev.nokee.internal.testing.GradleRunnerMatchers.outcome;
+import static dev.nokee.internal.testing.GradleRunnerMatchers.skipped;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
+
+@ExtendWith({TestDirectoryExtension.class, ContextualGradleRunnerParameterResolver.class})
+class BuildCacheFunctionalTests {
+	GradleRunner executer;
+	@TestDirectory Path testDirectory;
+
+	@BeforeEach
+	void given(GradleRunner runner) throws IOException {
+		new UpToDateCheck().writeToProject(testDirectory);
+		mutateProject(targetNamed("App", copyFilesBuildPhases(files(add(buildFileToProduct("Foo.framework")))))).accept(testDirectory.resolve("UpToDateCheck.xcodeproj"));
+		mutateProject(targetNamed("App", copyFilesBuildPhases(files(add(buildFileToProduct("Bar.framework")))))).accept(testDirectory.resolve("UpToDateCheck.xcodeproj"));
+		mutateProject(targetNamed("App", dependencies(add(targetDependencyTo("Foo"))))).accept(testDirectory.resolve("UpToDateCheck.xcodeproj"));
+		mutateProject(targetNamed("App", dependencies(add(targetDependencyTo("Bar"))))).accept(testDirectory.resolve("UpToDateCheck.xcodeproj"));
+
+		plugins(it -> it.id("dev.nokee.xcode-build-adapter")).writeTo(testDirectory.resolve("settings.gradle"));
+		executer = runner.withTasks("AppDebug").withArgument("-Dsdk=macosx").withBuildCacheEnabled();
+
+		ensureUpToDate(executer);
+	}
+
+	@Test
+	void restoreTargetOutputFromCache(GradleRunner runner) {
+		runner.withTasks("clean").build();
+
+		val result = executer.build();
+
+		assertThat(result.task(":UpToDateCheck:FooDebug"), outcome(equalTo(TaskOutcome.FROM_CACHE)));
+		assertThat(result.task(":UpToDateCheck:BarDebug"), outcome(equalTo(TaskOutcome.FROM_CACHE)));
+		assertThat(result.task(":UpToDateCheck:AppDebug"), outcome(equalTo(TaskOutcome.FROM_CACHE)));
+	}
+
+	private static void ensureUpToDate(GradleRunner executer) {
+		executer.build();
+		assertThat(executer.build().getTasks(), everyItem(skipped()));
+	}
+}

--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/buildcache/BuildCacheFunctionalTests.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/buildcache/BuildCacheFunctionalTests.java
@@ -24,6 +24,8 @@ import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
 import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
@@ -44,6 +46,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 
+@EnabledOnOs(OS.MAC)
 @ExtendWith({TestDirectoryExtension.class, ContextualGradleRunnerParameterResolver.class})
 class BuildCacheFunctionalTests {
 	GradleRunner executer;

--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/uptodate/UpToDateCheckDetectsChangeToPBXCopyFilesBuildPhaseFunctionalTests.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/uptodate/UpToDateCheckDetectsChangeToPBXCopyFilesBuildPhaseFunctionalTests.java
@@ -16,7 +16,6 @@
 package dev.nokee.buildadapter.xcode.uptodate;
 
 import com.google.common.collect.ImmutableMap;
-import dev.nokee.buildadapter.xcode.PBXProjectTestUtils;
 import dev.nokee.xcode.objects.PBXProject;
 import dev.nokee.xcode.objects.buildphase.PBXBuildFile;
 import dev.nokee.xcode.objects.files.PBXFileReference;
@@ -37,10 +36,11 @@ import java.util.function.UnaryOperator;
 import static com.google.common.collect.ImmutableList.of;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.add;
+import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.childNameOrPath;
 import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.clear;
+import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.copyFilesBuildPhases;
 import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.dependencies;
 import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.files;
-import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.childNameOrPath;
 import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.first;
 import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.targetDependencyTo;
 import static dev.nokee.internal.testing.GradleRunnerMatchers.outOfDate;

--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/uptodate/UpToDateCheckDetectsChangeToPBXFrameworksBuildPhaseFunctionalTests.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/uptodate/UpToDateCheckDetectsChangeToPBXFrameworksBuildPhaseFunctionalTests.java
@@ -29,6 +29,7 @@ import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.buildFileToProduc
 import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.clear;
 import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.files;
 import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.first;
+import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.frameworksBuildPhases;
 import static dev.nokee.internal.testing.GradleRunnerMatchers.outOfDate;
 import static java.nio.file.Files.delete;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/uptodate/UpToDateCheckDetectsChangeToPBXHeadersBuildPhaseFunctionalTests.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/uptodate/UpToDateCheckDetectsChangeToPBXHeadersBuildPhaseFunctionalTests.java
@@ -37,6 +37,7 @@ import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.clear;
 import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.dependencies;
 import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.files;
 import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.first;
+import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.headersBuildPhases;
 import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.targetDependencyTo;
 import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.targetNamed;
 import static dev.nokee.internal.testing.GradleRunnerMatchers.outOfDate;

--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/uptodate/UpToDateCheckDetectsChangeToPBXResourcesBuildPhaseFunctionalTests.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/uptodate/UpToDateCheckDetectsChangeToPBXResourcesBuildPhaseFunctionalTests.java
@@ -28,6 +28,7 @@ import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.children;
 import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.clear;
 import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.files;
 import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.first;
+import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.resourcesBuildPhases;
 import static dev.nokee.internal.testing.GradleRunnerMatchers.outOfDate;
 import static dev.nokee.internal.testing.GradleRunnerMatchers.upToDate;
 import static dev.nokee.xcode.objects.files.PBXFileReference.ofGroup;

--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/uptodate/UpToDateCheckDetectsChangeToPBXShellScriptBuildPhaseFunctionalTests.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/uptodate/UpToDateCheckDetectsChangeToPBXShellScriptBuildPhaseFunctionalTests.java
@@ -36,6 +36,7 @@ import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.removeFirst;
 import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.scriptPhaseName;
 import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.shellPath;
 import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.shellScript;
+import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.shellScriptBuildPhases;
 import static dev.nokee.internal.testing.GradleRunnerMatchers.outOfDate;
 import static dev.nokee.internal.testing.GradleRunnerMatchers.upToDate;
 import static dev.nokee.xcode.objects.files.PBXFileReference.ofGroup;

--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/uptodate/UpToDateCheckDetectsChangeToPBXSourcesBuildPhaseFunctionalTests.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/uptodate/UpToDateCheckDetectsChangeToPBXSourcesBuildPhaseFunctionalTests.java
@@ -33,6 +33,7 @@ import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.files;
 import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.first;
 import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.referenceNameOrPath;
 import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.removeIf;
+import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.sourcesBuildPhases;
 import static dev.nokee.internal.testing.GradleRunnerMatchers.outOfDate;
 import static dev.nokee.internal.testing.GradleRunnerMatchers.upToDate;
 import static dev.nokee.xcode.objects.files.PBXFileReference.ofGroup;

--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/uptodate/UpToDateCheckSpec.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/uptodate/UpToDateCheckSpec.java
@@ -26,11 +26,6 @@ import dev.nokee.xcode.objects.PBXProject;
 import dev.nokee.xcode.objects.buildphase.PBXBuildFile;
 import dev.nokee.xcode.objects.buildphase.PBXBuildPhase;
 import dev.nokee.xcode.objects.buildphase.PBXCopyFilesBuildPhase;
-import dev.nokee.xcode.objects.buildphase.PBXFrameworksBuildPhase;
-import dev.nokee.xcode.objects.buildphase.PBXHeadersBuildPhase;
-import dev.nokee.xcode.objects.buildphase.PBXResourcesBuildPhase;
-import dev.nokee.xcode.objects.buildphase.PBXShellScriptBuildPhase;
-import dev.nokee.xcode.objects.buildphase.PBXSourcesBuildPhase;
 import dev.nokee.xcode.objects.configuration.XCBuildConfiguration;
 import dev.nokee.xcode.objects.configuration.XCConfigurationList;
 import dev.nokee.xcode.objects.files.PBXFileReference;
@@ -56,19 +51,11 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
-import static com.google.common.base.Predicates.instanceOf;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static dev.gradleplugins.buildscript.blocks.PluginsBlock.plugins;
 import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.add;
-import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.asCopyFiles;
-import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.asFrameworks;
 import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.asGroup;
-import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.asHeaders;
-import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.asResources;
-import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.asShellScript;
-import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.asSources;
 import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.buildConfigurationList;
-import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.buildPhases;
 import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.childNameOrPath;
 import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.children;
 import static dev.nokee.buildadapter.xcode.PBXProjectTestUtils.mainGroup;
@@ -136,30 +123,6 @@ public abstract class UpToDateCheckSpec {
 			val newBuildConfigurations = PBXProjectTestUtils.<PBXProject, XCBuildConfiguration>matching((XCBuildConfiguration it) -> it.getName().equals("Release"), action).apply(self, buildConfigurations.getBuildConfigurations());
 			return buildConfigurations.toBuilder().buildConfigurations(newBuildConfigurations).build();
 		};
-	}
-
-	protected static BiFunction<PBXProject, PBXTarget, PBXTarget> copyFilesBuildPhases(BiFunction<? super PBXProject, ? super PBXCopyFilesBuildPhase, ? extends PBXCopyFilesBuildPhase> action) {
-		return buildPhases(matching(instanceOf(PBXCopyFilesBuildPhase.class), asCopyFiles(action)));
-	}
-
-	protected static BiFunction<PBXProject, PBXTarget, PBXTarget> frameworksBuildPhases(BiFunction<? super PBXProject, ? super PBXFrameworksBuildPhase, ? extends PBXFrameworksBuildPhase> action) {
-		return buildPhases(matching(instanceOf(PBXFrameworksBuildPhase.class), asFrameworks(action)));
-	}
-
-	protected static BiFunction<PBXProject, PBXTarget, PBXTarget> headersBuildPhases(BiFunction<? super PBXProject, ? super PBXHeadersBuildPhase, ? extends PBXHeadersBuildPhase> action) {
-		return buildPhases(matching(instanceOf(PBXHeadersBuildPhase.class), asHeaders(action)));
-	}
-
-	protected static BiFunction<PBXProject, PBXTarget, PBXTarget> resourcesBuildPhases(BiFunction<? super PBXProject, ? super PBXResourcesBuildPhase, ? extends PBXResourcesBuildPhase> action) {
-		return buildPhases(matching(instanceOf(PBXResourcesBuildPhase.class), asResources(action)));
-	}
-
-	protected static BiFunction<PBXProject, PBXTarget, PBXTarget> sourcesBuildPhases(BiFunction<? super PBXProject, ? super PBXSourcesBuildPhase, ? extends PBXSourcesBuildPhase> action) {
-		return buildPhases(matching(instanceOf(PBXSourcesBuildPhase.class), asSources(action)));
-	}
-
-	protected static BiFunction<PBXProject, PBXTarget, PBXTarget> shellScriptBuildPhases(BiFunction<? super PBXProject, ? super PBXShellScriptBuildPhase, ? extends PBXShellScriptBuildPhase> action) {
-		return buildPhases(matching(instanceOf(PBXShellScriptBuildPhase.class), asShellScript(action)));
 	}
 
 	protected static <T> BiFunction<PBXProject, List<T>, List<T>> shuffleOrdering() {

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeTargetExecTask.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeTargetExecTask.java
@@ -46,6 +46,7 @@ import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
@@ -79,6 +80,7 @@ import static dev.nokee.utils.ProviderUtils.disallowChanges;
 import static dev.nokee.utils.ProviderUtils.finalizeValueOnRead;
 import static dev.nokee.utils.ProviderUtils.ifPresent;
 
+@CacheableTask
 public abstract class XcodeTargetExecTask extends DefaultTask implements XcodebuildExecTask, HasConfigurableXcodeInstallation, HasXcodeTargetReference {
 	private final WorkerExecutor workerExecutor;
 	private final Provider<XCTargetReference> targetReference;

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/specs/AtInputFilesEncoder.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/specs/AtInputFilesEncoder.java
@@ -18,6 +18,8 @@ package dev.nokee.buildadapter.xcode.internal.plugins.specs;
 import dev.nokee.xcode.project.ValueEncoder;
 import lombok.EqualsAndHashCode;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 
 @EqualsAndHashCode
 public final class AtInputFilesEncoder<IN> implements ValueEncoder<XCBuildSpec, IN> {
@@ -36,6 +38,7 @@ public final class AtInputFilesEncoder<IN> implements ValueEncoder<XCBuildSpec, 
 				final XCBuildPlan result = references.resolve(context);
 				return new XCBuildPlan() {
 					@InputFiles
+					@PathSensitive(PathSensitivity.ABSOLUTE)
 					public Object getValue() {
 						return result;
 					}


### PR DESCRIPTION
This PR strictly enables build caching. The caching is inefficient as it will cache `<derivedDataPath>/Build/Products`, accumulating all the task's dependency outputs. We need to isolate the declared outputs to solve this inefficiency, which is easier said than done. Gradle only accepts files/directories and not "location", making it virtually impossible to declare the outputs to Gradle correctly. Instead, we will declare a single output directory (the isolated derived data path) and sync only the declared outputs before the task finishes. This work will be done in another PR. We still have a good performance gain over Xcode (~2min less over a 7min build) on a fully cached build. On API changes, we can expect a full rebuild starting from where Gradle misses a cache entry. Note that if a change doesn't result in a byte change to the outputs, Gradle will continue to restore from the cache as it doesn't rely on modification time.