### PR TITLE
Improve resilience of Xcode build adapter around empty PBXShellScriptBuildScript#inputPaths

### DIFF
--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/uptodate/UpToDateCheckDetectsChangeToPBXShellScriptBuildPhaseFunctionalTests.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/uptodate/UpToDateCheckDetectsChangeToPBXShellScriptBuildPhaseFunctionalTests.java
@@ -102,6 +102,13 @@ class UpToDateCheckDetectsChangeToPBXShellScriptBuildPhaseFunctionalTests extend
 			assertThat(targetUnderTestExecution(), upToDate());
 		}
 
+		@Test // https://github.com/nokeedev/gradle-native/issues/817
+		void ignoresEmptyInputPaths() {
+			xcodeproj(targetUnderTest(shellScriptBuildPhases(inputPaths(add("")))));
+
+			assertThat(targetUnderTestExecution(), upToDate());
+		}
+
 		@Test
 		void outOfDateWhenInputPathRemoved() {
 			xcodeproj(targetUnderTest(shellScriptBuildPhases(inputPaths(removeFirst()))));

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/specs/IgnoreEmptyStringEncoder.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/specs/IgnoreEmptyStringEncoder.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal.plugins.specs;
+
+import dev.nokee.util.internal.NotPredicate;
+import dev.nokee.xcode.project.ValueEncoder;
+import lombok.EqualsAndHashCode;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@EqualsAndHashCode
+public final class IgnoreEmptyStringEncoder<OUT> implements ValueEncoder<OUT, List<String>> {
+	private final ValueEncoder<OUT, List<String>> delegate;
+
+	public IgnoreEmptyStringEncoder(ValueEncoder<OUT, List<String>> delegate) {
+		this.delegate = delegate;
+	}
+
+	@Override
+	public OUT encode(List<String> value, Context context) {
+		return delegate.encode(value.stream().filter(new NotPredicate<>(String::isEmpty)).collect(Collectors.toList()), context);
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/specs/NormalizePBXBuildFileFileReferenceAsPBXReferenceEncoder.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/specs/NormalizePBXBuildFileFileReferenceAsPBXReferenceEncoder.java
@@ -20,15 +20,15 @@ import dev.nokee.xcode.project.ValueEncoder;
 import lombok.EqualsAndHashCode;
 
 @EqualsAndHashCode
-public final class NormalizePBXBuildFileFileReferenceAsPBXReferenceEncoder implements ValueEncoder<PBXReference, Object> {
-	private final ValueEncoder<PBXReference, Object> delegate;
+public final class NormalizePBXBuildFileFileReferenceAsPBXReferenceEncoder<T> implements ValueEncoder<PBXReference, T> {
+	private final ValueEncoder<PBXReference, T> delegate;
 
-	public NormalizePBXBuildFileFileReferenceAsPBXReferenceEncoder(ValueEncoder<PBXReference, Object> delegate) {
+	public NormalizePBXBuildFileFileReferenceAsPBXReferenceEncoder(ValueEncoder<PBXReference, T> delegate) {
 		this.delegate = delegate;
 	}
 
 	@Override
-	public PBXReference encode(Object value, Context context) {
+	public PBXReference encode(T value, Context context) {
 		if (value instanceof PBXReference) {
 			return (PBXReference) value;
 		} else {

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/specs/NormalizeStringAsPBXReferenceEncoder.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/specs/NormalizeStringAsPBXReferenceEncoder.java
@@ -21,15 +21,15 @@ import dev.nokee.xcode.project.ValueEncoder;
 import lombok.EqualsAndHashCode;
 
 @EqualsAndHashCode
-public final class NormalizeStringAsPBXReferenceEncoder implements ValueEncoder<PBXReference, Object> {
-	private final ValueEncoder<PBXReference, Object> delegate;
+public final class NormalizeStringAsPBXReferenceEncoder<T> implements ValueEncoder<PBXReference, T> {
+	private final ValueEncoder<PBXReference, T> delegate;
 
-	public NormalizeStringAsPBXReferenceEncoder(ValueEncoder<PBXReference, Object> delegate) {
+	public NormalizeStringAsPBXReferenceEncoder(ValueEncoder<PBXReference, T> delegate) {
 		this.delegate = delegate;
 	}
 
 	@Override
-	public PBXReference encode(Object value, Context context) {
+	public PBXReference encode(T value, Context context) {
 		if (value instanceof String) {
 			return PBXFileReference.ofAbsolutePath((String) value);
 		} else {

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/specs/XCBuildSpecCodingKeyCoders.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/specs/XCBuildSpecCodingKeyCoders.java
@@ -157,7 +157,7 @@ public final class XCBuildSpecCodingKeyCoders implements CodingKeyCoders {
 		put(CodeablePBXShellScriptBuildPhase.CodingKeys.files, null); // shell script uses input*/output* to check up-to-date
 		put(CodeablePBXShellScriptBuildPhase.CodingKeys.shellPath, forKey("shellPath", atInput(ofString())));
 		put(CodeablePBXShellScriptBuildPhase.CodingKeys.shellScript, forKey("shellScript", atInput(ofString())));
-		put(CodeablePBXShellScriptBuildPhase.CodingKeys.inputPaths, forKey("inputPaths", atInputFiles(set(ofLocation()))));
+		put(CodeablePBXShellScriptBuildPhase.CodingKeys.inputPaths, forKey("inputPaths", atInputFiles(setOfLocation())));
 		put(CodeablePBXShellScriptBuildPhase.CodingKeys.inputFileListPaths, null);
 		put(CodeablePBXShellScriptBuildPhase.CodingKeys.outputPaths, null);
 		put(CodeablePBXShellScriptBuildPhase.CodingKeys.outputFileListPaths, null);
@@ -246,7 +246,11 @@ public final class XCBuildSpecCodingKeyCoders implements CodingKeyCoders {
 	}
 
 	private static ValueEncoder<XCBuildSpec, Object> ofLocation() {
-		return new FileSystemLocationEncoder<>(new NormalizeStringAsPBXReferenceEncoder<>(new NormalizePBXBuildFileFileReferenceAsPBXReferenceEncoder<>(new ThrowingValueEncoder<>())));
+		return new FileSystemLocationEncoder<>(new NormalizePBXBuildFileFileReferenceAsPBXReferenceEncoder<>(new ThrowingValueEncoder<>()));
+	}
+
+	private static ValueEncoder<XCBuildSpec, List<String>> setOfLocation() {
+		return new IgnoreEmptyStringEncoder<>(AtNestedCollectionEncoder.atNestedSet(new ListEncoder<>(new FileSystemLocationEncoder<>(new NormalizeStringAsPBXReferenceEncoder<>(new ThrowingValueEncoder<>())))));
 	}
 
 	private static <T> ValueEncoder<XCBuildSpec, List<T>> list(ValueEncoder<XCBuildSpec, T> elementEncoder) {
@@ -283,10 +287,6 @@ public final class XCBuildSpecCodingKeyCoders implements CodingKeyCoders {
 
 	private static <T extends XCBuildConfiguration & Encodeable> ValueEncoder<XCBuildSpec, T> ofBuildConfiguration() {
 		return new AtNestedMapEncoder<>(new NoOpEncoder<>());
-	}
-
-	private static <T> ValueEncoder<XCBuildSpec, List<T>> set(ValueEncoder<XCBuildSpec, T> elementEncoder) {
-		return AtNestedCollectionEncoder.atNestedSet(new ListEncoder<>(elementEncoder));
 	}
 
 	private static <T extends XCBuildConfiguration & Encodeable> ValueEncoder<XCBuildSpec, XCConfigurationList> selection(ValueEncoder<XCBuildSpec, T> buildConfigurationEncoder) {

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/specs/XCBuildSpecCodingKeyCoders.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/specs/XCBuildSpecCodingKeyCoders.java
@@ -246,7 +246,7 @@ public final class XCBuildSpecCodingKeyCoders implements CodingKeyCoders {
 	}
 
 	private static ValueEncoder<XCBuildSpec, Object> ofLocation() {
-		return new FileSystemLocationEncoder<>(new NormalizeStringAsPBXReferenceEncoder(new NormalizePBXBuildFileFileReferenceAsPBXReferenceEncoder(new ThrowingValueEncoder<>())));
+		return new FileSystemLocationEncoder<>(new NormalizeStringAsPBXReferenceEncoder<>(new NormalizePBXBuildFileFileReferenceAsPBXReferenceEncoder<>(new ThrowingValueEncoder<>())));
 	}
 
 	private static <T> ValueEncoder<XCBuildSpec, List<T>> list(ValueEncoder<XCBuildSpec, T> elementEncoder) {

--- a/subprojects/build-adapter-xcode/src/test/java/dev/nokee/buildadapter/xcode/internal/plugins/specs/IgnoreEmptyStringEncoderTests.java
+++ b/subprojects/build-adapter-xcode/src/test/java/dev/nokee/buildadapter/xcode/internal/plugins/specs/IgnoreEmptyStringEncoderTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal.plugins.specs;
+
+import com.google.common.collect.ImmutableList;
+import dev.nokee.internal.testing.testdoubles.TestDouble;
+import dev.nokee.xcode.project.ValueEncoder;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static dev.nokee.internal.testing.invocations.InvocationMatchers.calledOnceWith;
+import static dev.nokee.internal.testing.reflect.MethodInformation.method;
+import static dev.nokee.internal.testing.testdoubles.Answers.doReturn;
+import static dev.nokee.internal.testing.testdoubles.MockitoBuilder.any;
+import static dev.nokee.internal.testing.testdoubles.MockitoBuilder.newMock;
+import static dev.nokee.internal.testing.testdoubles.TestDouble.callTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.sameInstance;
+
+class IgnoreEmptyStringEncoderTests {
+	ValueEncoder.Context context = newMock(ValueEncoder.Context.class).alwaysThrows().instance();
+	TestDouble<ValueEncoder<Object, List<String>>> delegate = newMock(ValueEncoder.class)
+		.when(any(callTo(method(ValueEncoder<Object, List<String>>::encode))).then(doReturn((it, args) -> args.getArgument(0))));
+
+	List<String> objectToEncode = ImmutableList.of("first", "", "third");
+	IgnoreEmptyStringEncoder<Object> subject = new IgnoreEmptyStringEncoder<>(delegate.instance());
+	Object result = subject.encode(objectToEncode, context);
+
+	@Test
+	void callsDelegateWithoutEmptyString() {
+		assertThat(delegate.to(method(ValueEncoder<Object, List<String>>::encode)), //
+			calledOnceWith(contains("first", "third"), sameInstance(context)));
+	}
+}

--- a/subprojects/build-adapter-xcode/src/test/java/dev/nokee/buildadapter/xcode/internal/plugins/specs/NormalizePBXBuildFileFileReferenceAsPBXReferenceEncoderTests.java
+++ b/subprojects/build-adapter-xcode/src/test/java/dev/nokee/buildadapter/xcode/internal/plugins/specs/NormalizePBXBuildFileFileReferenceAsPBXReferenceEncoderTests.java
@@ -39,7 +39,7 @@ class NormalizePBXBuildFileFileReferenceAsPBXReferenceEncoderTests {
 	ValueEncoder.Context context = newAlwaysThrowingMock(ValueEncoder.Context.class);
 	TestDouble<ValueEncoder<PBXReference, Object>> delegate = newMock(new TypeToken<ValueEncoder<PBXReference, Object>>() {})
 		.when(any(callTo(method(ValueEncoder<PBXReference, Object>::encode))).then(doReturn(ofAbsolutePath("/dummy/path.txt"))));
-	NormalizePBXBuildFileFileReferenceAsPBXReferenceEncoder subject = new NormalizePBXBuildFileFileReferenceAsPBXReferenceEncoder(delegate.instance());
+	NormalizePBXBuildFileFileReferenceAsPBXReferenceEncoder<Object> subject = new NormalizePBXBuildFileFileReferenceAsPBXReferenceEncoder<>(delegate.instance());
 
 	@Nested
 	class WhenEncodingPBXReferenceValues {

--- a/subprojects/build-adapter-xcode/src/test/java/dev/nokee/buildadapter/xcode/internal/plugins/specs/NormalizeStringAsPBXReferenceEncoderTests.java
+++ b/subprojects/build-adapter-xcode/src/test/java/dev/nokee/buildadapter/xcode/internal/plugins/specs/NormalizeStringAsPBXReferenceEncoderTests.java
@@ -38,7 +38,7 @@ class NormalizeStringAsPBXReferenceEncoderTests {
 	ValueEncoder.Context context = newAlwaysThrowingMock(ValueEncoder.Context.class);
 	TestDouble<ValueEncoder<PBXReference, Object>> delegate = newMock(new TypeToken<ValueEncoder<PBXReference, Object>>() {})
 		.when(any(callTo(method(ValueEncoder<PBXReference, Object>::encode))).then(doReturn(ofAbsolutePath("/dummy/path.txt"))));
-	NormalizeStringAsPBXReferenceEncoder subject = new NormalizeStringAsPBXReferenceEncoder(delegate.instance());
+	NormalizeStringAsPBXReferenceEncoder<Object> subject = new NormalizeStringAsPBXReferenceEncoder<>(delegate.instance());
 
 	@Nested
 	class WhenEncodingValidValues {

--- a/subprojects/build-adapter-xcode/src/test/java/dev/nokee/buildadapter/xcode/internal/plugins/specs/XCBuildSpecCodingKeyCodersTests.java
+++ b/subprojects/build-adapter-xcode/src/test/java/dev/nokee/buildadapter/xcode/internal/plugins/specs/XCBuildSpecCodingKeyCodersTests.java
@@ -103,7 +103,7 @@ class XCBuildSpecCodingKeyCodersTests {
 			add(arguments(CodeablePBXAggregateTarget.CodingKeys.buildConfigurationList, keyOf("buildConfigurationList", object(XCConfigurationList.class))));
 			add(arguments(CodeablePBXAggregateTarget.CodingKeys.buildPhases, keyOf("buildPhases", listOf(object(PBXBuildPhase.class)))));
 
-			add(arguments(CodeablePBXBuildFile.CodingKeys.fileRef, keyOf("fileRef", inputLocation(resolvablePaths()))));
+			add(arguments(CodeablePBXBuildFile.CodingKeys.fileRef, keyOf("fileRef", inputLocation(resolvableFileReference()))));
 			add(arguments(CodeablePBXBuildFile.CodingKeys.productRef, ignore()));
 			add(arguments(CodeablePBXBuildFile.CodingKeys.settings, keyOf("settings", inputOf(asIs()))));
 
@@ -171,7 +171,7 @@ class XCBuildSpecCodingKeyCodersTests {
 			add(arguments(CodeablePBXShellScriptBuildPhase.CodingKeys.name, ignore()));
 			add(arguments(CodeablePBXShellScriptBuildPhase.CodingKeys.shellPath, keyOf("shellPath", inputOf(string()))));
 			add(arguments(CodeablePBXShellScriptBuildPhase.CodingKeys.shellScript, keyOf("shellScript", inputOf(string()))));
-			add(arguments(CodeablePBXShellScriptBuildPhase.CodingKeys.inputPaths, keyOf("inputPaths", inputLocation(setOf(resolvablePaths())))));
+			add(arguments(CodeablePBXShellScriptBuildPhase.CodingKeys.inputPaths, keyOf("inputPaths", inputLocation(setOfResolvablePaths()))));
 			add(arguments(CodeablePBXShellScriptBuildPhase.CodingKeys.inputFileListPaths, ignore())); // TODO: implement support
 			add(arguments(CodeablePBXShellScriptBuildPhase.CodingKeys.outputPaths, ignore()));
 			add(arguments(CodeablePBXShellScriptBuildPhase.CodingKeys.outputFileListPaths, ignore())); // TODO: implement support
@@ -250,8 +250,8 @@ class XCBuildSpecCodingKeyCodersTests {
 		return emptyOptional();
 	}
 
-	private static ValueEncoder<XCBuildSpec, ?> resolvablePaths() {
-		return new FileSystemLocationEncoder<>(new NormalizeStringAsPBXReferenceEncoder<>(new NormalizePBXBuildFileFileReferenceAsPBXReferenceEncoder<>(new ThrowingValueEncoder<>())));
+	private static ValueEncoder<XCBuildSpec, ?> resolvableFileReference() {
+		return new FileSystemLocationEncoder<>(new NormalizePBXBuildFileFileReferenceAsPBXReferenceEncoder<>(new ThrowingValueEncoder<>()));
 	}
 
 	private static ValueEncoder<XCBuildSpec, ?> inputLocation(ValueEncoder<XCBuildSpec, ?> encoder) {
@@ -272,8 +272,8 @@ class XCBuildSpecCodingKeyCodersTests {
 		return new AtNestedCollectionEncoder<>(ImmutableList.toImmutableList(), new ListEncoder<>(elementEncoder));
 	}
 
-	public static <E> ValueEncoder<XCBuildSpec, List<E>> setOf(ValueEncoder<XCBuildSpec, E> elementEncoder) {
-		return new AtNestedCollectionEncoder<>(ImmutableSet.toImmutableSet(), new ListEncoder<>(elementEncoder));
+	public static ValueEncoder<XCBuildSpec, List<String>> setOfResolvablePaths() {
+		return new IgnoreEmptyStringEncoder<>(new AtNestedCollectionEncoder<>(ImmutableSet.toImmutableSet(), new ListEncoder<>(new FileSystemLocationEncoder<>(new NormalizeStringAsPBXReferenceEncoder<>(new ThrowingValueEncoder<>())))));
 	}
 
 	public static <IN> ValueEncoder<XCBuildSpec, IN> inputOf(ValueEncoder<?, IN> encoder) {

--- a/subprojects/build-adapter-xcode/src/test/java/dev/nokee/buildadapter/xcode/internal/plugins/specs/XCBuildSpecCodingKeyCodersTests.java
+++ b/subprojects/build-adapter-xcode/src/test/java/dev/nokee/buildadapter/xcode/internal/plugins/specs/XCBuildSpecCodingKeyCodersTests.java
@@ -251,7 +251,7 @@ class XCBuildSpecCodingKeyCodersTests {
 	}
 
 	private static ValueEncoder<XCBuildSpec, ?> resolvablePaths() {
-		return new FileSystemLocationEncoder<>(new NormalizeStringAsPBXReferenceEncoder(new NormalizePBXBuildFileFileReferenceAsPBXReferenceEncoder(new ThrowingValueEncoder<>())));
+		return new FileSystemLocationEncoder<>(new NormalizeStringAsPBXReferenceEncoder<>(new NormalizePBXBuildFileFileReferenceAsPBXReferenceEncoder<>(new ThrowingValueEncoder<>())));
 	}
 
 	private static ValueEncoder<XCBuildSpec, ?> inputLocation(ValueEncoder<XCBuildSpec, ?> encoder) {


### PR DESCRIPTION
This use case is present in the Wikipedia iOS application.