### PR TITLE
Generate VFS overlays for headers in child projects

### DIFF
--- a/gradle/libraries/gradle-build-script/src/main/java/dev/gradleplugins/buildscript/syntax/StringLiteralValue.java
+++ b/gradle/libraries/gradle-build-script/src/main/java/dev/gradleplugins/buildscript/syntax/StringLiteralValue.java
@@ -22,7 +22,7 @@ final class StringLiteralValue implements Expression {
 	private final CharSequence value;
 
 	public StringLiteralValue(CharSequence value) {
-		this.value = value;
+		this.value = value.toString().replace("\\", "\\\\");
 	}
 
 	CharSequence get() {

--- a/subprojects/build-adapter-xcode/build-adapter-xcode.gradle
+++ b/subprojects/build-adapter-xcode/build-adapter-xcode.gradle
@@ -54,6 +54,7 @@ test {
 		implementation templates(project(':xcodeIdeKit'))
 		implementation testFixtures(project(':coreExec'))
 		implementation "com.google.jimfs:jimfs:${jimfsVersion}"
+		implementation templates(project)
 		implementation testFixtures(project)
 	}
 }
@@ -63,6 +64,7 @@ integrationTest {
 		implementation 'dev.nokee:templates'
 		implementation templates(project(':xcodeIdeKit'))
 		implementation testFixtures(project)
+		implementation templates(project)
 	}
 	testTasks.configureEach {
 		maxParallelForks = Runtime.runtime.availableProcessors()

--- a/subprojects/build-adapter-xcode/build-adapter-xcode.gradle
+++ b/subprojects/build-adapter-xcode/build-adapter-xcode.gradle
@@ -8,6 +8,7 @@ plugins {
 	id 'dev.gradleplugins.documentation.api-reference-module'
 	id 'nokeedocs.sample-templates'
 	id 'antlr'
+	id 'java-test-fixtures'
 }
 
 dependencies {
@@ -27,6 +28,8 @@ dependencies {
 	implementation project(':xcodeIdeKit')
 	implementation "org.antlr:antlr4:${antlrVersion}"
 	antlr "org.antlr:antlr4:${antlrVersion}"
+
+	testFixturesApi project(":internalTesting")
 }
 tasks.named('generateGrammarSource', AntlrTask) { task ->
 	task.arguments += ['-visitor']
@@ -51,6 +54,7 @@ test {
 		implementation templates(project(':xcodeIdeKit'))
 		implementation testFixtures(project(':coreExec'))
 		implementation "com.google.jimfs:jimfs:${jimfsVersion}"
+		implementation testFixtures(project)
 	}
 }
 
@@ -58,6 +62,7 @@ integrationTest {
 	dependencies {
 		implementation 'dev.nokee:templates'
 		implementation templates(project(':xcodeIdeKit'))
+		implementation testFixtures(project)
 	}
 	testTasks.configureEach {
 		maxParallelForks = Runtime.runtime.availableProcessors()
@@ -80,6 +85,7 @@ functionalTest {
 		implementation templates(project)
 		implementation 'com.google.code.gson:gson:2.8.6'
 		implementation project(':coreExec')
+		implementation testFixtures(project)
 	}
 }
 

--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/GenerateVirtualFileSystemOverlaysFunctionalTests.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/GenerateVirtualFileSystemOverlaysFunctionalTests.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode;
+
+import dev.gradleplugins.buildscript.blocks.ProjectBlock;
+import dev.gradleplugins.buildscript.statements.BlockStatement;
+import dev.gradleplugins.buildscript.statements.ExpressionStatement;
+import dev.gradleplugins.buildscript.statements.GroupStatement;
+import dev.gradleplugins.buildscript.statements.Statement;
+import dev.gradleplugins.runnerkit.GradleRunner;
+import dev.nokee.buildadapter.xcode.internal.plugins.DefaultXcodeInstallation;
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.GenerateVirtualFileSystemOverlaysTask;
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.VirtualFileSystemOverlay;
+import dev.nokee.buildadapter.xcode.testers.VirtualFileSystemOverlayGenerateTester;
+import dev.nokee.internal.testing.junit.jupiter.ContextualGradleRunnerParameterResolver;
+import dev.nokee.xcode.XCProjectReference;
+import lombok.val;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static dev.gradleplugins.buildscript.blocks.BuildScriptBlock.classpath;
+import static dev.gradleplugins.buildscript.blocks.DependencyNotation.files;
+import static dev.gradleplugins.buildscript.statements.Statement.expressionOf;
+import static dev.gradleplugins.buildscript.syntax.Syntax.gradleProperty;
+import static dev.gradleplugins.buildscript.syntax.Syntax.groovy;
+import static dev.gradleplugins.buildscript.syntax.Syntax.invoke;
+import static dev.gradleplugins.buildscript.syntax.Syntax.literal;
+import static dev.gradleplugins.buildscript.syntax.Syntax.string;
+
+@ExtendWith({TestDirectoryExtension.class, ContextualGradleRunnerParameterResolver.class})
+class GenerateVirtualFileSystemOverlaysFunctionalTests implements VirtualFileSystemOverlayGenerateTester {
+	@TestDirectory
+	Path testDirectory;
+
+	@BeforeEach
+	void givenProjectWithGenerateTask(GradleRunner runner) throws IOException {
+		ProjectBlock.builder()
+			.buildscript(it -> it.dependencies(classpath(files(runner.getPluginClasspath()))))
+			.add(ExpressionStatement.of(groovy(Stream.of(
+				"import " + GenerateVirtualFileSystemOverlaysTask.class.getCanonicalName(),
+				"import " + XCProjectReference.class.getCanonicalName(),
+				"import " + DefaultXcodeInstallation.class.getCanonicalName(),
+				"tasks.register('verify', " + GenerateVirtualFileSystemOverlaysTask.class.getSimpleName() + ") {",
+				"  parameters {").collect(Collectors.joining("\n")))))
+			.add(toOverlays(overlay()))
+			.add(ExpressionStatement.of(groovy(Stream.of(
+				"    outputFile = new File('" + outputFile().toString() + "')",
+				"  }",
+				"}",
+				"").collect(Collectors.joining("\n")))))
+			.build().writeTo(testDirectory.resolve("build.gradle"));
+
+		runner.withTasks("verify").build();
+	}
+
+	static Statement toOverlays(Iterable<VirtualFileSystemOverlay.VirtualDirectory> roots) {
+		val builder = GroupStatement.builder();
+		for (VirtualFileSystemOverlay.VirtualDirectory root : roots) {
+			builder.add(BlockStatement.of(invoke("create", string(root.getName())).alwaysUseParenthesis(), toEntries(root)));
+		}
+		return BlockStatement.of(literal("overlays"), builder.build());
+	}
+
+	static Statement toEntries(Iterable<VirtualFileSystemOverlay.VirtualDirectory.RemappedEntry> entries) {
+		val builder = GroupStatement.builder();
+		for (VirtualFileSystemOverlay.VirtualDirectory.RemappedEntry entry : entries) {
+			builder.add(BlockStatement.of(invoke("create", string(entry.getName())).alwaysUseParenthesis(),
+				GroupStatement.of(expressionOf(gradleProperty(literal("location")).assign(string(entry.getExternalContents()))))));
+		}
+		return BlockStatement.of(literal("entries"), builder.build());
+	}
+
+	@Override
+	public Path testDirectory() {
+		return testDirectory;
+	}
+}

--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/GenerateVirtualFileSystemOverlaysFunctionalTests.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/GenerateVirtualFileSystemOverlaysFunctionalTests.java
@@ -46,6 +46,7 @@ import static dev.gradleplugins.buildscript.syntax.Syntax.groovy;
 import static dev.gradleplugins.buildscript.syntax.Syntax.invoke;
 import static dev.gradleplugins.buildscript.syntax.Syntax.literal;
 import static dev.gradleplugins.buildscript.syntax.Syntax.string;
+import static org.apache.commons.io.FilenameUtils.separatorsToUnix;
 
 @ExtendWith({TestDirectoryExtension.class, ContextualGradleRunnerParameterResolver.class})
 class GenerateVirtualFileSystemOverlaysFunctionalTests implements VirtualFileSystemOverlayGenerateTester {
@@ -64,7 +65,7 @@ class GenerateVirtualFileSystemOverlaysFunctionalTests implements VirtualFileSys
 				"  parameters {").collect(Collectors.joining("\n")))))
 			.add(toOverlays(overlay()))
 			.add(ExpressionStatement.of(groovy(Stream.of(
-				"    outputFile = new File('" + outputFile().toString() + "')",
+				"    outputFile = new File('" + separatorsToUnix(outputFile().toString()) + "')",
 				"  }",
 				"}",
 				"").collect(Collectors.joining("\n")))))

--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/GenerateVirtualFileSystemOverlaysTaskUpToDateDetectionFunctionalTests.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/GenerateVirtualFileSystemOverlaysTaskUpToDateDetectionFunctionalTests.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode;
+
+import dev.gradleplugins.buildscript.blocks.ProjectBlock;
+import dev.gradleplugins.buildscript.statements.ExpressionStatement;
+import dev.gradleplugins.runnerkit.GradleRunner;
+import dev.nokee.buildadapter.xcode.internal.plugins.DefaultXcodeInstallation;
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.GenerateVirtualFileSystemOverlaysTask;
+import dev.nokee.internal.testing.junit.jupiter.ContextualGradleRunnerParameterResolver;
+import dev.nokee.xcode.XCProjectReference;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static dev.gradleplugins.buildscript.blocks.BuildScriptBlock.classpath;
+import static dev.gradleplugins.buildscript.blocks.DependencyNotation.files;
+import static dev.gradleplugins.buildscript.syntax.Syntax.groovy;
+import static dev.nokee.internal.testing.GradleRunnerMatchers.outOfDate;
+import static dev.nokee.internal.testing.GradleRunnerMatchers.skipped;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.everyItem;
+
+@ExtendWith({TestDirectoryExtension.class, ContextualGradleRunnerParameterResolver.class})
+class GenerateVirtualFileSystemOverlaysTaskUpToDateDetectionFunctionalTests {
+	@TestDirectory Path testDirectory;
+	GradleRunner executer;
+
+	@BeforeEach
+	void givenProjectWithGenerateTask(GradleRunner runner) throws IOException {
+		executer = runner.withTasks("verify");
+
+		ProjectBlock.builder()
+			.buildscript(it -> it.dependencies(classpath(files(runner.getPluginClasspath()))))
+			.add(ExpressionStatement.of(groovy(Stream.of(
+				"import " + GenerateVirtualFileSystemOverlaysTask.class.getCanonicalName(),
+				"import " + XCProjectReference.class.getCanonicalName(),
+				"import " + DefaultXcodeInstallation.class.getCanonicalName(),
+				"tasks.register('verify', " + GenerateVirtualFileSystemOverlaysTask.class.getSimpleName() + ") {",
+				"  parameters {",
+				"    overlays {",
+				"      create('/my/root/dir') {",
+				"        entries.create('Foo.h') { location = '/my/path/to/Foo.h' }",
+				"      }",
+				"    }",
+				"    outputFile = file('my-framework-headers.yaml')",
+				"  }",
+				"}",
+				"").collect(Collectors.joining("\n")))))
+			.build().writeTo(testDirectory.resolve("build.gradle"));
+
+		ensureUpToDate(executer);
+	}
+
+	static void ensureUpToDate(GradleRunner executer) {
+		executer.build();
+		assertThat(executer.build().getTasks(), everyItem(skipped()));
+	}
+
+	@Nested
+	class OverlaysParameter {
+		@Test
+		void outOfDateWhenNewOverlayAdded() throws IOException {
+			ExpressionStatement.of(groovy(Stream.of(
+				"tasks.named('verify', " + GenerateVirtualFileSystemOverlaysTask.class.getSimpleName() + ") {",
+				"  parameters {",
+				"    overlays.create('/my/other-root/dir') { entries.create('Bar.h') { location = '/my/path/to/Bar.h' } }",
+				"  }",
+				"}",
+				"").collect(Collectors.joining("\n")))).appendTo(testDirectory.resolve("build.gradle"));
+
+			assertThat(executer.build().task(":verify"), outOfDate());
+		}
+
+		@Test
+		void outOfDateWhenOverlayRemoved() throws IOException {
+			ExpressionStatement.of(groovy(Stream.of(
+				"tasks.named('verify', " + GenerateVirtualFileSystemOverlaysTask.class.getSimpleName() + ") {",
+				"  parameters {",
+				"    overlays.clear()",
+				"  }",
+				"}",
+				"").collect(Collectors.joining("\n")))).appendTo(testDirectory.resolve("build.gradle"));
+
+			assertThat(executer.build().task(":verify"), outOfDate());
+		}
+
+		@Test
+		void outOfDateWhenOverlayEntryAdded() throws IOException {
+			ExpressionStatement.of(groovy(Stream.of(
+				"tasks.named('verify', " + GenerateVirtualFileSystemOverlaysTask.class.getSimpleName() + ") {",
+				"  parameters {",
+				"    overlays.named('/my/root/dir') { entries.create('Bar.h') { location = '/my/path/to/Bar.h' } }",
+				"  }",
+				"}",
+				"").collect(Collectors.joining("\n")))).appendTo(testDirectory.resolve("build.gradle"));
+
+			assertThat(executer.build().task(":verify"), outOfDate());
+		}
+
+		@Test
+		void outOfDateWhenOverlayEntryRemoved() throws IOException {
+			ExpressionStatement.of(groovy(Stream.of(
+				"tasks.named('verify', " + GenerateVirtualFileSystemOverlaysTask.class.getSimpleName() + ") {",
+				"  parameters {",
+				"    overlays.named('/my/root/dir') { entries.clear() }",
+				"  }",
+				"}",
+				"").collect(Collectors.joining("\n")))).appendTo(testDirectory.resolve("build.gradle"));
+
+			assertThat(executer.build().task(":verify"), outOfDate());
+		}
+	}
+
+	@Nested
+	class OutputFileParameter {
+		@Test
+		void outOfDateWhenPathChanged() throws IOException {
+			ExpressionStatement.of(groovy(Stream.of(
+				"tasks.named('verify', " + GenerateVirtualFileSystemOverlaysTask.class.getSimpleName() + ") {",
+				"  parameters {",
+				"    outputFile = file('other-my-framework-headers.yaml')",
+				"  }",
+				"}",
+				"").collect(Collectors.joining("\n")))).appendTo(testDirectory.resolve("build.gradle"));
+
+			assertThat(executer.build().task(":verify"), outOfDate());
+		}
+
+		@Test
+		void outOfDateWhenFileDeleted() throws IOException {
+			Files.delete(testDirectory.resolve("my-framework-headers.yaml"));
+
+			assertThat(executer.build().task(":verify"), outOfDate());
+		}
+
+		@Test
+		void outOfDateWhenFileChanged() throws IOException {
+			Files.write(testDirectory.resolve("my-framework-headers.yaml"), Arrays.asList("", "", ""), StandardOpenOption.APPEND);
+
+			assertThat(executer.build().task(":verify"), outOfDate());
+		}
+	}
+}

--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/MergeVirtualFileSystemOverlaysFunctionalTests.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/MergeVirtualFileSystemOverlaysFunctionalTests.java
@@ -33,6 +33,7 @@ import static dev.gradleplugins.buildscript.blocks.BuildScriptBlock.classpath;
 import static dev.gradleplugins.buildscript.blocks.DependencyNotation.files;
 import static dev.gradleplugins.buildscript.syntax.Syntax.groovy;
 import static java.util.stream.Collectors.joining;
+import static org.apache.commons.io.FilenameUtils.separatorsToUnix;
 
 @ExtendWith({TestDirectoryExtension.class, ContextualGradleRunnerParameterResolver.class})
 class MergeVirtualFileSystemOverlaysFunctionalTests implements VirtualFileSystemOverlayMergeTester {
@@ -46,9 +47,9 @@ class MergeVirtualFileSystemOverlaysFunctionalTests implements VirtualFileSystem
 				"import " + MergeVirtualFileSystemOverlaysTask.class.getCanonicalName(),
 				"tasks.register('verify', " + MergeVirtualFileSystemOverlaysTask.class.getSimpleName() + ") {",
 				"  parameters {",
-				"    sources.from(" + inputFiles().stream().map(it -> "new File('" + it + "')").collect(joining(", ")) + ")",
-				"    derivedDataPath = new File('" + derivedDataPath() + "')",
-				"    outputFile = new File('" + outputFile() + "')",
+				"    sources.from(" + inputFiles().stream().map(it -> "new File('" + separatorsToUnix(it.toString()) + "')").collect(joining(", ")) + ")",
+				"    derivedDataPath = new File('" + separatorsToUnix(derivedDataPath().toString()) + "')",
+				"    outputFile = new File('" + separatorsToUnix(outputFile().toString()) + "')",
 				"  }",
 				"}",
 				"").collect(joining("\n")))))

--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/MergeVirtualFileSystemOverlaysFunctionalTests.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/MergeVirtualFileSystemOverlaysFunctionalTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode;
+
+import dev.gradleplugins.buildscript.blocks.ProjectBlock;
+import dev.gradleplugins.buildscript.statements.ExpressionStatement;
+import dev.gradleplugins.runnerkit.GradleRunner;
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.MergeVirtualFileSystemOverlaysTask;
+import dev.nokee.buildadapter.xcode.testers.VirtualFileSystemOverlayMergeTester;
+import dev.nokee.internal.testing.junit.jupiter.ContextualGradleRunnerParameterResolver;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import static dev.gradleplugins.buildscript.blocks.BuildScriptBlock.classpath;
+import static dev.gradleplugins.buildscript.blocks.DependencyNotation.files;
+import static dev.gradleplugins.buildscript.syntax.Syntax.groovy;
+import static java.util.stream.Collectors.joining;
+
+@ExtendWith({TestDirectoryExtension.class, ContextualGradleRunnerParameterResolver.class})
+class MergeVirtualFileSystemOverlaysFunctionalTests implements VirtualFileSystemOverlayMergeTester {
+	@TestDirectory Path testDirectory;
+
+	@BeforeEach
+	void givenProjectWithMergeTask(GradleRunner runner) throws Exception {
+		ProjectBlock.builder()
+			.buildscript(it -> it.dependencies(classpath(files(runner.getPluginClasspath()))))
+			.add(ExpressionStatement.of(groovy(Stream.of(
+				"import " + MergeVirtualFileSystemOverlaysTask.class.getCanonicalName(),
+				"tasks.register('verify', " + MergeVirtualFileSystemOverlaysTask.class.getSimpleName() + ") {",
+				"  parameters {",
+				"    sources.from(" + inputFiles().stream().map(it -> "new File('" + it + "')").collect(joining(", ")) + ")",
+				"    derivedDataPath = new File('" + derivedDataPath() + "')",
+				"    outputFile = new File('" + outputFile() + "')",
+				"  }",
+				"}",
+				"").collect(joining("\n")))))
+			.build().writeTo(testDirectory.resolve("build.gradle"));
+
+		runner.withTasks("verify").build();
+	}
+
+	@Override
+	public Path testDirectory() {
+		return testDirectory;
+	}
+}

--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/MergeVirtualFileSystemOverlaysTaskUpToDateDetectionFunctionalTests.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/MergeVirtualFileSystemOverlaysTaskUpToDateDetectionFunctionalTests.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode;
+
+import com.google.common.collect.ImmutableList;
+import dev.gradleplugins.buildscript.blocks.ProjectBlock;
+import dev.gradleplugins.buildscript.statements.ExpressionStatement;
+import dev.gradleplugins.runnerkit.GradleRunner;
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.MergeVirtualFileSystemOverlaysTask;
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.DefaultWritable;
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.VirtualFileSystemOverlay;
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.VirtualFileSystemOverlayWriter;
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.Writable;
+import dev.nokee.internal.testing.junit.jupiter.ContextualGradleRunnerParameterResolver;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static dev.gradleplugins.buildscript.blocks.BuildScriptBlock.classpath;
+import static dev.gradleplugins.buildscript.blocks.DependencyNotation.files;
+import static dev.gradleplugins.buildscript.syntax.Syntax.groovy;
+import static dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.VirtualFileSystemOverlay.VirtualDirectory.file;
+import static dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.VirtualFileSystemOverlay.VirtualDirectory.from;
+import static dev.nokee.internal.testing.GradleRunnerMatchers.outOfDate;
+import static dev.nokee.internal.testing.GradleRunnerMatchers.skipped;
+import static dev.nokee.internal.testing.GradleRunnerMatchers.upToDate;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.everyItem;
+
+@ExtendWith({TestDirectoryExtension.class, ContextualGradleRunnerParameterResolver.class})
+class MergeVirtualFileSystemOverlaysTaskUpToDateDetectionFunctionalTests {
+	@TestDirectory Path testDirectory;
+	GradleRunner executer;
+
+	@BeforeEach
+	void givenProjectWithMergeTask(GradleRunner runner) throws Exception {
+		executer = runner.withTasks("verify");
+		ProjectBlock.builder()
+			.buildscript(it -> it.dependencies(classpath(files(runner.getPluginClasspath()))))
+			.add(ExpressionStatement.of(groovy(Stream.of(
+				"import " + MergeVirtualFileSystemOverlaysTask.class.getCanonicalName(),
+				"tasks.register('verify', " + MergeVirtualFileSystemOverlaysTask.class.getSimpleName() + ") {",
+				"  parameters {",
+				"    sources.from(file('foo.yaml'), file('bar.yaml'))",
+				"    derivedDataPath = file('derived-data')",
+				"    outputFile = file('all-products-headers.yaml')",
+				"  }",
+				"}",
+				"").collect(Collectors.joining("\n")))))
+			.build().writeTo(testDirectory.resolve("build.gradle"));
+
+		overlayOf(from("Build/Products/Foo.framework/Headers")
+			.remap(file("Foo.h", testDirectory.resolve("Foo/Foo.h")))
+			.remap(file("MyFoo.h", testDirectory.resolve("Foo/MyFoo.h"))).build())
+			.writeTo(testDirectory.resolve("foo.yaml"));
+		overlayOf(from("Build/Products/Bar.framework/Headers")
+			.remap(file("Bar.h", testDirectory.resolve("Bar/Bar.h"))).build())
+			.writeTo(testDirectory.resolve("bar.yaml"));
+
+		ensureUpToDate(executer);
+	}
+
+	static void ensureUpToDate(GradleRunner executer) {
+		executer.build();
+		assertThat(executer.build().getTasks(), everyItem(skipped()));
+	}
+
+	@Nested
+	class SourcesParameter {
+		@Test
+		void outOfDateWhenFileChanged() throws Exception {
+			// Rewrite foo.yaml to remove MyFoo.h file
+			overlayOf(from("Build/Products/Foo.framework/Headers")
+				.remap(file("Foo.h", testDirectory.resolve("Foo/Foo.h"))).build())
+				.writeTo(testDirectory.resolve("foo.yaml"));
+
+			assertThat(executer.build().task(":verify"), outOfDate());
+		}
+
+		@Test
+		void outOfDateWhenFileAdded() throws Exception {
+			ExpressionStatement.of(groovy(Stream.of(
+				"tasks.named('verify', " + MergeVirtualFileSystemOverlaysTask.class.getSimpleName() + ") {",
+				"  parameters {",
+				"    sources.from(file('far.yaml'))",
+				"  }",
+				"}",
+				"").collect(Collectors.joining("\n")))).appendTo(testDirectory.resolve("build.gradle"));
+
+			overlayOf(from("Build/Products/Far.framework/Headers")
+				.remap(file("Far.h", testDirectory.resolve("Far/Far.h"))).build())
+				.writeTo(testDirectory.resolve("far.yaml"));
+
+			assertThat(executer.build().task(":verify"), outOfDate());
+		}
+
+		@Test
+		void ignoresMissingNewFiles() throws Exception {
+			ExpressionStatement.of(groovy(Stream.of(
+				"tasks.named('verify', " + MergeVirtualFileSystemOverlaysTask.class.getSimpleName() + ") {",
+				"  parameters {",
+				"    sources.from(file('missing.yaml'))",
+				"  }",
+				"}",
+				"").collect(Collectors.joining("\n")))).appendTo(testDirectory.resolve("build.gradle"));
+
+			assertThat(executer.build().task(":verify"), upToDate());
+		}
+
+		@Test
+		void outOfDateWhenFileRemoved() throws IOException {
+			ExpressionStatement.of(groovy(Stream.of(
+				"tasks.named('verify', " + MergeVirtualFileSystemOverlaysTask.class.getSimpleName() + ") {",
+				"  parameters {",
+				"    sources.setFrom(file('foo.yaml'))",
+				"  }",
+				"}",
+				"").collect(Collectors.joining("\n")))).appendTo(testDirectory.resolve("build.gradle"));
+
+			assertThat(executer.build().task(":verify"), outOfDate());
+		}
+	}
+
+	@Nested
+	class DerivedDataPathParameter {
+		@Test
+		void outOfDateWhenPathChanged() throws IOException {
+			ExpressionStatement.of(groovy(Stream.of(
+				"tasks.named('verify', " + MergeVirtualFileSystemOverlaysTask.class.getSimpleName() + ") {",
+				"  parameters {",
+				"    derivedDataPath = file('my-derived-data')",
+				"  }",
+				"}",
+				"").collect(Collectors.joining("\n")))).appendTo(testDirectory.resolve("build.gradle"));
+
+			assertThat(executer.build().task(":verify"), outOfDate());
+		}
+
+		@Test
+		void ignoreChangesToDirectoryContent() throws IOException {
+			Files.createDirectory(testDirectory.resolve("derived-data"));
+			Files.createFile(testDirectory.resolve("derived-data/foo.txt"));
+
+			assertThat(executer.build().task(":verify"), upToDate());
+		}
+	}
+
+	@Nested
+	class OutputFileParameter {
+		@Test
+		void outOfDateWhenPathChanged() throws IOException {
+			ExpressionStatement.of(groovy(Stream.of(
+				"tasks.named('verify', " + MergeVirtualFileSystemOverlaysTask.class.getSimpleName() + ") {",
+				"  parameters {",
+				"    outputFile = file('other-my-framework-headers.yaml')",
+				"  }",
+				"}",
+				"").collect(Collectors.joining("\n")))).appendTo(testDirectory.resolve("build.gradle"));
+
+			assertThat(executer.build().task(":verify"), outOfDate());
+		}
+
+		@Test
+		void outOfDateWhenFileRemoved() throws IOException {
+			Files.delete(testDirectory.resolve("all-products-headers.yaml"));
+
+			assertThat(executer.build().task(":verify"), outOfDate());
+		}
+
+		@Test
+		void outOfDateWhenFileChanged() throws IOException {
+			Files.write(testDirectory.resolve("all-products-headers.yaml"), Arrays.asList("", "", ""), StandardOpenOption.APPEND);
+
+			assertThat(executer.build().task(":verify"), outOfDate());
+		}
+	}
+
+	private Writable<VirtualFileSystemOverlay> overlayOf(VirtualFileSystemOverlay.VirtualDirectory virtualDirectory) {
+		return new DefaultWritable<>(VirtualFileSystemOverlayWriter::new, new VirtualFileSystemOverlay(ImmutableList.of(virtualDirectory)));
+	}
+}

--- a/subprojects/build-adapter-xcode/src/integrationTest/java/dev/nokee/buildadapter/xcode/vfsoverlays/GenerateVirtualFileSystemOverlaysTaskActionIntegrationTests.java
+++ b/subprojects/build-adapter-xcode/src/integrationTest/java/dev/nokee/buildadapter/xcode/vfsoverlays/GenerateVirtualFileSystemOverlaysTaskActionIntegrationTests.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.vfsoverlays;
+
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.ConfigurableContainer;
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.GenerateVirtualFileSystemOverlaysTask.Parameters;
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.GenerateVirtualFileSystemOverlaysTask.TaskAction;
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.VFSOverlaySpec;
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.VirtualFileSystemOverlay;
+import dev.nokee.buildadapter.xcode.testers.VirtualFileSystemOverlayGenerateTester;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
+import org.gradle.api.Action;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.nio.file.Path;
+
+import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
+
+@ExtendWith(TestDirectoryExtension.class)
+class GenerateVirtualFileSystemOverlaysTaskActionIntegrationTests implements VirtualFileSystemOverlayGenerateTester {
+	@TestDirectory Path testDirectory;
+	Parameters parameters = objectFactory().newInstance(Parameters.class);
+	TaskAction subject = new TaskAction() {
+		@Override
+		public Parameters getParameters() {
+			return parameters;
+		}
+	};
+
+	@BeforeEach
+	void givenConfiguredParameters() {
+		parameters.getOverlays().configure(toOverlays(overlay()));
+		parameters.getOutputFile().set(outputFile().toFile());
+
+		subject.execute();
+	}
+
+	static Action<ConfigurableContainer<VFSOverlaySpec>> toOverlays(Iterable<VirtualFileSystemOverlay.VirtualDirectory> roots) {
+		return it -> {
+			for (VirtualFileSystemOverlay.VirtualDirectory root : roots) {
+				it.create(root.getName(), toEntries(root));
+			}
+		};
+	}
+
+	static Action<VFSOverlaySpec> toEntries(Iterable<VirtualFileSystemOverlay.VirtualDirectory.RemappedEntry> entries) {
+		return it -> {
+			for (VirtualFileSystemOverlay.VirtualDirectory.RemappedEntry entry : entries) {
+				it.getEntries().create(entry.getName(), spec -> spec.getLocation().set(entry.getExternalContents()));
+			}
+		};
+	}
+
+	@Override
+	public Path testDirectory() {
+		return testDirectory;
+	}
+}

--- a/subprojects/build-adapter-xcode/src/integrationTest/java/dev/nokee/buildadapter/xcode/vfsoverlays/GenerateVirtualFileSystemOverlaysTaskParametersIntegrationTests.java
+++ b/subprojects/build-adapter-xcode/src/integrationTest/java/dev/nokee/buildadapter/xcode/vfsoverlays/GenerateVirtualFileSystemOverlaysTaskParametersIntegrationTests.java
@@ -16,7 +16,6 @@
 package dev.nokee.buildadapter.xcode.vfsoverlays;
 
 import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.GenerateVirtualFileSystemOverlaysTask.Parameters;
-import dev.nokee.buildadapter.xcode.testers.VirtualFileSystemOverlayTestUtils;
 import dev.nokee.utils.FileSystemLocationUtils;
 import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
 import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
@@ -27,6 +26,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.nio.file.Path;
 
+import static dev.nokee.buildadapter.xcode.testers.VirtualFileSystemOverlayTestUtils.entries;
+import static dev.nokee.buildadapter.xcode.testers.VirtualFileSystemOverlayTestUtils.location;
 import static dev.nokee.internal.testing.GradleNamedMatchers.named;
 import static dev.nokee.internal.testing.GradleProviderMatchers.providerOf;
 import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
@@ -59,12 +60,12 @@ class GenerateVirtualFileSystemOverlaysTaskParametersIntegrationTests {
 
 		@Test
 		void copiesOverlays() {
-			assertThat(dst.getOverlays(), contains(allOf(
+			assertThat(dst.getOverlays().getElements(), providerOf(contains(allOf(
 				named("my/path/to/dir"),
-				VirtualFileSystemOverlayTestUtils.entries(contains(allOf(
+				entries(contains(allOf(
 					named("foo.h"),
-					VirtualFileSystemOverlayTestUtils.location(providerOf("/path/to/foo.h"))
-				))))));
+					location(providerOf("/path/to/foo.h"))
+				)))))));
 		}
 	}
 }

--- a/subprojects/build-adapter-xcode/src/integrationTest/java/dev/nokee/buildadapter/xcode/vfsoverlays/GenerateVirtualFileSystemOverlaysTaskParametersIntegrationTests.java
+++ b/subprojects/build-adapter-xcode/src/integrationTest/java/dev/nokee/buildadapter/xcode/vfsoverlays/GenerateVirtualFileSystemOverlaysTaskParametersIntegrationTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.vfsoverlays;
+
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.GenerateVirtualFileSystemOverlaysTask.Parameters;
+import dev.nokee.buildadapter.xcode.testers.VirtualFileSystemOverlayTestUtils;
+import dev.nokee.utils.FileSystemLocationUtils;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.nio.file.Path;
+
+import static dev.nokee.internal.testing.GradleNamedMatchers.named;
+import static dev.nokee.internal.testing.GradleProviderMatchers.providerOf;
+import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+
+@ExtendWith(TestDirectoryExtension.class)
+class GenerateVirtualFileSystemOverlaysTaskParametersIntegrationTests {
+	@TestDirectory Path testDirectory;
+
+	@Nested
+	class CheckCopyTo {
+		Parameters src = objectFactory().newInstance(Parameters.class);
+		Parameters dst = objectFactory().newInstance(Parameters.class);
+
+		@BeforeEach
+		void givenCopiedParameters() {
+			src.getOverlays().create("my/path/to/dir", it -> it.getEntries().create("foo.h", e -> e.getLocation().set("/path/to/foo.h")));
+			src.getOutputFile().set(testDirectory.resolve("out.yaml").toFile());
+
+			src.copyTo(dst);
+		}
+
+		@Test
+		void copiesOutputFile() {
+			assertThat(dst.getOutputFile().map(FileSystemLocationUtils::asPath),
+				providerOf(testDirectory.resolve("out.yaml")));
+		}
+
+		@Test
+		void copiesOverlays() {
+			assertThat(dst.getOverlays(), contains(allOf(
+				named("my/path/to/dir"),
+				VirtualFileSystemOverlayTestUtils.entries(contains(allOf(
+					named("foo.h"),
+					VirtualFileSystemOverlayTestUtils.location(providerOf("/path/to/foo.h"))
+				))))));
+		}
+	}
+}

--- a/subprojects/build-adapter-xcode/src/integrationTest/java/dev/nokee/buildadapter/xcode/vfsoverlays/MergeVirtualFileSystemOverlaysTaskActionIntegrationTests.java
+++ b/subprojects/build-adapter-xcode/src/integrationTest/java/dev/nokee/buildadapter/xcode/vfsoverlays/MergeVirtualFileSystemOverlaysTaskActionIntegrationTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.vfsoverlays;
+
+import dev.nokee.VirtualFileSystemOverlays;
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.MergeVirtualFileSystemOverlaysTask.Parameters;
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.MergeVirtualFileSystemOverlaysTask.TaskAction;
+import dev.nokee.buildadapter.xcode.testers.VirtualFileSystemOverlayMergeTester;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.nio.file.Path;
+
+import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
+
+@ExtendWith(TestDirectoryExtension.class)
+class MergeVirtualFileSystemOverlaysTaskActionIntegrationTests implements VirtualFileSystemOverlayMergeTester {
+	@TestDirectory Path testDirectory;
+	Parameters parameters = objectFactory().newInstance(Parameters.class);
+	TaskAction subject = new TaskAction() {
+		@Override
+		public Parameters getParameters() {
+			return parameters;
+		}
+	};
+
+	@BeforeEach
+	void givenConfiguredParameters() {
+		new VirtualFileSystemOverlays().writeToProject(testDirectory);
+
+		parameters.getSources().from(inputFiles());
+		parameters.getOutputFile().set(outputFile().toFile());
+		parameters.getDerivedDataPath().set(derivedDataPath().toFile());
+
+		subject.execute();
+	}
+
+	@Override
+	public Path testDirectory() {
+		return testDirectory;
+	}
+}

--- a/subprojects/build-adapter-xcode/src/integrationTest/java/dev/nokee/buildadapter/xcode/vfsoverlays/MergeVirtualFileSystemOverlaysTaskParametersIntegrationTests.java
+++ b/subprojects/build-adapter-xcode/src/integrationTest/java/dev/nokee/buildadapter/xcode/vfsoverlays/MergeVirtualFileSystemOverlaysTaskParametersIntegrationTests.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.vfsoverlays;
+
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.MergeVirtualFileSystemOverlaysTask.Parameters;
+import dev.nokee.utils.FileSystemLocationUtils;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.nio.file.Path;
+
+import static dev.nokee.internal.testing.FileSystemMatchers.aFile;
+import static dev.nokee.internal.testing.FileSystemMatchers.withAbsolutePath;
+import static dev.nokee.internal.testing.GradleProviderMatchers.providerOf;
+import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.endsWith;
+
+@ExtendWith(TestDirectoryExtension.class)
+class MergeVirtualFileSystemOverlaysTaskParametersIntegrationTests {
+	@TestDirectory Path testDirectory;
+
+	@Nested
+	class CheckCopyTo {
+		Parameters src = objectFactory().newInstance(Parameters.class);
+		Parameters dst = objectFactory().newInstance(Parameters.class);
+
+		@BeforeEach
+		void givenCopiedParameters() {
+			src.getSources().setFrom(testDirectory.resolve("first-overlay.yaml"), testDirectory.resolve("second-overlay.yaml"));
+			src.getOutputFile().set(testDirectory.resolve("out.yaml").toFile());
+			src.getDerivedDataPath().set(testDirectory.resolve("derived-data").toFile());
+
+			src.copyTo(dst);
+		}
+
+		@Test
+		void copiesOutputFile() {
+			assertThat(dst.getOutputFile().map(FileSystemLocationUtils::asPath),
+				providerOf(testDirectory.resolve("out.yaml")));
+		}
+
+		@Test
+		void copiesSources() {
+			assertThat(dst.getSources(), containsInAnyOrder(aFile(withAbsolutePath(endsWith("/first-overlay.yaml"))),
+				aFile(withAbsolutePath(endsWith("/second-overlay.yaml")))));
+		}
+
+		@Test
+		void copiesDerivedDataPath() {
+			assertThat(dst.getDerivedDataPath().map(FileSystemLocationUtils::asPath),
+				providerOf(testDirectory.resolve("derived-data")));
+		}
+	}
+}

--- a/subprojects/build-adapter-xcode/src/integrationTest/java/dev/nokee/buildadapter/xcode/vfsoverlays/VFSOverlayActionIntegrationTests.java
+++ b/subprojects/build-adapter-xcode/src/integrationTest/java/dev/nokee/buildadapter/xcode/vfsoverlays/VFSOverlayActionIntegrationTests.java
@@ -63,10 +63,10 @@ class VFSOverlayActionIntegrationTests {
 	void hasAllPublicHeaders() {
 		assertThat(property.getElements(), providerOf(contains(allOf(
 			named("Build/Products/MyFramework.framework/Headers"),
-			entries(contains(allOf(
-				named("MyFramework.h"), location(providerOf(endsWith("/MyFramework/MyFramework.h"))),
-				named("MyPublicHeader.h"), location(providerOf(endsWith("/MyFramework/MyPublicHeader.h")))
-			)))
+			entries(contains(
+				allOf(named("MyPublicHeader.h"), location(providerOf(endsWith("/MyFramework/MyPublicHeader.h")))),
+				allOf(named("MyFramework.h"), location(providerOf(endsWith("/MyFramework/MyFramework.h"))))
+			))
 		))));
 	}
 }

--- a/subprojects/build-adapter-xcode/src/integrationTest/java/dev/nokee/buildadapter/xcode/vfsoverlays/VFSOverlayActionIntegrationTests.java
+++ b/subprojects/build-adapter-xcode/src/integrationTest/java/dev/nokee/buildadapter/xcode/vfsoverlays/VFSOverlayActionIntegrationTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.vfsoverlays;
+
+import dev.nokee.VirtualFileSystemOverlays;
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.ConfigurableOverlays;
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.VFSOverlayAction;
+import dev.nokee.xcode.XCProjectReference;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.nio.file.Path;
+
+import static dev.nokee.buildadapter.xcode.testers.VirtualFileSystemOverlayTestUtils.entries;
+import static dev.nokee.buildadapter.xcode.testers.VirtualFileSystemOverlayTestUtils.location;
+import static dev.nokee.buildadapter.xcode.testers.XCBuildSettingTestUtils.buildSettings;
+import static dev.nokee.internal.testing.GradleNamedMatchers.named;
+import static dev.nokee.internal.testing.GradleProviderMatchers.providerOf;
+import static dev.nokee.internal.testing.util.ProjectTestUtils.objectFactory;
+import static dev.nokee.internal.testing.util.ProjectTestUtils.providerFactory;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.endsWith;
+
+@ExtendWith(TestDirectoryExtension.class)
+class VFSOverlayActionIntegrationTests {
+	@TestDirectory Path testDirectory;
+	ConfigurableOverlays property = objectFactory().newInstance(ConfigurableOverlays.class);
+
+
+	@BeforeEach
+	void givenXcodeProject() {
+		new VirtualFileSystemOverlays().writeToProject(testDirectory);
+
+		property.configure(new VFSOverlayAction(objectFactory(),
+			providerFactory().provider(() -> XCProjectReference.of(testDirectory.resolve("VirtualFileSystemOverlays.xcodeproj")).ofTarget("MyFramework")),
+			providerFactory().provider(() -> buildSettings(builder -> builder
+				.put("PUBLIC_HEADERS_FOLDER_PATH", "$(TARGET_NAME).framework/Headers")
+				.put("TARGET_NAME", "MyFramework")
+				.put("SOURCE_ROOT", testDirectory.toString())
+				.put("BUILT_PRODUCTS_DIR", testDirectory.resolve("derived-data/Build/Products").toString()))),
+			providerFactory().provider(() -> testDirectory.resolve("derived-data"))));
+	}
+
+	@Test
+	void hasAllPublicHeaders() {
+		assertThat(property, contains(allOf(
+			named("Build/Products/MyFramework.framework/Headers"),
+			entries(contains(allOf(
+				named("MyFramework.h"), location(providerOf(endsWith("/MyFramework/MyFramework.h"))),
+				named("MyPublicHeader.h"), location(providerOf(endsWith("/MyFramework/MyPublicHeader.h")))
+			)))
+		)));
+	}
+}

--- a/subprojects/build-adapter-xcode/src/integrationTest/java/dev/nokee/buildadapter/xcode/vfsoverlays/VFSOverlayActionIntegrationTests.java
+++ b/subprojects/build-adapter-xcode/src/integrationTest/java/dev/nokee/buildadapter/xcode/vfsoverlays/VFSOverlayActionIntegrationTests.java
@@ -61,12 +61,12 @@ class VFSOverlayActionIntegrationTests {
 
 	@Test
 	void hasAllPublicHeaders() {
-		assertThat(property, contains(allOf(
+		assertThat(property.getElements(), providerOf(contains(allOf(
 			named("Build/Products/MyFramework.framework/Headers"),
 			entries(contains(allOf(
 				named("MyFramework.h"), location(providerOf(endsWith("/MyFramework/MyFramework.h"))),
 				named("MyPublicHeader.h"), location(providerOf(endsWith("/MyFramework/MyPublicHeader.h")))
 			)))
-		)));
+		))));
 	}
 }

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/ConfigurableXCBuildSettings.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/ConfigurableXCBuildSettings.java
@@ -29,7 +29,6 @@ import dev.nokee.xcode.XCString;
 import groovy.lang.Closure;
 import lombok.val;
 import org.gradle.api.provider.ListProperty;
-import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
@@ -45,16 +44,6 @@ import java.util.stream.Collectors;
 import static java.util.stream.Collectors.joining;
 
 public abstract class ConfigurableXCBuildSettings implements XCBuildSettings {
-	public ConfigurableXCBuildSettings() {
-		getValue().set(getObjects().map(it -> {
-			List<Object> l = new ArrayList<>(it);
-			Collections.reverse(l);
-			// flatUnpack takes care of the Iterable, List, Set, Provider of any value, Callable of any value, etc.
-			//   toLayer only needs to consider Map, XCBuildSettingLayer
-			return new DefaultXCBuildSettings(new CompositeXCBuildSettingLayer(DeferredUtils.flatUnpack(l).stream().map(ConfigurableXCBuildSettings::toLayer).collect(Collectors.toList())));
-		}));
-	}
-
 	@Nullable
 	@Override
 	public String get(String name) {
@@ -131,5 +120,13 @@ public abstract class ConfigurableXCBuildSettings implements XCBuildSettings {
 	protected abstract ListProperty<Object> getObjects();
 
 	@Input
-	protected abstract Property<XCBuildSettings> getValue();
+	protected Provider<XCBuildSettings> getValue() {
+		return getObjects().map(it -> {
+			List<Object> l = new ArrayList<>(it);
+			Collections.reverse(l);
+			// flatUnpack takes care of the Iterable, List, Set, Provider of any value, Callable of any value, etc.
+			//   toLayer only needs to consider Map, XCBuildSettingLayer
+			return new DefaultXCBuildSettings(new CompositeXCBuildSettingLayer(DeferredUtils.flatUnpack(l).stream().map(ConfigurableXCBuildSettings::toLayer).collect(Collectors.toList())));
+		});
+	}
 }

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/CopyTo.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/CopyTo.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal.plugins;
+
+public interface CopyTo<T> {
+    CopyTo<T> copyTo(T other);
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/ParameterizedTask.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/ParameterizedTask.java
@@ -54,7 +54,10 @@ public abstract class ParameterizedTask<P extends WorkParameters & CopyTo<P>> ex
 	}
 
 	@Nested
-	public final P getParameters() {
+	// We cannot mark this getter as `final` because of https://github.com/gradle/gradle/issues/24747
+	//   The intention here is to prevent any implementer to override this getter as they don't own the returned instance.
+	//   Please, do not override this method!
+	public /*final*/ P getParameters() {
 		return parameters;
 	}
 

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/ParameterizedTask.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/ParameterizedTask.java
@@ -61,7 +61,7 @@ public abstract class ParameterizedTask<P extends WorkParameters & CopyTo<P>> ex
 		return parameters;
 	}
 
-	@Inject
+	@Inject // This method is considered private to this class, do not use!
 	protected abstract ObjectFactory getObjects();
 
 	@TaskAction

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/ParameterizedTask.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/ParameterizedTask.java
@@ -49,7 +49,7 @@ public abstract class ParameterizedTask<P extends WorkParameters & CopyTo<P>> ex
 	}
 
 	public final ParameterizedTask<P> parameters(Action<? super P> action) {
-		action.execute(parameters);
+		action.execute(getParameters());
 		return this;
 	}
 
@@ -63,7 +63,7 @@ public abstract class ParameterizedTask<P extends WorkParameters & CopyTo<P>> ex
 
 	@TaskAction
 	private void doGenerate() {
-		factory.create().submit(actionType, parameters::copyTo);
+		factory.create().submit(actionType, getParameters()::copyTo);
 	}
 
 	public interface WorkQueueFactory {

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/ParameterizedTask.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/ParameterizedTask.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal.plugins;
+
+import com.google.common.reflect.TypeToken;
+import org.gradle.api.Action;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.workers.WorkAction;
+import org.gradle.workers.WorkParameters;
+import org.gradle.workers.WorkQueue;
+
+import javax.inject.Inject;
+
+/**
+ * Parameterized tasks represent a task that execute solely through a Gradle worker allowing parallel-by-default.
+ *
+ * <p>The implementor needs to specify two important aspect: 1) the WorkAction class and 2) a WorkQueue factory.
+ *
+ * <p>The ParameterizedTask type should not be exposed to the users, they should only be aware of {@code parameters(Action)}.
+ *
+ * @param <P> the parameter types
+ */
+@SuppressWarnings({"unchecked", "UnstableApiUsage"})
+public abstract class ParameterizedTask<P extends WorkParameters & CopyTo<P>> extends DefaultTask {
+	private final Class<? extends WorkAction<P>> actionType;
+	private final WorkQueueFactory factory;
+	private final P parameters;
+
+	protected ParameterizedTask(Class<? extends WorkAction<P>> actionType, WorkQueueFactory factory) {
+		this.actionType = actionType;
+		this.factory = factory;
+		this.parameters = getObjects().newInstance((Class<P>) new TypeToken<P>(getClass()) {}.getRawType());
+	}
+
+	public final ParameterizedTask<P> parameters(Action<? super P> action) {
+		action.execute(parameters);
+		return this;
+	}
+
+	@Nested
+	public final P getParameters() {
+		return parameters;
+	}
+
+	@Inject
+	protected abstract ObjectFactory getObjects();
+
+	@TaskAction
+	private void doGenerate() {
+		factory.create().submit(actionType, parameters::copyTo);
+	}
+
+	public interface WorkQueueFactory {
+		WorkQueue create();
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeBuildAdapterPlugin.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeBuildAdapterPlugin.java
@@ -228,8 +228,10 @@ public class XcodeBuildAdapterPlugin implements Plugin<Settings> {
 				val derivedDataTask = project.getExtensions().getByType(ModelRegistry.class).register(DomainObjectEntities.newEntity(TaskName.of("assemble", "derivedDataDir"), AssembleDerivedDataDirectoryTask.class, it -> it.ownedBy(entity)))
 					.as(AssembleDerivedDataDirectoryTask.class)
 					.configure(task -> {
-						task.getIncomingDerivedDataPaths().from(derivedData);
-						task.getXcodeDerivedDataPath().set(project.getLayout().getBuildDirectory().dir("tmp-derived-data/" + target.getName() + "-" + variantInfo.getName()));
+						task.parameters(parameters -> {
+							parameters.getIncomingDerivedDataPaths().from(derivedData);
+							parameters.getXcodeDerivedDataPath().set(project.getLayout().getBuildDirectory().dir("tmp-derived-data/" + target.getName() + "-" + variantInfo.getName()));
+						});
 					});
 
 				val targetTask = project.getExtensions().getByType(ModelRegistry.class).register(DomainObjectEntities.newEntity(TaskName.lifecycle(), XcodeTargetExecTask.class, it -> it.ownedBy(entity)))
@@ -239,7 +241,7 @@ public class XcodeBuildAdapterPlugin implements Plugin<Settings> {
 						task.getXcodeProject().set(reference);
 						task.getTargetName().set(target.getName());
 						task.getOutputs().upToDateWhen(because(String.format("a shell script build phase of %s has no inputs or outputs defined", reference.ofTarget(target.getName())), everyShellScriptBuildPhaseHasDeclaredInputsAndOutputs()));
-						task.getDerivedDataPath().set(derivedDataTask.flatMap(AssembleDerivedDataDirectoryTask::getXcodeDerivedDataPath));
+						task.getDerivedDataPath().set(derivedDataTask.flatMap(it -> it.getParameters().getXcodeDerivedDataPath()));
 						task.getOutputDirectory().set(project.getLayout().getBuildDirectory().dir("derivedData/" + task.getName()));
 						task.getXcodeInstallation().set(project.getProviders().of(CurrentXcodeInstallationValueSource.class, ActionUtils.doNothing()));
 						task.getConfiguration().set(variantInfo.getName());

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeTargetExecTask.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeTargetExecTask.java
@@ -119,6 +119,9 @@ public abstract class XcodeTargetExecTask extends DefaultTask implements Xcodebu
 		return targetReference;
 	}
 
+	@Internal
+	public abstract Property<XCBuildSettings> getAllBuildSettings();
+
 	@Nested
 	public Provider<XCBuildPlan> getBuildPlan() {
 		return buildSpec;
@@ -141,8 +144,11 @@ public abstract class XcodeTargetExecTask extends DefaultTask implements Xcodebu
 
 		this.targetReference = ZipProviderBuilder.newBuilder(objects).value(getXcodeProject()).value(getTargetName())
 			.zip(XCProjectReference::ofTarget);
+
+		getAllBuildSettings().value(new DefaultXCBuildSettings(new CompositeXCBuildSettingLayer(ImmutableList.of(overrideLayer(), xcodebuildLayer()))));
+
 		this.buildSpec = finalizeValueOnRead(objects.property(XCBuildPlan.class).value(getTargetReference().map(XCLoaders.buildSpecLoader()::load).map(spec -> {
-			final XCBuildSettings buildSettings = new DefaultXCBuildSettings(new CompositeXCBuildSettingLayer(ImmutableList.of(overrideLayer(), xcodebuildLayer())));
+			final XCBuildSettings buildSettings = getAllBuildSettings().get();
 
 			val context = new BuildSettingsResolveContext(FileSystems.getDefault(), buildSettings);
 			val fileRefs = XCLoaders.fileReferences().load(getXcodeProject().get());

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeTargetExecTask.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeTargetExecTask.java
@@ -53,6 +53,7 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.process.CommandLineArgumentProvider;
 import org.gradle.process.ExecOperations;
 import org.gradle.workers.WorkAction;
 import org.gradle.workers.WorkParameters;
@@ -82,6 +83,7 @@ import static dev.nokee.core.exec.CommandLineToolInvocationOutputRedirection.toS
 import static dev.nokee.utils.ProviderUtils.disallowChanges;
 import static dev.nokee.utils.ProviderUtils.finalizeValueOnRead;
 import static dev.nokee.utils.ProviderUtils.ifPresent;
+import static dev.nokee.utils.TransformerUtils.flatTransformEach;
 
 @CacheableTask
 public abstract class XcodeTargetExecTask extends DefaultTask implements XcodebuildExecTask, HasConfigurableXcodeInstallation, HasXcodeTargetReference {
@@ -99,6 +101,9 @@ public abstract class XcodeTargetExecTask extends DefaultTask implements Xcodebu
 
 	@OutputDirectory
 	public abstract DirectoryProperty getOutputDirectory();
+
+	@Nested
+	public abstract ListProperty<CommandLineArgumentProvider> getArguments();
 
 	@Internal
 	public abstract ListProperty<String> getAllArguments();
@@ -130,6 +135,7 @@ public abstract class XcodeTargetExecTask extends DefaultTask implements Xcodebu
 		getAllArguments().addAll(getSdk().map(sdk -> of("-sdk", sdk)).orElse(of()));
 		getAllArguments().addAll(getConfiguration().map(buildType -> of("-configuration", buildType)).orElse(of()));
 		getAllArguments().addAll(getBuildSettings().asProvider().map(buildSettingsOverride()).map(toFlags()));
+		getAllArguments().addAll(getArguments().map(flatTransformEach(CommandLineArgumentProvider::asArguments)));
 
 		finalizeValueOnRead(disallowChanges(getAllArguments()));
 

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/ConfigurableContainer.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/ConfigurableContainer.java
@@ -45,8 +45,7 @@ public abstract class ConfigurableContainer<T extends NamedDomainObject> {
 
 	@SuppressWarnings("unchecked")
 	private Class<T> defaultType() {
-		return (Class<T>) new TypeToken<T>(getClass()) {
-		}.getRawType();
+		return (Class<T>) new TypeToken<T>(getClass()) {}.getRawType();
 	}
 
 	public boolean addAll(Iterable<? extends T> l) {

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/ConfigurableContainer.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/ConfigurableContainer.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Streams;
+import com.google.common.reflect.TypeToken;
+import org.gradle.api.Action;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.Internal;
+
+import javax.inject.Inject;
+import java.util.Iterator;
+import java.util.function.Function;
+
+public abstract class ConfigurableContainer<T extends NamedDomainObject> implements Iterable<T> {
+	public T create(String name, Action<? super T> action) {
+		T result = getObjects().newInstance(defaultType());
+		result.getName().set(name);
+		result.getName().finalizeValue();
+		action.execute(result);
+		getValues().put(name, result);
+		return result;
+	}
+
+	@SuppressWarnings("unchecked")
+	private Class<T> defaultType() {
+		return (Class<T>) new TypeToken<T>(getClass()) {
+		}.getRawType();
+	}
+
+	public boolean addAll(Iterable<? extends T> l) {
+		l.forEach(it -> getValues().put(it.getName().get(), it));
+		return true;
+	}
+
+	public boolean addAll(Provider<? extends Iterable<? extends T>> provider) {
+		getValues().putAll(provider.map(it -> Streams.stream(it).collect(ImmutableMap.toImmutableMap(t -> t.getName().get(), Function.identity()))));
+		return true;
+	}
+
+	public void clear() {
+		getValues().empty();
+	}
+
+	public void named(String name, Action<? super T> action) {
+		action.execute(getValues().getting(name).get());
+	}
+
+	@Inject
+	protected abstract ObjectFactory getObjects();
+
+	@Internal
+	protected abstract MapProperty<String, T> getValues();
+
+	@Override
+	public Iterator<T> iterator() {
+		return getValues().get().values().iterator();
+	}
+
+	public ConfigurableContainer<T> configure(Action<? super ConfigurableContainer<T>> action) {
+		action.execute(this);
+		return this;
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/ConfigurableEntries.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/ConfigurableEntries.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay;
+
+public abstract class ConfigurableEntries extends ConfigurableContainer<VFSOverlaySpec.EntrySpec> {
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/ConfigurableOverlays.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/ConfigurableOverlays.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay;
+
+public abstract class ConfigurableOverlays extends ConfigurableContainer<VFSOverlaySpec> {
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/DefaultWritable.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/DefaultWritable.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay;
+
+import lombok.val;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.file.Path;
+
+public final class DefaultWritable<T> implements Writable<T> {
+	private final ObjectWriter.Factory<T> factory;
+	private final T delegate;
+
+	public DefaultWritable(ObjectWriter.Factory<T> factory, T delegate) {
+		this.factory = factory;
+		this.delegate = delegate;
+	}
+
+	@Override
+	public Path writeTo(Path path) throws IOException {
+		val writer = factory.create(path);
+		try {
+			writer.write(delegate);
+		} finally {
+			if (writer instanceof Closeable) {
+				((Closeable) writer).close();
+			}
+		}
+		return path;
+	}
+
+	@Override
+	public void writeTo(Writer out) throws IOException {
+		val writer = factory.create(out);
+		try {
+			writer.write(delegate);
+		} finally {
+			if (writer instanceof Closeable) {
+				((Closeable) writer).close();
+			}
+		}
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/GenerateVirtualFileSystemOverlaysTask.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/GenerateVirtualFileSystemOverlaysTask.java
@@ -98,8 +98,8 @@ public abstract class GenerateVirtualFileSystemOverlaysTask extends Parameterize
 		@Override
 		public void execute() {
 			val virtualDirectories = new ArrayList<VirtualFileSystemOverlay.VirtualDirectory>();
-			for (VFSOverlaySpec overlay : getParameters().getOverlays()) {
-				virtualDirectories.add(new VirtualFileSystemOverlay.VirtualDirectory(overlay.getName().get(), Streams.stream(overlay.getEntries()).map(it -> file(it.getName().get(), fileSystem.getPath(it.getLocation().get()))).collect(Collectors.toList())));
+			for (VFSOverlaySpec overlay : getParameters().getOverlays().getElements().get()) {
+				virtualDirectories.add(new VirtualFileSystemOverlay.VirtualDirectory(overlay.getName().get(), Streams.stream(overlay.getEntries().getElements().get()).map(it -> file(it.getName().get(), fileSystem.getPath(it.getLocation().get()))).collect(Collectors.toList())));
 			}
 
 			try (val writer = new VirtualFileSystemOverlayWriter(Files.newBufferedWriter(outputFile()))) {

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/GenerateVirtualFileSystemOverlaysTask.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/GenerateVirtualFileSystemOverlaysTask.java
@@ -42,22 +42,6 @@ public abstract class GenerateVirtualFileSystemOverlaysTask extends Parameterize
 	@Inject
 	public GenerateVirtualFileSystemOverlaysTask(WorkerExecutor workerExecutor) {
 		super(TaskAction.class, workerExecutor::noIsolation);
-
-//		// TODO: Configure from the outside
-//		val xcodebuildLayer = new XcodebuildBuildSettingLayer.Builder(objects)
-//			.targetReference(getParameters().getTargetReference())
-//			.sdk(getParameters().getSdk())
-//			.configuration(getParameters().getConfiguration())
-//			.developerDir(getParameters().getXcodeInstallation().map(XcodeInstallation::getDeveloperDirectory))
-//			.buildSettings(getParameters().getBuildSettings().asProvider().map(buildSettingsOverride()))
-//			.build();
-//		getParameters().getBuildSettings().setFrom(xcodebuildLayer);
-//
-//		// TODO: Configure from the outside
-//		val derivedDataOverride = objects.mapProperty(String.class, String.class);
-//		derivedDataOverride.put("OBJROOT", getParameters().getDerivedDataPath().map(it -> it.dir("Build/Intermediates.noindex").getAsFile().getAbsolutePath()));
-//		derivedDataOverride.put("SYMROOT", getParameters().getDerivedDataPath().map(it -> it.dir("Build/Products").getAsFile().getAbsolutePath()));
-//		getParameters().getBuildSettings().from(derivedDataOverride);
 	}
 
 	public interface Parameters extends WorkParameters, CopyTo<Parameters> {

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/GenerateVirtualFileSystemOverlaysTask.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/GenerateVirtualFileSystemOverlaysTask.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay;
+
+import com.google.common.collect.Streams;
+import dev.nokee.buildadapter.xcode.internal.plugins.CopyTo;
+import dev.nokee.buildadapter.xcode.internal.plugins.ParameterizedTask;
+import lombok.val;
+import org.gradle.api.Action;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.workers.WorkParameters;
+import org.gradle.workers.WorkerExecutor;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+
+import static dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.VirtualFileSystemOverlay.VirtualDirectory.file;
+
+public abstract class GenerateVirtualFileSystemOverlaysTask extends ParameterizedTask<GenerateVirtualFileSystemOverlaysTask.Parameters> {
+	@Inject
+	public GenerateVirtualFileSystemOverlaysTask(WorkerExecutor workerExecutor) {
+		super(TaskAction.class, workerExecutor::noIsolation);
+
+//		// TODO: Configure from the outside
+//		val xcodebuildLayer = new XcodebuildBuildSettingLayer.Builder(objects)
+//			.targetReference(getParameters().getTargetReference())
+//			.sdk(getParameters().getSdk())
+//			.configuration(getParameters().getConfiguration())
+//			.developerDir(getParameters().getXcodeInstallation().map(XcodeInstallation::getDeveloperDirectory))
+//			.buildSettings(getParameters().getBuildSettings().asProvider().map(buildSettingsOverride()))
+//			.build();
+//		getParameters().getBuildSettings().setFrom(xcodebuildLayer);
+//
+//		// TODO: Configure from the outside
+//		val derivedDataOverride = objects.mapProperty(String.class, String.class);
+//		derivedDataOverride.put("OBJROOT", getParameters().getDerivedDataPath().map(it -> it.dir("Build/Intermediates.noindex").getAsFile().getAbsolutePath()));
+//		derivedDataOverride.put("SYMROOT", getParameters().getDerivedDataPath().map(it -> it.dir("Build/Products").getAsFile().getAbsolutePath()));
+//		getParameters().getBuildSettings().from(derivedDataOverride);
+	}
+
+	public interface Parameters extends WorkParameters, CopyTo<Parameters> {
+		@Nested
+		ConfigurableOverlays getOverlays();
+
+		default void overlays(Action<? super ConfigurableOverlays> action) {
+			action.execute(getOverlays());
+		}
+
+		@OutputFile
+		RegularFileProperty getOutputFile();
+
+		@Override
+		default Parameters copyTo(Parameters other) {
+			other.getOutputFile().set(getOutputFile());
+			other.getOverlays().addAll(getOverlays());
+			return this;
+		}
+	}
+
+	public static abstract class TaskAction implements org.gradle.workers.WorkAction<Parameters> {
+		private final FileSystem fileSystem;
+
+		@Inject
+		public TaskAction() {
+			this(FileSystems.getDefault());
+		}
+
+		protected TaskAction(FileSystem fileSystem) {
+			this.fileSystem = fileSystem;
+		}
+
+		private Path outputFile() {
+			return getParameters().getOutputFile().get().getAsFile().toPath();
+		}
+
+		@Override
+		public void execute() {
+			val virtualDirectories = new ArrayList<VirtualFileSystemOverlay.VirtualDirectory>();
+			for (VFSOverlaySpec overlay : getParameters().getOverlays()) {
+				virtualDirectories.add(new VirtualFileSystemOverlay.VirtualDirectory(overlay.getName().get(), Streams.stream(overlay.getEntries()).map(it -> file(it.getName().get(), fileSystem.getPath(it.getLocation().get()))).collect(Collectors.toList())));
+			}
+
+			try (val writer = new VirtualFileSystemOverlayWriter(Files.newBufferedWriter(outputFile()))) {
+				writer.write(new VirtualFileSystemOverlay(virtualDirectories));
+			} catch (IOException e) {
+				throw new UncheckedIOException(e);
+			}
+		}
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/MergeVirtualFileSystemOverlaysTask.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/MergeVirtualFileSystemOverlaysTask.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay;
+
+import dev.nokee.buildadapter.xcode.internal.plugins.CopyTo;
+import dev.nokee.buildadapter.xcode.internal.plugins.ParameterizedTask;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.workers.WorkAction;
+import org.gradle.workers.WorkParameters;
+import org.gradle.workers.WorkerExecutor;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+public abstract class MergeVirtualFileSystemOverlaysTask extends ParameterizedTask<MergeVirtualFileSystemOverlaysTask.Parameters> {
+	@Inject
+	public MergeVirtualFileSystemOverlaysTask(WorkerExecutor workExecutor) {
+		super(TaskAction.class, workExecutor::noIsolation);
+	}
+
+	public interface Parameters extends WorkParameters, CopyTo<Parameters> {
+		@InputFiles
+		ConfigurableFileCollection getSources();
+
+		@Internal
+		DirectoryProperty getDerivedDataPath();
+
+		@OutputFile
+		RegularFileProperty getOutputFile();
+
+		@Override
+		default CopyTo<Parameters> copyTo(Parameters other) {
+			other.getSources().setFrom(getSources());
+			other.getDerivedDataPath().set(getDerivedDataPath());
+			other.getOutputFile().set(getOutputFile());
+			return this;
+		}
+	}
+
+	@Input
+	protected final Provider<String> getDerivedDataPathLocation() {
+		return getParameters().getDerivedDataPath().map(it -> it.getAsFile().getAbsolutePath());
+	}
+
+	public static abstract class TaskAction implements WorkAction<Parameters> {
+		@Override
+		public void execute() {
+			try {
+				final VirtualFileSystemOverlayMerger merger = new VirtualFileSystemOverlayMerger();
+				getParameters().getSources().getFiles().forEach(it -> merger.withOverlayFile(it.toPath()));
+				merger.rebaseOn(getParameters().getDerivedDataPath().get().getAsFile().toPath());
+				merger.mergeTo(getParameters().getOutputFile().get().getAsFile().toPath());
+			} catch (IOException e) {
+				throw new UncheckedIOException(e);
+			}
+		}
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/NamedDomainObject.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/NamedDomainObject.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay;
+
+import org.gradle.api.provider.Property;
+
+public interface NamedDomainObject {
+	Property<String> getName();
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/ObjectWriter.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/ObjectWriter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public interface ObjectWriter<T> {
+	void write(T t) throws IOException;
+
+	interface Factory<T> {
+		default ObjectWriter<T> create(Path path) throws IOException {
+			return create(Files.newBufferedWriter(path));
+		}
+
+		ObjectWriter<T> create(Writer writer) throws IOException;
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/VFSOverlayAction.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/VFSOverlayAction.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay;
+
+import com.google.common.collect.ImmutableList;
+import dev.nokee.buildadapter.xcode.internal.plugins.BuildSettingsResolveContext;
+import dev.nokee.buildadapter.xcode.internal.plugins.XcodeTargetExecTask;
+import dev.nokee.util.provider.ZipProviderBuilder;
+import dev.nokee.utils.FileSystemLocationUtils;
+import dev.nokee.utils.Optionals;
+import dev.nokee.xcode.XCBuildSettings;
+import dev.nokee.xcode.XCFileReference;
+import dev.nokee.xcode.XCFileReferencesLoader;
+import dev.nokee.xcode.XCLoaders;
+import dev.nokee.xcode.XCTargetReference;
+import dev.nokee.xcode.objects.buildphase.PBXBuildFile;
+import dev.nokee.xcode.objects.buildphase.PBXBuildPhase;
+import dev.nokee.xcode.objects.buildphase.PBXHeadersBuildPhase;
+import dev.nokee.xcode.objects.files.PBXFileReference;
+import dev.nokee.xcode.objects.files.PBXReference;
+import dev.nokee.xcode.objects.targets.PBXNativeTarget;
+import dev.nokee.xcode.objects.targets.PBXTarget;
+import dev.nokee.xcode.objects.targets.ProductTypes;
+import lombok.val;
+import org.gradle.api.Action;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Provider;
+
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+public final class VFSOverlayAction implements Action<ConfigurableContainer<VFSOverlaySpec>> {
+	private final ObjectFactory objects;
+	private final Provider<XCTargetReference> targetReferenceProvider;
+	private final Provider<XCBuildSettings> buildSettingsProvider;
+	private final Provider<Path> derivedDataPathProvider;
+
+	public VFSOverlayAction(ObjectFactory objects, Provider<XcodeTargetExecTask> targetTask) {
+		this(objects, targetTask.flatMap(it -> it.getTargetReference()), targetTask.flatMap(it -> it.getBuildSettings().asProvider()), targetTask.flatMap(it -> it.getOutputDirectory().map(FileSystemLocationUtils::asPath)));
+	}
+
+	public VFSOverlayAction(ObjectFactory objects, Provider<XCTargetReference> targetReferenceProvider, Provider<XCBuildSettings> buildSettingsProvider, Provider<Path> derivedDataPathProvider) {
+		this.objects = objects;
+		this.targetReferenceProvider = targetReferenceProvider;
+		this.buildSettingsProvider = buildSettingsProvider;
+		this.derivedDataPathProvider = derivedDataPathProvider;
+	}
+
+	@Override
+	public void execute(ConfigurableContainer<VFSOverlaySpec> specs) {
+		specs.addAll(ZipProviderBuilder.newBuilder(objects)
+			.value(targetReferenceProvider)
+			.value(buildSettingsProvider)
+			.value(derivedDataPathProvider)
+			.zip(values -> combine(values.get(0), values.get(1), values.get(2))));
+	}
+
+	public Iterable<? extends VFSOverlaySpec> combine(XCTargetReference targetReference, XCBuildSettings buildSettings, Path derivedDataPath) {
+		val context = new BuildSettingsResolveContext(FileSystems.getDefault(), buildSettings);
+		val fileRefs = XCLoaders.fileReferences().load(targetReference.getProject());
+		val target = XCLoaders.pbxtargetLoader().load(targetReference);
+
+
+		val remapping = Stream.of(target)
+			.filter(frameworkProducts())
+			.flatMap(headersBuildPhases())
+			.flatMap(publicHeaders())
+			.flatMap(localFileReferences())
+			.map(findReference(fileRefs))
+			.map(resolveReference(context))
+			.map(it -> newFileEntry(it.getFileName().toString(), it))
+			.collect(ImmutableList.toImmutableList());
+
+		if (!remapping.isEmpty()) {
+			val frameworkProductHeaderDir = XCFileReference.builtProduct("$(PUBLIC_HEADERS_FOLDER_PATH)").resolve(context);
+
+			val result = objects.newInstance(VFSOverlaySpec.class);
+			result.getName().set(derivedDataPath.relativize(frameworkProductHeaderDir).toString());
+			result.getEntries().addAll(remapping);
+			return ImmutableList.of(result);
+		} else {
+			return ImmutableList.of();
+		}
+	}
+
+	private VFSOverlaySpec.EntrySpec newFileEntry(String name, Path location) {
+		val result = objects.newInstance(VFSOverlaySpec.EntrySpec.class);
+		result.getName().set(name);
+		result.getLocation().set(location.toString());
+		return result;
+	}
+
+	private static Function<PBXReference, XCFileReference> findReference(XCFileReferencesLoader.XCFileReferences references) {
+		return references::get;
+	}
+
+	private static Function<XCFileReference, Path> resolveReference(XCFileReference.ResolveContext context) {
+		return it -> it.resolve(context);
+	}
+
+	private static Function<PBXTarget, Stream<PBXBuildPhase>> headersBuildPhases() {
+		return target -> target.getBuildPhases().stream().filter(PBXHeadersBuildPhase.class::isInstance);
+	}
+
+	private static Function<PBXBuildPhase, Stream<PBXBuildFile>> publicHeaders() {
+		return buildPhase -> buildPhase.getFiles().stream()
+			.filter(buildFile -> {
+				val attributes = buildFile.getSettings().get("ATTRIBUTES");
+				if (attributes instanceof List) {
+					return ((List<?>) attributes).contains("Public");
+				}
+				return false;
+			});
+	}
+
+	private static Function<PBXBuildFile, Stream<PBXFileReference>> localFileReferences() {
+		return buildFile -> Optionals.stream(buildFile.getFileRef()
+			.filter(it -> it instanceof PBXFileReference)
+			.map(PBXFileReference.class::cast));
+	}
+
+	private static Predicate<PBXTarget> frameworkProducts() {
+		return target -> target instanceof PBXNativeTarget && target.getProductType().map(ProductTypes.FRAMEWORK::equals).orElse(false);
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/VFSOverlayAction.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/VFSOverlayAction.java
@@ -53,7 +53,7 @@ public final class VFSOverlayAction implements Action<ConfigurableContainer<VFSO
 	private final Provider<Path> derivedDataPathProvider;
 
 	public VFSOverlayAction(ObjectFactory objects, Provider<XcodeTargetExecTask> targetTask) {
-		this(objects, targetTask.flatMap(it -> it.getTargetReference()), targetTask.flatMap(it -> it.getBuildSettings().asProvider()), targetTask.flatMap(it -> it.getOutputDirectory().map(FileSystemLocationUtils::asPath)));
+		this(objects, targetTask.flatMap(it -> it.getTargetReference()), targetTask.flatMap(it -> it.getBuildSettings().asProvider()), targetTask.flatMap(it -> it.getOutputDirectory().getLocationOnly().map(FileSystemLocationUtils::asPath)));
 	}
 
 	public VFSOverlayAction(ObjectFactory objects, Provider<XCTargetReference> targetReferenceProvider, Provider<XCBuildSettings> buildSettingsProvider, Provider<Path> derivedDataPathProvider) {

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/VFSOverlaySpec.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/VFSOverlaySpec.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay;
+
+import org.gradle.api.Action;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Nested;
+
+public interface VFSOverlaySpec extends NamedDomainObject {
+	@Override
+	@Input
+	Property<String> getName();
+
+	@Nested
+	ConfigurableEntries getEntries();
+
+	default void entries(Action<? super ConfigurableEntries> action) {
+		action.execute(getEntries());
+	}
+
+	interface EntrySpec extends NamedDomainObject {
+		@Override
+		@Input
+		Property<String> getName();
+
+		@Input
+		Property<String> getLocation();
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/VirtualFileSystemOverlay.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/VirtualFileSystemOverlay.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay;
+
+import java.io.Serializable;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+// The model is losely based on the unofficial vfsoverlay specification under https://llvm.org/doxygen/VirtualFileSystem_8h_source.html
+//   We made this decision with the idea the specification may change which the reader/writer will act as a buffer zone.
+//   It will ensure this model is not strictly tied to the specification causing all code depending on the model to be refactored.
+//   In the future, we should ensure the model represent *what* the overlay represent and leave the on-disk representation to the IO classes.
+public final class VirtualFileSystemOverlay implements Iterable<VirtualFileSystemOverlay.VirtualDirectory>, Serializable {
+	private final List<VirtualDirectory> roots;
+
+	public VirtualFileSystemOverlay(List<VirtualDirectory> roots) {
+		assert roots != null : "'roots' must not be null";
+		this.roots = roots;
+	}
+
+	@Override
+	public Iterator<VirtualDirectory> iterator() {
+		return roots.iterator();
+	}
+
+	@Override
+	public String toString() {
+		return toStringHelper(VirtualFileSystemOverlay.class)
+			.add("roots", roots)
+			.toString();
+	}
+
+	public static final class VirtualDirectory implements Iterable<VirtualDirectory.RemappedEntry>, Serializable {
+		private final String name;
+		private final List<RemappedEntry> contents;
+
+		public VirtualDirectory(String name, List<RemappedEntry> contents) {
+			this.name = name;
+			this.contents = contents;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		@Override
+		public Iterator<RemappedEntry> iterator() {
+			return contents.iterator();
+		}
+
+		@Override
+		public String toString() {
+			return toStringHelper(VirtualDirectory.class)
+				.add("name", name)
+				.add("contents", contents)
+				.toString();
+		}
+
+		public static RemappedEntry file(String path, Path location) {
+			// it should create a file remap, for now we only support file remap
+			return new RemappedEntry(path, location.toString());
+		}
+
+		public static final class RemappedEntry implements Serializable {
+			private final String name;
+			private final String externalContents;
+
+			public RemappedEntry(String name, String externalContents) {
+				this.name = name;
+				this.externalContents = externalContents;
+			}
+
+			public String getName() {
+				return name;
+			}
+
+			public String getExternalContents() {
+				return externalContents;
+			}
+
+			@Override
+			public String toString() {
+				return toStringHelper(RemappedEntry.class)
+					.add("name", name)
+					.add("externalContents", externalContents)
+					.toString();
+			}
+		}
+
+		public static Builder from(String path) {
+			return new Builder(path);
+		}
+
+		public static final class Builder {
+			private final List<RemappedEntry> entries = new ArrayList<>();
+			private final String name;
+
+			private Builder(String name) {
+				this.name = name;
+			}
+
+			public Builder remap(RemappedEntry entry) {
+				entries.add(entry);
+				return this;
+			}
+
+			public VirtualDirectory build() {
+				return new VirtualDirectory(name, entries);
+			}
+		}
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/VirtualFileSystemOverlayMerger.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/VirtualFileSystemOverlayMerger.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay;
+
+import com.google.common.collect.ImmutableList;
+import lombok.val;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class VirtualFileSystemOverlayMerger {
+	private final List<Path> files = new ArrayList<>();
+	private Path rebaseLocation;
+
+	public VirtualFileSystemOverlayMerger withOverlayFile(Path file) {
+		files.add(file);
+		return this;
+	}
+
+	public VirtualFileSystemOverlayMerger rebaseOn(Path path) {
+		rebaseLocation = path;
+		return this;
+	}
+
+	public void mergeTo(Path outputFile) throws IOException {
+		// Here were merge all vfsoverlay files together because -ivfsoverlay (clang) can only appear once as opposed to -vfsoverlay (swiftc)
+		try (val writer = new VirtualFileSystemOverlayWriter(Files.newBufferedWriter(outputFile))) {
+			val directories = ImmutableList.<VirtualFileSystemOverlay.VirtualDirectory>builder();
+			for (val overlayFile : files) {
+				try (val reader = new VirtualFileSystemOverlayReader(Files.newBufferedReader(overlayFile))) {
+					val overlay = reader.read();
+					overlay.forEach(it -> {
+						// We know that *our* vfsoverlay are relative to the derived data path,
+						//   so we need to resolve the virtual directory against the current derived data path.
+						directories.add(new VirtualFileSystemOverlay.VirtualDirectory(rebaseLocation.resolve(it.getName()).toString(), ImmutableList.copyOf(it)));
+					});
+				}
+			}
+
+			writer.write(new VirtualFileSystemOverlay(directories.build()));
+		}
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/VirtualFileSystemOverlayReader.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/VirtualFileSystemOverlayReader.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay;
+
+import com.google.common.collect.ImmutableList;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import lombok.val;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.List;
+
+// https://llvm.org/doxygen/VirtualFileSystem_8h_source.html
+public final class VirtualFileSystemOverlayReader implements AutoCloseable {
+	private final JsonReader reader;
+
+	public VirtualFileSystemOverlayReader(Reader delegate) {
+		this.reader = new JsonReader(delegate);
+	}
+
+	public VirtualFileSystemOverlay read() throws IOException {
+		List<VirtualFileSystemOverlay.VirtualDirectory> roots = null;
+
+		reader.beginObject();
+		while (reader.hasNext()) {
+			String fieldName = reader.nextName();
+			if (fieldName.equals("roots")) {
+				roots = readArray(reader, VirtualFileSystemOverlayReader::readVirtualDirectory);
+			} else {
+				reader.skipValue();
+			}
+		}
+		reader.endObject();
+
+		return new VirtualFileSystemOverlay(roots);
+	}
+
+	private static VirtualFileSystemOverlay.VirtualDirectory readVirtualDirectory(JsonReader reader) throws IOException {
+		String name = null;
+		List<VirtualFileSystemOverlay.VirtualDirectory.RemappedEntry> contents = null;
+
+		reader.beginObject();
+		while (reader.hasNext()) {
+			val fieldName = reader.nextName();
+			if (fieldName.equals("name")) {
+				name = reader.nextString();
+			} else if (fieldName.equals("contents")) {
+				contents = readArray(reader, VirtualFileSystemOverlayReader::readRemappedEntry);
+			} else {
+				reader.skipValue();
+			}
+		}
+		reader.endObject();
+
+		return new VirtualFileSystemOverlay.VirtualDirectory(name, contents);
+	}
+
+	private static VirtualFileSystemOverlay.VirtualDirectory.RemappedEntry readRemappedEntry(JsonReader reader) throws IOException {
+		String name = null;
+		String externalContents = null;
+
+		reader.beginObject();
+		while (reader.hasNext()) {
+			val fieldName = reader.nextName();
+			if (fieldName.equals("name")) {
+				name = reader.nextString();
+			} else if (fieldName.equals("external-contents")) {
+				externalContents = reader.nextString();
+			} else {
+				reader.skipValue();
+			}
+		}
+		reader.endObject();
+
+		return new VirtualFileSystemOverlay.VirtualDirectory.RemappedEntry(name, externalContents);
+	}
+
+	private static <T> List<T> readArray(JsonReader reader, Readable<T> elementReader) throws IOException {
+		if (reader.peek().equals(JsonToken.NULL)) {
+			return ImmutableList.of();
+		} else {
+			val builder = ImmutableList.<T>builder();
+			reader.beginArray();
+			while (reader.hasNext()) {
+				builder.add(elementReader.read(reader));
+			}
+			reader.endArray();
+
+			return builder.build();
+		}
+	}
+
+	@Override
+	public void close() throws IOException {
+		reader.close();
+	}
+
+	private interface Readable<T> {
+		T read(JsonReader reader) throws IOException;
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/VirtualFileSystemOverlayWriter.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/VirtualFileSystemOverlayWriter.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay;
+
+import com.google.gson.stream.JsonWriter;
+import lombok.val;
+
+import java.io.IOException;
+import java.io.Writer;
+
+// https://llvm.org/doxygen/VirtualFileSystem_8h_source.html
+public final class VirtualFileSystemOverlayWriter implements AutoCloseable, ObjectWriter<VirtualFileSystemOverlay> {
+	private final JsonWriter writer;
+
+	public VirtualFileSystemOverlayWriter(Writer delegate) {
+		this.writer = new JsonWriter(delegate);
+	}
+
+	public void write(VirtualFileSystemOverlay overlay) throws IOException {
+		writer.beginObject();
+		writer.name("version").value(0); // assume always version zero
+		writer.name("case-sensitive").value(Boolean.FALSE.toString()); // it seems this boolean is a string
+
+		writer.name("roots").beginArray();
+		for (val root : overlay) {
+			writer.beginObject();
+			writer.name("type").value("directory");
+			writer.name("name").value(root.getName());
+			writer.name("contents").beginArray();
+			for (val remapped : root) {
+				writer.beginObject();
+				writer.name("type").value("file");
+				writer.name("name").value(remapped.getName());
+				writer.name("external-contents").value(remapped.getExternalContents());
+				writer.endObject();
+			}
+			writer.endArray();
+			writer.endObject();
+		}
+		writer.endArray();
+
+		writer.endObject();
+		writer.flush();
+	}
+
+	@Override
+	public void close() throws IOException {
+		writer.close();
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/Writable.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/Writable.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.file.Path;
+
+public interface Writable<T> {
+	Path writeTo(Path path) throws IOException;
+
+	void writeTo(Writer out) throws IOException;
+}

--- a/subprojects/build-adapter-xcode/src/templates/virtual-file-system-overlays/MyFramework/MyFramework.h
+++ b/subprojects/build-adapter-xcode/src/templates/virtual-file-system-overlays/MyFramework/MyFramework.h
@@ -1,0 +1,18 @@
+//
+//  MyFramework.h
+//  MyFramework
+//
+//  Created by Daniel Lacasse on 2023-04-04.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for MyFramework.
+FOUNDATION_EXPORT double MyFrameworkVersionNumber;
+
+//! Project version string for MyFramework.
+FOUNDATION_EXPORT const unsigned char MyFrameworkVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <MyFramework/PublicHeader.h>
+
+

--- a/subprojects/build-adapter-xcode/src/templates/virtual-file-system-overlays/MyFramework/MyPrivateHeader.h
+++ b/subprojects/build-adapter-xcode/src/templates/virtual-file-system-overlays/MyFramework/MyPrivateHeader.h
@@ -1,0 +1,12 @@
+//
+//  MyPrivateHeader.h
+//  MyFramework
+//
+//  Created by Daniel Lacasse on 2023-04-04.
+//
+
+#ifndef MyPrivateHeader_h
+#define MyPrivateHeader_h
+
+
+#endif /* MyPrivateHeader_h */

--- a/subprojects/build-adapter-xcode/src/templates/virtual-file-system-overlays/MyFramework/MyProjectHeader.h
+++ b/subprojects/build-adapter-xcode/src/templates/virtual-file-system-overlays/MyFramework/MyProjectHeader.h
@@ -1,0 +1,12 @@
+//
+//  MyProjectHeader.h
+//  MyFramework
+//
+//  Created by Daniel Lacasse on 2023-04-04.
+//
+
+#ifndef MyProjectHeader_h
+#define MyProjectHeader_h
+
+
+#endif /* MyProjectHeader_h */

--- a/subprojects/build-adapter-xcode/src/templates/virtual-file-system-overlays/MyFramework/MyPublicHeader.h
+++ b/subprojects/build-adapter-xcode/src/templates/virtual-file-system-overlays/MyFramework/MyPublicHeader.h
@@ -1,0 +1,12 @@
+//
+//  MyPublicHeader.h
+//  MyFramework
+//
+//  Created by Daniel Lacasse on 2023-04-04.
+//
+
+#ifndef MyPublicHeader_h
+#define MyPublicHeader_h
+
+
+#endif /* MyPublicHeader_h */

--- a/subprojects/build-adapter-xcode/src/templates/virtual-file-system-overlays/VirtualFileSystemOverlays.xcodeproj/project.pbxproj
+++ b/subprojects/build-adapter-xcode/src/templates/virtual-file-system-overlays/VirtualFileSystemOverlays.xcodeproj/project.pbxproj
@@ -1,0 +1,340 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		6528577129DC44A7003C3524 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 6528577029DC44A7003C3524 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6528577629DC44D9003C3524 /* MyPublicHeader.h in Headers */ = {isa = PBXBuildFile; fileRef = 6528577529DC44D9003C3524 /* MyPublicHeader.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6528577829DC44E9003C3524 /* MyPrivateHeader.h in Headers */ = {isa = PBXBuildFile; fileRef = 6528577729DC44E8003C3524 /* MyPrivateHeader.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		6528577A29DC4505003C3524 /* MyProjectHeader.h in Headers */ = {isa = PBXBuildFile; fileRef = 6528577929DC4505003C3524 /* MyProjectHeader.h */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		6528576D29DC44A7003C3524 /* MyFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MyFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6528577029DC44A7003C3524 /* MyFramework.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MyFramework.h; sourceTree = "<group>"; };
+		6528577529DC44D9003C3524 /* MyPublicHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MyPublicHeader.h; sourceTree = "<group>"; };
+		6528577729DC44E8003C3524 /* MyPrivateHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MyPrivateHeader.h; sourceTree = "<group>"; };
+		6528577929DC4505003C3524 /* MyProjectHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MyProjectHeader.h; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		6528576A29DC44A7003C3524 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		6528576129DC4488003C3524 = {
+			isa = PBXGroup;
+			children = (
+				6528576F29DC44A7003C3524 /* MyFramework */,
+				6528576E29DC44A7003C3524 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		6528576E29DC44A7003C3524 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				6528576D29DC44A7003C3524 /* MyFramework.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		6528576F29DC44A7003C3524 /* MyFramework */ = {
+			isa = PBXGroup;
+			children = (
+				6528577029DC44A7003C3524 /* MyFramework.h */,
+				6528577529DC44D9003C3524 /* MyPublicHeader.h */,
+				6528577729DC44E8003C3524 /* MyPrivateHeader.h */,
+				6528577929DC4505003C3524 /* MyProjectHeader.h */,
+			);
+			path = MyFramework;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		6528576829DC44A7003C3524 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6528577629DC44D9003C3524 /* MyPublicHeader.h in Headers */,
+				6528577A29DC4505003C3524 /* MyProjectHeader.h in Headers */,
+				6528577829DC44E9003C3524 /* MyPrivateHeader.h in Headers */,
+				6528577129DC44A7003C3524 /* MyFramework.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		6528576C29DC44A7003C3524 /* MyFramework */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6528577229DC44A7003C3524 /* Build configuration list for PBXNativeTarget "MyFramework" */;
+			buildPhases = (
+				6528576829DC44A7003C3524 /* Headers */,
+				6528576929DC44A7003C3524 /* Sources */,
+				6528576A29DC44A7003C3524 /* Frameworks */,
+				6528576B29DC44A7003C3524 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MyFramework;
+			productName = MyFramework;
+			productReference = 6528576D29DC44A7003C3524 /* MyFramework.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		6528576229DC4488003C3524 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastUpgradeCheck = 1420;
+				TargetAttributes = {
+					6528576C29DC44A7003C3524 = {
+						CreatedOnToolsVersion = 14.2;
+					};
+				};
+			};
+			buildConfigurationList = 6528576529DC4488003C3524 /* Build configuration list for PBXProject "VirtualFileSystemOverlays" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 6528576129DC4488003C3524;
+			productRefGroup = 6528576E29DC44A7003C3524 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				6528576C29DC44A7003C3524 /* MyFramework */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		6528576B29DC44A7003C3524 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		6528576929DC44A7003C3524 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		6528576629DC4488003C3524 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		6528576729DC4488003C3524 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		6528577329DC44A7003C3524 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.nokee.samples.xcode.MyFramework;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		6528577429DC44A7003C3524 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.nokee.samples.xcode.MyFramework;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		6528576529DC4488003C3524 /* Build configuration list for PBXProject "VirtualFileSystemOverlays" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6528576629DC4488003C3524 /* Debug */,
+				6528576729DC4488003C3524 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6528577229DC44A7003C3524 /* Build configuration list for PBXNativeTarget "MyFramework" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6528577329DC44A7003C3524 /* Debug */,
+				6528577429DC44A7003C3524 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 6528576229DC4488003C3524 /* Project object */;
+}

--- a/subprojects/build-adapter-xcode/src/templates/virtual-file-system-overlays/VirtualFileSystemOverlays.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/subprojects/build-adapter-xcode/src/templates/virtual-file-system-overlays/VirtualFileSystemOverlays.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/subprojects/build-adapter-xcode/src/templates/virtual-file-system-overlays/VirtualFileSystemOverlays.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/subprojects/build-adapter-xcode/src/templates/virtual-file-system-overlays/VirtualFileSystemOverlays.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/subprojects/build-adapter-xcode/src/test/java/dev/nokee/buildadapter/xcode/BuildSettingsResolveContextTests.java
+++ b/subprojects/build-adapter-xcode/src/test/java/dev/nokee/buildadapter/xcode/BuildSettingsResolveContextTests.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import static com.google.common.jimfs.Configuration.unix;
 import static dev.nokee.internal.testing.FileSystemMatchers.absolutePath;
-import static dev.nokee.xcode.buildsettings.XCBuildSettingTestUtils.buildSettings;
+import static dev.nokee.buildadapter.xcode.testers.XCBuildSettingTestUtils.buildSettings;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 

--- a/subprojects/build-adapter-xcode/src/test/java/dev/nokee/buildadapter/xcode/VirtualFileSystemOverlayMergerTests.java
+++ b/subprojects/build-adapter-xcode/src/test/java/dev/nokee/buildadapter/xcode/VirtualFileSystemOverlayMergerTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.VirtualFileSystemOverlayMerger;
+import dev.nokee.buildadapter.xcode.testers.VirtualFileSystemOverlayMergeTester;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+class VirtualFileSystemOverlayMergerTests implements VirtualFileSystemOverlayMergeTester {
+	FileSystem fileSystem = Jimfs.newFileSystem(Configuration.osX());
+	Path testDirectory = fileSystem.getPath("test");
+
+	@BeforeEach
+	void exec() throws IOException {
+		VirtualFileSystemOverlayMerger subject = new VirtualFileSystemOverlayMerger();
+		inputFiles().forEach(subject::withOverlayFile);
+		subject.rebaseOn(derivedDataPath());
+		subject.mergeTo(outputFile());
+	}
+
+	@Override
+	public Path testDirectory() {
+		try {
+			return Files.createDirectories(testDirectory);
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+	}
+}

--- a/subprojects/build-adapter-xcode/src/test/java/dev/nokee/xcode/XCLoadersIntegrationTests.java
+++ b/subprojects/build-adapter-xcode/src/test/java/dev/nokee/xcode/XCLoadersIntegrationTests.java
@@ -15,6 +15,7 @@
  */
 package dev.nokee.xcode;
 
+import dev.nokee.xcode.objects.PBXProject;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -67,6 +68,16 @@ class XCLoadersIntegrationTests {
 	@Nested
 	class WhenAllTargetsLoader {
 		XCLoader<Set<XCTargetReference>, XCProjectReference> subject = XCLoaders.allTargetsLoader();
+
+		@Test
+		void canSerialize() {
+			assertThat(subject, isSerializable());
+		}
+	}
+
+	@Nested
+	class WhenPBXProjectLoader {
+		XCLoader<PBXProject, XCProjectReference> subject = XCLoaders.pbxprojectLoader();
 
 		@Test
 		void canSerialize() {

--- a/subprojects/build-adapter-xcode/src/test/java/dev/nokee/xcode/buildsettings/CompositeXCBuildSettingLayerTests.java
+++ b/subprojects/build-adapter-xcode/src/test/java/dev/nokee/xcode/buildsettings/CompositeXCBuildSettingLayerTests.java
@@ -21,9 +21,9 @@ import org.junit.jupiter.api.Test;
 
 import static com.google.common.collect.ImmutableList.of;
 import static dev.nokee.internal.testing.SerializableMatchers.isSerializable;
-import static dev.nokee.xcode.buildsettings.XCBuildSettingTestUtils.buildSetting;
-import static dev.nokee.xcode.buildsettings.XCBuildSettingTestUtils.buildSettingNamed;
-import static dev.nokee.xcode.buildsettings.XCBuildSettingTestUtils.layerOf;
+import static dev.nokee.buildadapter.xcode.testers.XCBuildSettingTestUtils.buildSetting;
+import static dev.nokee.buildadapter.xcode.testers.XCBuildSettingTestUtils.buildSettingNamed;
+import static dev.nokee.buildadapter.xcode.testers.XCBuildSettingTestUtils.layerOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;

--- a/subprojects/build-adapter-xcode/src/test/java/dev/nokee/xcode/buildsettings/DefaultXCBuildSettingLayerTests.java
+++ b/subprojects/build-adapter-xcode/src/test/java/dev/nokee/xcode/buildsettings/DefaultXCBuildSettingLayerTests.java
@@ -23,10 +23,10 @@ import lombok.val;
 import org.junit.jupiter.api.Test;
 
 import static dev.nokee.internal.testing.SerializableMatchers.isSerializable;
-import static dev.nokee.xcode.buildsettings.XCBuildSettingTestUtils.buildSetting;
-import static dev.nokee.xcode.buildsettings.XCBuildSettingTestUtils.buildSettingNamed;
-import static dev.nokee.xcode.buildsettings.XCBuildSettingTestUtils.mapOf;
-import static dev.nokee.xcode.buildsettings.XCBuildSettingTestUtils.nullBuildSetting;
+import static dev.nokee.buildadapter.xcode.testers.XCBuildSettingTestUtils.buildSetting;
+import static dev.nokee.buildadapter.xcode.testers.XCBuildSettingTestUtils.buildSettingNamed;
+import static dev.nokee.buildadapter.xcode.testers.XCBuildSettingTestUtils.mapOf;
+import static dev.nokee.buildadapter.xcode.testers.XCBuildSettingTestUtils.nullBuildSetting;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;

--- a/subprojects/build-adapter-xcode/src/test/java/dev/nokee/xcode/buildsettings/DefaultXCBuildSettingSearchContextTests.java
+++ b/subprojects/build-adapter-xcode/src/test/java/dev/nokee/xcode/buildsettings/DefaultXCBuildSettingSearchContextTests.java
@@ -18,7 +18,7 @@ package dev.nokee.xcode.buildsettings;
 import dev.nokee.xcode.DefaultXCBuildSettingSearchContext;
 import org.junit.jupiter.api.Test;
 
-import static dev.nokee.xcode.buildsettings.XCBuildSettingTestUtils.nullBuildSetting;
+import static dev.nokee.buildadapter.xcode.testers.XCBuildSettingTestUtils.nullBuildSetting;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 

--- a/subprojects/build-adapter-xcode/src/test/java/dev/nokee/xcode/buildsettings/DefaultXCBuildSettingsTests.java
+++ b/subprojects/build-adapter-xcode/src/test/java/dev/nokee/xcode/buildsettings/DefaultXCBuildSettingsTests.java
@@ -31,11 +31,11 @@ import java.util.Map;
 import java.util.function.Function;
 
 import static dev.nokee.internal.testing.SerializableMatchers.isSerializable;
-import static dev.nokee.xcode.buildsettings.XCBuildSettingTestUtils.buildSetting;
-import static dev.nokee.xcode.buildsettings.XCBuildSettingTestUtils.evaluateTo;
-import static dev.nokee.xcode.buildsettings.XCBuildSettingTestUtils.evaluateToNested;
-import static dev.nokee.xcode.buildsettings.XCBuildSettingTestUtils.evaluateToNull;
-import static dev.nokee.xcode.buildsettings.XCBuildSettingTestUtils.throwsException;
+import static dev.nokee.buildadapter.xcode.testers.XCBuildSettingTestUtils.buildSetting;
+import static dev.nokee.buildadapter.xcode.testers.XCBuildSettingTestUtils.evaluateTo;
+import static dev.nokee.buildadapter.xcode.testers.XCBuildSettingTestUtils.evaluateToNested;
+import static dev.nokee.buildadapter.xcode.testers.XCBuildSettingTestUtils.evaluateToNull;
+import static dev.nokee.buildadapter.xcode.testers.XCBuildSettingTestUtils.throwsException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;

--- a/subprojects/build-adapter-xcode/src/testFixtures/java/dev/nokee/buildadapter/xcode/testers/VirtualFileSystemOverlayGenerateTester.java
+++ b/subprojects/build-adapter-xcode/src/testFixtures/java/dev/nokee/buildadapter/xcode/testers/VirtualFileSystemOverlayGenerateTester.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.testers;
+
+import com.google.common.collect.ImmutableList;
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.VirtualFileSystemOverlay;
+import lombok.val;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static dev.nokee.buildadapter.xcode.testers.VirtualFileSystemOverlayTestUtils.overlayAt;
+import static dev.nokee.buildadapter.xcode.testers.VirtualFileSystemOverlayTestUtils.remappedFile;
+import static dev.nokee.internal.testing.FileSystemMatchers.withAbsolutePath;
+import static dev.nokee.internal.testing.GradleNamedMatchers.named;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.endsWith;
+
+public interface VirtualFileSystemOverlayGenerateTester {
+	Path testDirectory();
+
+	default Path outputFile() {
+		return testDirectory().resolve("out.yaml");
+	}
+
+	default VirtualFileSystemOverlay overlay() {
+		return new VirtualFileSystemOverlay(ImmutableList.of(new VirtualFileSystemOverlay.VirtualDirectory("Build/Products/MyFramework.framework/Headers", ImmutableList.of(new VirtualFileSystemOverlay.VirtualDirectory.RemappedEntry("MyFramework.h", testDirectory().resolve("MyFramework/MyFramework.h").toString()), new VirtualFileSystemOverlay.VirtualDirectory.RemappedEntry("MyPublicHeader.h", testDirectory().resolve("MyFramework/MyPublicHeader.h").toString())))));
+	}
+
+	@Test
+	default void canGenerateOverlayFile() throws IOException {
+		val result = overlayAt(testDirectory().resolve("out.yaml"));
+		assertThat(result, contains(allOf(
+			named("Build/Products/MyFramework.framework/Headers"),
+			containsInAnyOrder(
+				remappedFile("MyFramework.h", withAbsolutePath(endsWith("/MyFramework/MyFramework.h"))),
+				remappedFile("MyPublicHeader.h", withAbsolutePath(endsWith("/MyFramework/MyPublicHeader.h")))
+			))));
+	}
+}

--- a/subprojects/build-adapter-xcode/src/testFixtures/java/dev/nokee/buildadapter/xcode/testers/VirtualFileSystemOverlayMergeTester.java
+++ b/subprojects/build-adapter-xcode/src/testFixtures/java/dev/nokee/buildadapter/xcode/testers/VirtualFileSystemOverlayMergeTester.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.testers;
+
+import com.google.common.collect.ImmutableList;
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.VirtualFileSystemOverlayReader;
+import lombok.val;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.VirtualFileSystemOverlay.VirtualDirectory.file;
+import static dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.VirtualFileSystemOverlay.VirtualDirectory.from;
+import static dev.nokee.buildadapter.xcode.testers.VirtualFileSystemOverlayTestUtils.overlayOf;
+import static dev.nokee.buildadapter.xcode.testers.VirtualFileSystemOverlayTestUtils.remappedFile;
+import static dev.nokee.internal.testing.FileSystemMatchers.withAbsolutePath;
+import static dev.nokee.internal.testing.GradleNamedMatchers.named;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.endsWith;
+
+public interface VirtualFileSystemOverlayMergeTester {
+	Path testDirectory();
+
+	default Path outputFile() {
+		return testDirectory().resolve("all-products-headers.yaml");
+	}
+
+	default List<Path> inputFiles() {
+		return ImmutableList.of(testDirectory().resolve("foo.yaml"), testDirectory().resolve("bar.yaml"));
+	}
+
+	default Path derivedDataPath() {
+		return testDirectory().resolve("derived-data");
+	}
+
+	@BeforeEach
+	default void givenOverlayFiles() throws Exception {
+		assert inputFiles().size() == 2;
+		overlayOf(from("Build/Products/Foo.framework/Headers")
+			.remap(file("Foo.h", testDirectory().resolve("Foo/Foo.h")))
+			.remap(file("MyFoo.h", testDirectory().resolve("Foo/MyFoo.h"))).build())
+			.writeTo(inputFiles().get(0));
+		overlayOf(from("Build/Products/Bar.framework/Headers")
+			.remap(file("Bar.h", testDirectory().resolve("Bar/Bar.h"))).build())
+			.writeTo(inputFiles().get(1));
+	}
+
+	@Test
+	default void mergesOverlays() throws IOException {
+		try (val reader = new VirtualFileSystemOverlayReader(Files.newBufferedReader(outputFile()))) {
+			val result = reader.read();
+			assertThat(result, contains(
+				allOf(named(endsWith("Build/Products/Foo.framework/Headers")),
+					containsInAnyOrder(
+						remappedFile("Foo.h", withAbsolutePath(endsWith("/Foo/Foo.h"))),
+						remappedFile("MyFoo.h", withAbsolutePath(endsWith("/Foo/MyFoo.h")))
+					)),
+				allOf(named(endsWith("Build/Products/Bar.framework/Headers")),
+					containsInAnyOrder(
+						remappedFile("Bar.h", withAbsolutePath(endsWith("/Bar/Bar.h")))
+					))
+			));
+		}
+	}
+
+	@Test
+	default void rebaseVirtualDirectoriesToCurrentDerivedDataPath() throws IOException {
+		try (val reader = new VirtualFileSystemOverlayReader(Files.newBufferedReader(outputFile()))) {
+			val result = reader.read();
+			assertThat(result, contains(
+				named(derivedDataPath().resolve("Build/Products/Foo.framework/Headers").toString()),
+				named(derivedDataPath().resolve("Build/Products/Bar.framework/Headers").toString())
+			));
+		}
+	}
+}

--- a/subprojects/build-adapter-xcode/src/testFixtures/java/dev/nokee/buildadapter/xcode/testers/VirtualFileSystemOverlayMergeTester.java
+++ b/subprojects/build-adapter-xcode/src/testFixtures/java/dev/nokee/buildadapter/xcode/testers/VirtualFileSystemOverlayMergeTester.java
@@ -30,6 +30,7 @@ import static dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.VirtualFi
 import static dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.VirtualFileSystemOverlay.VirtualDirectory.from;
 import static dev.nokee.buildadapter.xcode.testers.VirtualFileSystemOverlayTestUtils.overlayOf;
 import static dev.nokee.buildadapter.xcode.testers.VirtualFileSystemOverlayTestUtils.remappedFile;
+import static dev.nokee.internal.testing.FileSystemMatchers.aFile;
 import static dev.nokee.internal.testing.FileSystemMatchers.withAbsolutePath;
 import static dev.nokee.internal.testing.GradleNamedMatchers.named;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -70,12 +71,12 @@ public interface VirtualFileSystemOverlayMergeTester {
 		try (val reader = new VirtualFileSystemOverlayReader(Files.newBufferedReader(outputFile()))) {
 			val result = reader.read();
 			assertThat(result, contains(
-				allOf(named(endsWith("Build/Products/Foo.framework/Headers")),
+				allOf(named(aFile(withAbsolutePath(endsWith("Build/Products/Foo.framework/Headers")))),
 					containsInAnyOrder(
 						remappedFile("Foo.h", withAbsolutePath(endsWith("/Foo/Foo.h"))),
 						remappedFile("MyFoo.h", withAbsolutePath(endsWith("/Foo/MyFoo.h")))
 					)),
-				allOf(named(endsWith("Build/Products/Bar.framework/Headers")),
+				allOf(named(aFile(withAbsolutePath(endsWith("Build/Products/Bar.framework/Headers")))),
 					containsInAnyOrder(
 						remappedFile("Bar.h", withAbsolutePath(endsWith("/Bar/Bar.h")))
 					))

--- a/subprojects/build-adapter-xcode/src/testFixtures/java/dev/nokee/buildadapter/xcode/testers/VirtualFileSystemOverlayTestUtils.java
+++ b/subprojects/build-adapter-xcode/src/testFixtures/java/dev/nokee/buildadapter/xcode/testers/VirtualFileSystemOverlayTestUtils.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.testers;
+
+import com.google.common.collect.ImmutableList;
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.DefaultWritable;
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.VFSOverlaySpec;
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.VirtualFileSystemOverlay;
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.VirtualFileSystemOverlayReader;
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.VirtualFileSystemOverlayWriter;
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.Writable;
+import lombok.val;
+import org.gradle.api.provider.Provider;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static dev.nokee.internal.testing.GradleNamedMatchers.named;
+import static org.hamcrest.Matchers.allOf;
+
+public final class VirtualFileSystemOverlayTestUtils {
+
+	public static VirtualFileSystemOverlay overlayAt(Path path) throws IOException {
+		try (val reader = new VirtualFileSystemOverlayReader(Files.newBufferedReader(path))) {
+			return reader.read();
+		}
+	}
+
+	public static Matcher<VirtualFileSystemOverlay.VirtualDirectory.RemappedEntry> remappedFile(String name, Matcher<? super File> matcher) {
+		return allOf(named(name), new FeatureMatcher<VirtualFileSystemOverlay.VirtualDirectory.RemappedEntry, File>(matcher, "", "") {
+			@Override
+			protected File featureValueOf(VirtualFileSystemOverlay.VirtualDirectory.RemappedEntry actual) {
+				return Paths.get(actual.getExternalContents()).toFile();
+			}
+		});
+	}
+
+	public static Writable<VirtualFileSystemOverlay> overlayOf(VirtualFileSystemOverlay.VirtualDirectory virtualDirectory) {
+		return new DefaultWritable<>(VirtualFileSystemOverlayWriter::new, new VirtualFileSystemOverlay(ImmutableList.of(virtualDirectory)));
+	}
+
+	public static Matcher<VFSOverlaySpec> entries(Matcher<? super Iterable<VFSOverlaySpec.EntrySpec>> matcher) {
+		return new FeatureMatcher<VFSOverlaySpec, Iterable<VFSOverlaySpec.EntrySpec>>(matcher, "", "") {
+
+			@Override
+			protected Iterable<VFSOverlaySpec.EntrySpec> featureValueOf(VFSOverlaySpec actual) {
+				return actual.getEntries();
+			}
+		};
+	}
+
+	public static Matcher<VFSOverlaySpec.EntrySpec> location(Matcher<? super Provider<String>> matcher) {
+		return new FeatureMatcher<VFSOverlaySpec.EntrySpec, Provider<String>>(matcher, "", "") {
+			@Override
+			protected Provider<String> featureValueOf(VFSOverlaySpec.EntrySpec actual) {
+				return actual.getLocation();
+			}
+		};
+	}
+}

--- a/subprojects/build-adapter-xcode/src/testFixtures/java/dev/nokee/buildadapter/xcode/testers/VirtualFileSystemOverlayTestUtils.java
+++ b/subprojects/build-adapter-xcode/src/testFixtures/java/dev/nokee/buildadapter/xcode/testers/VirtualFileSystemOverlayTestUtils.java
@@ -62,7 +62,7 @@ public final class VirtualFileSystemOverlayTestUtils {
 
 			@Override
 			protected Iterable<VFSOverlaySpec.EntrySpec> featureValueOf(VFSOverlaySpec actual) {
-				return actual.getEntries();
+				return actual.getEntries().getElements().get();
 			}
 		};
 	}

--- a/subprojects/build-adapter-xcode/src/testFixtures/java/dev/nokee/buildadapter/xcode/testers/XCBuildSettingTestUtils.java
+++ b/subprojects/build-adapter-xcode/src/testFixtures/java/dev/nokee/buildadapter/xcode/testers/XCBuildSettingTestUtils.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.nokee.xcode.buildsettings;
+package dev.nokee.buildadapter.xcode.testers;
 
 import com.google.common.collect.ImmutableMap;
 import dev.nokee.xcode.DefaultXCBuildSetting;
@@ -130,5 +130,14 @@ public class XCBuildSettingTestUtils {
 		builderAction.accept(builder);
 		final Map<String, String> values = builder.build();
 		return new DefaultXCBuildSettings(new DefaultXCBuildSettingLayer(values.entrySet().stream().map(it -> new DefaultXCBuildSetting(it.getKey(), XCString.of(it.getValue()))).collect(ImmutableMap.toImmutableMap(XCBuildSetting::getName, Function.identity()))));
+	}
+
+	public static Matcher<XCBuildSettings> hasBuildSetting(String name, String resolved) {
+		return new FeatureMatcher<XCBuildSettings, String>(equalTo(resolved), "", "") {
+			@Override
+			protected String featureValueOf(XCBuildSettings actual) {
+				return actual.get(name);
+			}
+		};
 	}
 }

--- a/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/FileSystemMatchers.java
+++ b/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/FileSystemMatchers.java
@@ -30,6 +30,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Arrays;
@@ -69,6 +70,8 @@ public final class FileSystemMatchers {
 					return ((Path) actual).toFile();
 				} else if (actual instanceof DescendantFile) {
 					return ((DescendantFile) actual).getFile();
+				} else if (actual instanceof String) {
+					return Paths.get((String) actual).toFile(); // TODO: we should validate the string represent a path
 				} else if (actual instanceof Provider) {
 					throw new IllegalArgumentException("Please make sure there is not confusion between Provider#map vs Provider#flatMap. Otherwise, use GradleProviderMatchers#providerOf.");
 				} else {

--- a/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/GradleNamedMatchers.java
+++ b/subprojects/internal-testing/src/main/java/dev/nokee/internal/testing/GradleNamedMatchers.java
@@ -20,6 +20,7 @@ import org.gradle.api.NamedDomainObjectCollectionSchema;
 import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
@@ -75,6 +76,12 @@ public final class GradleNamedMatchers {
 					if (String.class.isAssignableFrom(getNameMethod.getReturnType())) {
 						try {
 							return (String) getNameMethod.invoke(actual);
+						} catch (InvocationTargetException | IllegalAccessException e) {
+							throw new RuntimeException(e);
+						}
+					} else if (Provider.class.isAssignableFrom(getNameMethod.getReturnType())) {
+						try {
+							return (String) ((Provider) getNameMethod.invoke(actual)).getOrNull();
 						} catch (InvocationTargetException | IllegalAccessException e) {
 							throw new RuntimeException(e);
 						}


### PR DESCRIPTION
Because of our target isolation trick, Xcode is not properly identifying the headers belonging to dependencies, thus having a difficult time handling them. Within a workspace, Xcode will automatically generate the VFS overlays. However, in a single target build, this is not the case. We believe this behaviour is to work around misconfigurations of the builds where some include path points into the product directory while simultaneously referencing headers in the PBXGroup. The overlays help overcome this by matching the headers from the Products to their original source.