### PR TITLE
Ensure Swift package dependencies behave after target isolation

### DIFF
--- a/subprojects/build-adapter-xcode/src/integrationTest/java/dev/nokee/buildadapter/xcode/vfsoverlays/GenerateVirtualFileSystemOverlaysTaskActionIntegrationTests.java
+++ b/subprojects/build-adapter-xcode/src/integrationTest/java/dev/nokee/buildadapter/xcode/vfsoverlays/GenerateVirtualFileSystemOverlaysTaskActionIntegrationTests.java
@@ -15,7 +15,7 @@
  */
 package dev.nokee.buildadapter.xcode.vfsoverlays;
 
-import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.ConfigurableContainer;
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.ConfigurableMapContainer;
 import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.GenerateVirtualFileSystemOverlaysTask.Parameters;
 import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.GenerateVirtualFileSystemOverlaysTask.TaskAction;
 import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.VFSOverlaySpec;
@@ -50,7 +50,7 @@ class GenerateVirtualFileSystemOverlaysTaskActionIntegrationTests implements Vir
 		subject.execute();
 	}
 
-	static Action<ConfigurableContainer<VFSOverlaySpec>> toOverlays(Iterable<VirtualFileSystemOverlay.VirtualDirectory> roots) {
+	static Action<ConfigurableMapContainer<VFSOverlaySpec>> toOverlays(Iterable<VirtualFileSystemOverlay.VirtualDirectory> roots) {
 		return it -> {
 			for (VirtualFileSystemOverlay.VirtualDirectory root : roots) {
 				it.create(root.getName(), toEntries(root));

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/GenerateSwiftPackageManifestTask.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/GenerateSwiftPackageManifestTask.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal.plugins;
+
+import dev.nokee.xcode.XCLoaders;
+import dev.nokee.xcode.XCProjectReference;
+import dev.nokee.xcode.objects.targets.PBXNativeTarget;
+import dev.nokee.xcode.project.CodeableXCSwiftPackageProductDependency;
+import lombok.val;
+import org.apache.commons.lang3.SerializationUtils;
+import org.apache.tools.ant.taskdefs.XSLTProcess;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.workers.WorkAction;
+import org.gradle.workers.WorkParameters;
+import org.gradle.workers.WorkerExecutor;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+
+public abstract class GenerateSwiftPackageManifestTask extends ParameterizedTask<GenerateSwiftPackageManifestTask.Parameters> {
+	@Inject
+	public GenerateSwiftPackageManifestTask(WorkerExecutor workerExecutor) {
+		super(TaskAction.class, workerExecutor::noIsolation);
+	}
+
+	public interface Parameters extends WorkParameters, CopyTo<Parameters> {
+		@InputDirectory
+		DirectoryProperty getProjectLocation();
+
+		@Input
+		Property<String> getTargetName();
+
+		@OutputFile
+		RegularFileProperty getManifestFile();
+
+		@Override
+		default CopyTo<Parameters> copyTo(Parameters other) {
+			other.getManifestFile().set(getManifestFile());
+			other.getTargetName().set(getTargetName());
+			other.getProjectLocation().set(getProjectLocation());
+			return this;
+		}
+	}
+
+	public static abstract class TaskAction implements WorkAction<Parameters> {
+		@Override
+		public void execute() {
+			val target = XCLoaders.pbxtargetLoader().load(XCProjectReference.of(getParameters().getProjectLocation().get().getAsFile().toPath()).ofTarget(getParameters().getTargetName().get()));
+			ArrayList<XCTargetIsolationTask.PackageRef> packagesGids = new ArrayList<>();
+			if (target instanceof PBXNativeTarget) {
+				((PBXNativeTarget) target).getPackageProductDependencies().stream().forEach(it -> packagesGids.add(new XCTargetIsolationTask.PackageRef(it.getProductName(), ((CodeableXCSwiftPackageProductDependency) it).globalId())));
+			}
+
+			try (val outStream = Files.newOutputStream(getParameters().getManifestFile().get().getAsFile().toPath())) {
+				SerializationUtils.serialize(packagesGids, outStream);
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+		}
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/ProvidedBuildSettingsBuilder.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/ProvidedBuildSettingsBuilder.java
@@ -54,7 +54,6 @@ public final class ProvidedBuildSettingsBuilder {
 		assert reference != null : "'reference' must not be null";
 		buildSettings.put("PROJECT_NAME", reference.map(it -> it.getProject().getName()));
 		buildSettings.put("TARGET_NAME", reference.map(it -> it.getName()));
-		buildSettings.put("SRCROOT", reference.map(it -> it.getProject().getLocation().getParent().toString()));
 		return this;
 	}
 

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XCTargetIsolationTask.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XCTargetIsolationTask.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal.plugins;
+
+import dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay.ConfigurableSetContainer;
+import dev.nokee.xcode.XCLoaders;
+import dev.nokee.xcode.XCProjectReference;
+import dev.nokee.xcode.objects.PBXProject;
+import dev.nokee.xcode.objects.targets.TargetDependenciesAwareBuilder;
+import dev.nokee.xcode.project.PBXObjectArchiver;
+import dev.nokee.xcode.project.PBXProjWriter;
+import lombok.EqualsAndHashCode;
+import lombok.val;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.FileSystemOperations;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.workers.WorkAction;
+import org.gradle.workers.WorkParameters;
+import org.gradle.workers.WorkerExecutor;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.io.Serializable;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.util.stream.Collectors;
+
+import static com.google.common.collect.ImmutableList.of;
+
+public abstract class XCTargetIsolationTask extends ParameterizedTask<XCTargetIsolationTask.Parameters> {
+
+	@Inject
+	public XCTargetIsolationTask(WorkerExecutor workerExecutor) {
+		super(TaskAction.class, workerExecutor::noIsolation);
+	}
+
+	public interface Parameters extends WorkParameters, CopyTo<Parameters> {
+		@Nested
+		ConfigurableIsolations getIsolations();
+
+		@InputDirectory
+		DirectoryProperty getOriginalProjectLocation();
+
+		@OutputDirectory
+		DirectoryProperty getIsolatedProjectLocation();
+
+		@Override
+		default CopyTo<Parameters> copyTo(Parameters other) {
+			other.getIsolatedProjectLocation().set(getIsolatedProjectLocation());
+			other.getOriginalProjectLocation().set(getOriginalProjectLocation());
+			other.getIsolations().addAll(getIsolations());
+			return this;
+		}
+	}
+
+	public static abstract class ConfigurableIsolations extends ConfigurableSetContainer<IsolationSpec> {}
+
+	public interface IsolationSpec {
+		PBXProject apply(PBXProject project);
+	}
+
+	public static abstract class IsolateTargetSpec implements IsolationSpec {
+		@Input
+		public abstract Property<String> getTargetNameToIsolate();
+
+		@Override
+		public PBXProject apply(PBXProject project) {
+			return project.toBuilder()
+				.targets(project.getTargets().stream()
+					.filter(target -> target.getName().equals(getTargetNameToIsolate().get()))
+					.map(target -> {
+						val builder = target.toBuilder();
+						((TargetDependenciesAwareBuilder<?>) builder).dependencies(of());
+						return builder.build();
+					}).collect(Collectors.toList()))
+				.build();
+		}
+	}
+
+	@EqualsAndHashCode
+	public static final class PackageRef implements Serializable {
+		private final String productName;
+		private final String globalId;
+
+		public PackageRef(String productName, String globalId) {
+			this.productName = productName;
+			this.globalId = globalId;
+		}
+
+		public String getProductName() {
+			return productName;
+		}
+
+		public String getGlobalId() {
+			return globalId;
+		}
+	}
+
+	public static abstract class TaskAction implements WorkAction<Parameters> {
+		private final FileSystemOperations fileOperations;
+
+		@Inject
+		public TaskAction(FileSystemOperations fileOperations) {
+			this.fileOperations = fileOperations;
+		}
+
+		@Override
+		public void execute() {
+			val originalProjectLocation = getParameters().getOriginalProjectLocation().get().getAsFile().toPath();
+			val isolatedProjectLocation = getParameters().getIsolatedProjectLocation().get().getAsFile().toPath();
+			fileOperations.sync(spec -> {
+				spec.from(originalProjectLocation);
+				spec.into(isolatedProjectLocation);
+			});
+
+			PBXProject project = XCLoaders.pbxprojectLoader().load(XCProjectReference.of(originalProjectLocation));
+
+			project = project.toBuilder().projectDirPath(originalProjectLocation.getParent().toString()).build();
+
+			for (IsolationSpec spec : getParameters().getIsolations().getElements().get()) {
+				project = spec.apply(project);
+			}
+
+			try (val writer = new PBXProjWriter(Files.newBufferedWriter(isolatedProjectLocation.resolve("project.pbxproj")))) {
+				writer.write(new PBXObjectArchiver().encode(project));
+			} catch (IOException e) {
+				throw new UncheckedIOException(e);
+			}
+		}
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeBuildAdapterPlugin.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeBuildAdapterPlugin.java
@@ -316,7 +316,7 @@ public class XcodeBuildAdapterPlugin implements Plugin<Settings> {
 						});
 					});
 
-				val generateTask = project.getExtensions().getByType(ModelRegistry.class).register(DomainObjectEntities.newEntity(TaskName.of("generate", "virtualFileSystemOverlays"), GenerateVirtualFileSystemOverlaysTask.class, it -> it.ownedBy(entity)))
+				val generateVirtualSystemOverlaysTask = project.getExtensions().getByType(ModelRegistry.class).register(DomainObjectEntities.newEntity(TaskName.of("generate", "virtualFileSystemOverlays"), GenerateVirtualFileSystemOverlaysTask.class, it -> it.ownedBy(entity)))
 					.as(GenerateVirtualFileSystemOverlaysTask.class)
 					.configure(task -> {
 						task.parameters(parameters -> {
@@ -336,7 +336,7 @@ public class XcodeBuildAdapterPlugin implements Plugin<Settings> {
 					.configure(configuration -> {
 						configuration.outgoing(outgoing -> {
 							outgoing.capability("net.nokeedev.xcode:" + project.getName() + "-" + target.getName() + ":1.0");
-							outgoing.artifact(generateTask.flatMap(it -> it.getParameters().getOutputFile()));
+							outgoing.artifact(generateVirtualSystemOverlaysTask.flatMap(it -> it.getParameters().getOutputFile()));
 						});
 					});
 			})));

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeBuildAdapterPlugin.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeBuildAdapterPlugin.java
@@ -280,6 +280,7 @@ public class XcodeBuildAdapterPlugin implements Plugin<Settings> {
 						task.getOutputDirectory().set(project.getLayout().getBuildDirectory().dir("derivedData/" + task.getName()));
 						task.getXcodeInstallation().set(project.getProviders().of(CurrentXcodeInstallationValueSource.class, ActionUtils.doNothing()));
 						task.getConfiguration().set(variantInfo.getName());
+						task.getBuildSettings().from(ImmutableMap.of("SRCROOT", reference.getLocation().getParent().toString()));
 						task.getArguments().add(new CommandLineArgumentProvider() {
 							@InputFile
 							@PathSensitive(PathSensitivity.ABSOLUTE)

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeTargetExecTask.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeTargetExecTask.java
@@ -25,7 +25,6 @@ import dev.nokee.core.exec.CommandLineToolInvocation;
 import dev.nokee.util.provider.ZipProviderBuilder;
 import dev.nokee.utils.FileSystemLocationUtils;
 import dev.nokee.xcode.CompositeXCBuildSettingLayer;
-import dev.nokee.xcode.DefaultXCBuildSettings;
 import dev.nokee.xcode.XCBuildSetting;
 import dev.nokee.xcode.XCBuildSettingLayer;
 import dev.nokee.xcode.XCBuildSettings;
@@ -119,9 +118,6 @@ public abstract class XcodeTargetExecTask extends DefaultTask implements Xcodebu
 		return targetReference;
 	}
 
-	@Internal
-	public abstract Property<XCBuildSettings> getAllBuildSettings();
-
 	@Nested
 	public Provider<XCBuildPlan> getBuildPlan() {
 		return buildSpec;
@@ -145,10 +141,8 @@ public abstract class XcodeTargetExecTask extends DefaultTask implements Xcodebu
 		this.targetReference = ZipProviderBuilder.newBuilder(objects).value(getXcodeProject()).value(getTargetName())
 			.zip(XCProjectReference::ofTarget);
 
-		getAllBuildSettings().value(new DefaultXCBuildSettings(new CompositeXCBuildSettingLayer(ImmutableList.of(overrideLayer(), xcodebuildLayer()))));
-
 		this.buildSpec = finalizeValueOnRead(objects.property(XCBuildPlan.class).value(getTargetReference().map(XCLoaders.buildSpecLoader()::load).map(spec -> {
-			final XCBuildSettings buildSettings = getAllBuildSettings().get();
+			final XCBuildSettings buildSettings = getBuildSettings();
 
 			val context = new BuildSettingsResolveContext(FileSystems.getDefault(), buildSettings);
 			val fileRefs = XCLoaders.fileReferences().load(getXcodeProject().get());

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/ConfigurableEntries.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/ConfigurableEntries.java
@@ -15,5 +15,5 @@
  */
 package dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay;
 
-public abstract class ConfigurableEntries extends ConfigurableContainer<VFSOverlaySpec.EntrySpec> {
+public abstract class ConfigurableEntries extends ConfigurableMapContainer<VFSOverlaySpec.EntrySpec> {
 }

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/ConfigurableMapContainer.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/ConfigurableMapContainer.java
@@ -33,7 +33,7 @@ import java.util.function.Function;
 //   In a @Nested context, Gradle will prefer unpacking (iterate) the object instead of looking for more
 //   @Nested properties which would discover the implicit task dependencies. Instead, users should use
 //   #getElements() provider and iterate the value.
-public abstract class ConfigurableContainer<T extends NamedDomainObject> {
+public abstract class ConfigurableMapContainer<T extends NamedDomainObject> {
 	public T create(String name, Action<? super T> action) {
 		T result = getObjects().newInstance(defaultType());
 		result.getName().set(name);
@@ -58,7 +58,7 @@ public abstract class ConfigurableContainer<T extends NamedDomainObject> {
 		return true;
 	}
 
-	public boolean addAll(ConfigurableContainer<? extends T> container) {
+	public boolean addAll(ConfigurableMapContainer<? extends T> container) {
 		getValues().putAll(container.getValues());
 		return true;
 	}
@@ -82,7 +82,7 @@ public abstract class ConfigurableContainer<T extends NamedDomainObject> {
 		return getValues().map(Map::values);
 	}
 
-	public ConfigurableContainer<T> configure(Action<? super ConfigurableContainer<T>> action) {
+	public ConfigurableMapContainer<T> configure(Action<? super ConfigurableMapContainer<T>> action) {
 		action.execute(this);
 		return this;
 	}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/ConfigurableMapContainer.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/ConfigurableMapContainer.java
@@ -35,7 +35,16 @@ import java.util.function.Function;
 //   #getElements() provider and iterate the value.
 public abstract class ConfigurableMapContainer<T extends NamedDomainObject> {
 	public T create(String name, Action<? super T> action) {
-		T result = getObjects().newInstance(defaultType());
+		final T result = getObjects().newInstance(defaultType());
+		result.getName().set(name);
+		result.getName().finalizeValue();
+		action.execute(result);
+		getValues().put(name, result);
+		return result;
+	}
+
+	public <S extends T> S create(String name, Class<S> type, Action<? super S> action) {
+		final S result = getObjects().newInstance(type);
 		result.getName().set(name);
 		result.getName().finalizeValue();
 		action.execute(result);

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/ConfigurableOverlays.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/ConfigurableOverlays.java
@@ -15,5 +15,5 @@
  */
 package dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay;
 
-public abstract class ConfigurableOverlays extends ConfigurableContainer<VFSOverlaySpec> {
+public abstract class ConfigurableOverlays extends ConfigurableMapContainer<VFSOverlaySpec> {
 }

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/ConfigurableSetContainer.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/ConfigurableSetContainer.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal.plugins.vfsoverlay;
+
+import com.google.common.reflect.TypeToken;
+import org.gradle.api.Action;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Nested;
+
+import javax.inject.Inject;
+import java.util.Set;
+
+// Note: we cannot declare this class as Iterable<T> because we are typically using it in a @Nested context
+//   In a @Nested context, Gradle will prefer unpacking (iterate) the object instead of looking for more
+//   @Nested properties which would discover the implicit task dependencies. Instead, users should use
+//   #getElements() provider and iterate the value.
+public abstract class ConfigurableSetContainer<T> {
+	public T create(Action<? super T> action) {
+		final T result = getObjects().newInstance(defaultType());
+		action.execute(result);
+		getValues().add(result);
+		return result;
+	}
+
+	public <S extends T> S create(Class<S> type, Action<? super S> action) {
+		final S result = getObjects().newInstance(type);
+		action.execute(result);
+		getValues().add(result);
+		return result;
+	}
+
+	@SuppressWarnings("unchecked")
+	private Class<T> defaultType() {
+		return (Class<T>) new TypeToken<T>(getClass()) {}.getRawType();
+	}
+
+	public boolean addAll(Iterable<? extends T> l) {
+		getValues().addAll(l);
+		return true;
+	}
+
+	public boolean addAll(Provider<? extends Iterable<? extends T>> provider) {
+		getValues().addAll(provider);
+		return true;
+	}
+
+	public boolean addAll(ConfigurableSetContainer<? extends T> container) {
+		getValues().addAll(container.getValues());
+		return true;
+	}
+
+	public void clear() {
+		getValues().empty();
+	}
+
+	@Inject
+	protected abstract ObjectFactory getObjects();
+
+	@Internal
+	protected abstract SetProperty<T> getValues();
+
+	@Nested
+	public Provider<Set<T>> getElements() {
+		return getValues();
+	}
+
+	public ConfigurableSetContainer<T> configure(Action<? super ConfigurableSetContainer<T>> action) {
+		action.execute(this);
+		return this;
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/VFSOverlayAction.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/VFSOverlayAction.java
@@ -53,7 +53,7 @@ public final class VFSOverlayAction implements Action<ConfigurableMapContainer<V
 	private final Provider<Path> derivedDataPathProvider;
 
 	public VFSOverlayAction(ObjectFactory objects, Provider<XcodeTargetExecTask> targetTask) {
-		this(objects, targetTask.flatMap(it -> it.getTargetReference()), targetTask.flatMap(it -> it.getBuildSettings().asProvider()), targetTask.flatMap(it -> it.getOutputDirectory().getLocationOnly().map(FileSystemLocationUtils::asPath)));
+		this(objects, targetTask.flatMap(it -> it.getTargetReference()), targetTask.flatMap(it -> it.getBuildSettings().asProvider()), targetTask.flatMap(it -> it.getDerivedDataPath().getLocationOnly().map(FileSystemLocationUtils::asPath)));
 	}
 
 	public VFSOverlayAction(ObjectFactory objects, Provider<XCTargetReference> targetReferenceProvider, Provider<XCBuildSettings> buildSettingsProvider, Provider<Path> derivedDataPathProvider) {

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/VFSOverlayAction.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/vfsoverlay/VFSOverlayAction.java
@@ -46,7 +46,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-public final class VFSOverlayAction implements Action<ConfigurableContainer<VFSOverlaySpec>> {
+public final class VFSOverlayAction implements Action<ConfigurableMapContainer<VFSOverlaySpec>> {
 	private final ObjectFactory objects;
 	private final Provider<XCTargetReference> targetReferenceProvider;
 	private final Provider<XCBuildSettings> buildSettingsProvider;
@@ -64,7 +64,7 @@ public final class VFSOverlayAction implements Action<ConfigurableContainer<VFSO
 	}
 
 	@Override
-	public void execute(ConfigurableContainer<VFSOverlaySpec> specs) {
+	public void execute(ConfigurableMapContainer<VFSOverlaySpec> specs) {
 		specs.addAll(ZipProviderBuilder.newBuilder(objects)
 			.value(targetReferenceProvider)
 			.value(buildSettingsProvider)

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/targets/PBXNativeTarget.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/targets/PBXNativeTarget.java
@@ -28,6 +28,7 @@ import dev.nokee.xcode.project.KeyedObject;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Consumer;
 
 import static com.google.common.collect.Streams.stream;
 import static dev.nokee.xcode.project.DefaultKeyedObject.key;
@@ -123,6 +124,13 @@ public interface PBXNativeTarget extends PBXTarget {
 
 		public Builder packageProductDependencies(Iterable<? extends XCSwiftPackageProductDependency> packageProductDependencies) {
 			builder.put(CodeablePBXNativeTarget.CodingKeys.packageProductDependencies, packageProductDependencies);
+			return this;
+		}
+
+		public Builder packageProductDependency(Consumer<? super XCSwiftPackageProductDependency.Builder> builderConsumer) {
+			XCSwiftPackageProductDependency.Builder builder = new XCSwiftPackageProductDependency.Builder();
+			builderConsumer.accept(builder);
+			this.builder.add(CodeablePBXNativeTarget.CodingKeys.packageProductDependencies, builder.build());
 			return this;
 		}
 


### PR DESCRIPTION
When isolating the Xcode targets, the transitive Swift package dependencies are lost. This PR ensure they are passed down to the consuming projects.