### PR TITLE
Fix gaps in Swift PM dependencies isolation

### DIFF
--- a/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/swiftpm/GenerateSwiftPackageManifestTaskFunctionalTests.java
+++ b/subprojects/build-adapter-xcode/src/functionalTest/java/dev/nokee/buildadapter/xcode/swiftpm/GenerateSwiftPackageManifestTaskFunctionalTests.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.swiftpm;
+
+import dev.gradleplugins.buildscript.blocks.ProjectBlock;
+import dev.gradleplugins.buildscript.statements.ExpressionStatement;
+import dev.gradleplugins.runnerkit.GradleRunner;
+import dev.nokee.SwiftPackageProductDependencies;
+import dev.nokee.buildadapter.xcode.internal.plugins.GenerateSwiftPackageManifestTask;
+import dev.nokee.internal.testing.junit.jupiter.ContextualGradleRunnerParameterResolver;
+import dev.nokee.xcode.objects.swiftpackage.XCSwiftPackageProductDependency;
+import lombok.val;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectory;
+import net.nokeedev.testing.junit.jupiter.io.TestDirectoryExtension;
+import org.apache.commons.lang3.SerializationUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static dev.gradleplugins.buildscript.blocks.BuildScriptBlock.classpath;
+import static dev.gradleplugins.buildscript.blocks.DependencyNotation.files;
+import static dev.gradleplugins.buildscript.syntax.Syntax.groovy;
+import static dev.nokee.internal.testing.GradleRunnerMatchers.succeed;
+import static dev.nokee.xcode.objects.swiftpackage.XCRemoteSwiftPackageReference.VersionRequirement.Kind.UP_TO_NEXT_MAJOR_VERSION;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.iterableWithSize;
+
+@ExtendWith({TestDirectoryExtension.class, ContextualGradleRunnerParameterResolver.class})
+class GenerateSwiftPackageManifestTaskFunctionalTests {
+	@TestDirectory Path testDirectory;
+	GradleRunner executer;
+
+	@BeforeEach
+	void given(GradleRunner runner) throws IOException {
+		executer = runner.withTasks("verify");
+
+		new SwiftPackageProductDependencies().writeToProject(testDirectory);
+
+		ProjectBlock.builder()
+			.buildscript(it -> it.dependencies(classpath(files(runner.getPluginClasspath()))))
+			.add(ExpressionStatement.of(groovy(Stream.of(
+				"import " + GenerateSwiftPackageManifestTask.class.getCanonicalName(),
+				"tasks.register('verify', " + GenerateSwiftPackageManifestTask.class.getSimpleName() + ") {",
+				"  parameters {",
+				"    project.location = file('SwiftPackageProductDependencies.xcodeproj')",
+				"    manifestFile = file('swift-pm.manifest')",
+				"  }",
+				"}",
+				"").collect(Collectors.joining("\n")))))
+			.build().writeTo(testDirectory.resolve("build.gradle"));
+	}
+
+	@Nested
+	class NoSwiftPackageTests {
+		List<XCSwiftPackageProductDependency> result;
+
+		@BeforeEach
+		void given() throws IOException {
+			ExpressionStatement.of(groovy(Stream.of(
+				"tasks.named('verify', " + GenerateSwiftPackageManifestTask.class.getSimpleName() + ") {",
+				"  parameters {",
+				"    targetName = 'WithoutSwiftProductDependencies'",
+				"  }",
+				"}",
+				"").collect(Collectors.joining("\n")))).appendTo(testDirectory.resolve("build.gradle"));
+
+			assertThat(executer.build().task(":verify"), succeed());
+
+			try (val inStream = Files.newInputStream(testDirectory.resolve("swift-pm.manifest"))) {
+				result = SerializationUtils.deserialize(inStream);
+			}
+		}
+
+		@Test
+		void hasNoSwiftPackageProductDependencies() {
+			assertThat(result, emptyIterable());
+		}
+	}
+
+	@Nested
+	class WithSwiftPackageTests {
+		List<XCSwiftPackageProductDependency> result;
+
+		@BeforeEach
+		void given() throws IOException {
+			ExpressionStatement.of(groovy(Stream.of(
+				"tasks.named('verify', " + GenerateSwiftPackageManifestTask.class.getSimpleName() + ") {",
+				"  parameters {",
+				"    targetName = 'WithSwiftProductDependencies'",
+				"  }",
+				"}",
+				"").collect(Collectors.joining("\n")))).appendTo(testDirectory.resolve("build.gradle"));
+
+			assertThat(executer.build().task(":verify"), succeed());
+
+			try (val inStream = Files.newInputStream(testDirectory.resolve("swift-pm.manifest"))) {
+				result = SerializationUtils.deserialize(inStream);
+			}
+		}
+
+		@Test
+		void hasExpectedSwiftPackageProductDependencies() {
+			assertThat(result, iterableWithSize(2));
+			assertThat(result.get(0).getProductName(), equalTo("NIO"));
+			assertThat(result.get(0).getPackageReference().getRepositoryUrl(), equalTo("https://github.com/apple/swift-nio.git"));
+			assertThat(result.get(0).getPackageReference().getRequirement().getKind(), equalTo(UP_TO_NEXT_MAJOR_VERSION));
+			assertThat(result.get(1).getProductName(), equalTo("ArgumentParser"));
+			assertThat(result.get(1).getPackageReference().getRepositoryUrl(), equalTo("https://github.com/apple/swift-argument-parser.git"));
+			assertThat(result.get(1).getPackageReference().getRequirement().getKind(), equalTo(UP_TO_NEXT_MAJOR_VERSION));
+		}
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/ConfigurableXCProjectLocation.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/ConfigurableXCProjectLocation.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.buildadapter.xcode.internal.plugins;
+
+import dev.nokee.utils.FileSystemLocationUtils;
+import dev.nokee.xcode.XCProjectReference;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.FileTree;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
+
+public abstract class ConfigurableXCProjectLocation {
+	@Internal
+	public abstract DirectoryProperty getLocation();
+
+	public ConfigurableXCProjectLocation from(XCProjectReference projectReference) {
+		getLocation().set(projectReference.getLocation().toFile());
+		return this;
+	}
+
+	@Internal
+	public Provider<XCProjectReference> getAsReference() {
+		return getLocation().map(FileSystemLocationUtils::asPath).map(XCProjectReference::of);
+	}
+
+	public Object asInput() {
+		return new Object() {
+			@InputFiles
+			public FileTree getInputFiles() {
+				return getLocation().getAsFileTree().matching(it -> it.exclude("**/xcuserdata/**"));
+			}
+		};
+	}
+}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/GenerateSwiftPackageManifestTask.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/GenerateSwiftPackageManifestTask.java
@@ -16,9 +16,8 @@
 package dev.nokee.buildadapter.xcode.internal.plugins;
 
 import dev.nokee.xcode.XCLoaders;
-import dev.nokee.xcode.XCProjectReference;
+import dev.nokee.xcode.objects.swiftpackage.XCSwiftPackageProductDependency;
 import dev.nokee.xcode.objects.targets.PBXNativeTarget;
-import dev.nokee.xcode.project.CodeableXCSwiftPackageProductDependency;
 import lombok.val;
 import org.apache.commons.lang3.SerializationUtils;
 import org.gradle.api.file.RegularFileProperty;
@@ -69,13 +68,13 @@ public abstract class GenerateSwiftPackageManifestTask extends ParameterizedTask
 		@Override
 		public void execute() {
 			val target = XCLoaders.pbxtargetLoader().load(getParameters().getProject().getAsReference().get().ofTarget(getParameters().getTargetName().get()));
-			ArrayList<XCTargetIsolationTask.PackageRef> packagesGids = new ArrayList<>();
+			val productDependencies = new ArrayList<XCSwiftPackageProductDependency>();
 			if (target instanceof PBXNativeTarget) {
-				((PBXNativeTarget) target).getPackageProductDependencies().stream().forEach(it -> packagesGids.add(new XCTargetIsolationTask.PackageRef(it.getProductName(), ((CodeableXCSwiftPackageProductDependency) it).globalId())));
+				productDependencies.addAll(((PBXNativeTarget) target).getPackageProductDependencies());
 			}
 
 			try (val outStream = Files.newOutputStream(getParameters().getManifestFile().get().getAsFile().toPath())) {
-				SerializationUtils.serialize(packagesGids, outStream);
+				SerializationUtils.serialize(productDependencies, outStream);
 			} catch (IOException e) {
 				throw new RuntimeException(e);
 			}

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeBuildAdapterPlugin.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeBuildAdapterPlugin.java
@@ -294,7 +294,7 @@ public class XcodeBuildAdapterPlugin implements Plugin<Settings> {
 					.as(XCTargetIsolationTask.class)
 					.configure(task -> {
 						task.parameters(parameters -> {
-							parameters.getOriginalProjectLocation().set(reference.getLocation().toFile());
+							parameters.getOriginalProject().from(reference);
 							parameters.getIsolatedProjectLocation().set(project.getLayout().getBuildDirectory().dir(temporaryDirectoryPath(task) + "/" + reference.getLocation().getFileName().toString()));
 							parameters.getIsolations().create(XCTargetIsolationTask.IsolateTargetSpec.class, it -> {
 								it.getTargetNameToIsolate().set(target.getName());
@@ -391,7 +391,7 @@ public class XcodeBuildAdapterPlugin implements Plugin<Settings> {
 					.as(GenerateSwiftPackageManifestTask.class)
 					.configure(task -> {
 						task.parameters(parameters -> {
-							parameters.getProjectLocation().set(reference.getLocation().toFile());
+							parameters.getProject().from(reference);
 							parameters.getTargetName().set(target.getName());
 							parameters.getManifestFile().set(project.getLayout().getBuildDirectory().file(temporaryDirectoryPath(task) + "/remote-swift-packages.manifest"));
 						});

--- a/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeBuildAdapterPlugin.java
+++ b/subprojects/build-adapter-xcode/src/main/java/dev/nokee/buildadapter/xcode/internal/plugins/XcodeBuildAdapterPlugin.java
@@ -69,6 +69,7 @@ import dev.nokee.xcode.XCDependenciesLoader;
 import dev.nokee.xcode.XCLoaders;
 import dev.nokee.xcode.XCProjectReference;
 import dev.nokee.xcode.XCTargetReference;
+import dev.nokee.xcode.objects.swiftpackage.XCSwiftPackageProductDependency;
 import lombok.val;
 import org.apache.commons.lang3.SerializationUtils;
 import org.gradle.api.Action;
@@ -304,8 +305,7 @@ public class XcodeBuildAdapterPlugin implements Plugin<Settings> {
 								it.getPackageProductDependencies().addAll(remoteSwiftPackages.flatMap(t -> t.getElements()).map(t -> {
 									return t.stream().map(FileSystemLocationUtils::asPath).flatMap(a -> {
 										try (val inStream = Files.newInputStream(a)) {
-											List<XCTargetIsolationTask.PackageRef> result = SerializationUtils.deserialize(inStream);
-											return result.stream();
+											return SerializationUtils.<List<XCSwiftPackageProductDependency>>deserialize(inStream).stream();
 										} catch (IOException e) {
 											throw new UncheckedIOException(e);
 										}

--- a/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/SwiftPackageProductDependencies.xcodeproj/project.pbxproj
+++ b/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/SwiftPackageProductDependencies.xcodeproj/project.pbxproj
@@ -1,0 +1,619 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		6511B1FD2A06749600D00FA0 /* WithoutSwiftProductDependenciesApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6511B1FC2A06749600D00FA0 /* WithoutSwiftProductDependenciesApp.swift */; };
+		6511B1FF2A06749600D00FA0 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6511B1FE2A06749600D00FA0 /* ContentView.swift */; };
+		6511B2012A06749800D00FA0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6511B2002A06749800D00FA0 /* Assets.xcassets */; };
+		6511B2042A06749800D00FA0 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6511B2032A06749800D00FA0 /* Preview Assets.xcassets */; };
+		6511B2102A0674AE00D00FA0 /* WithSwiftProductDependenciesApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6511B20F2A0674AE00D00FA0 /* WithSwiftProductDependenciesApp.swift */; };
+		6511B2122A0674AE00D00FA0 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6511B2112A0674AE00D00FA0 /* ContentView.swift */; };
+		6511B2142A0674AF00D00FA0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6511B2132A0674AF00D00FA0 /* Assets.xcassets */; };
+		6511B2172A0674AF00D00FA0 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6511B2162A0674AF00D00FA0 /* Preview Assets.xcassets */; };
+		6511B21E2A0675D500D00FA0 /* NIO in Frameworks */ = {isa = PBXBuildFile; productRef = 6511B21D2A0675D500D00FA0 /* NIO */; };
+		6511B2212A0675FB00D00FA0 /* ArgumentParser in Frameworks */ = {isa = PBXBuildFile; productRef = 6511B2202A0675FB00D00FA0 /* ArgumentParser */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		6511B1F92A06749600D00FA0 /* WithoutSwiftProductDependencies.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WithoutSwiftProductDependencies.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		6511B1FC2A06749600D00FA0 /* WithoutSwiftProductDependenciesApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithoutSwiftProductDependenciesApp.swift; sourceTree = "<group>"; };
+		6511B1FE2A06749600D00FA0 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		6511B2002A06749800D00FA0 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		6511B2032A06749800D00FA0 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		6511B2052A06749800D00FA0 /* WithoutSwiftProductDependencies.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = WithoutSwiftProductDependencies.entitlements; sourceTree = "<group>"; };
+		6511B20D2A0674AE00D00FA0 /* WithSwiftProductDependencies.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WithSwiftProductDependencies.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		6511B20F2A0674AE00D00FA0 /* WithSwiftProductDependenciesApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithSwiftProductDependenciesApp.swift; sourceTree = "<group>"; };
+		6511B2112A0674AE00D00FA0 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		6511B2132A0674AF00D00FA0 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		6511B2162A0674AF00D00FA0 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		6511B2182A0674AF00D00FA0 /* WithSwiftProductDependencies.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = WithSwiftProductDependencies.entitlements; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		6511B1F62A06749600D00FA0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6511B20A2A0674AE00D00FA0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6511B2212A0675FB00D00FA0 /* ArgumentParser in Frameworks */,
+				6511B21E2A0675D500D00FA0 /* NIO in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		6511B1EE2A06740700D00FA0 = {
+			isa = PBXGroup;
+			children = (
+				6511B1FB2A06749600D00FA0 /* WithoutSwiftProductDependencies */,
+				6511B20E2A0674AE00D00FA0 /* WithSwiftProductDependencies */,
+				6511B1FA2A06749600D00FA0 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		6511B1FA2A06749600D00FA0 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				6511B1F92A06749600D00FA0 /* WithoutSwiftProductDependencies.app */,
+				6511B20D2A0674AE00D00FA0 /* WithSwiftProductDependencies.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		6511B1FB2A06749600D00FA0 /* WithoutSwiftProductDependencies */ = {
+			isa = PBXGroup;
+			children = (
+				6511B1FC2A06749600D00FA0 /* WithoutSwiftProductDependenciesApp.swift */,
+				6511B1FE2A06749600D00FA0 /* ContentView.swift */,
+				6511B2002A06749800D00FA0 /* Assets.xcassets */,
+				6511B2052A06749800D00FA0 /* WithoutSwiftProductDependencies.entitlements */,
+				6511B2022A06749800D00FA0 /* Preview Content */,
+			);
+			path = WithoutSwiftProductDependencies;
+			sourceTree = "<group>";
+		};
+		6511B2022A06749800D00FA0 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				6511B2032A06749800D00FA0 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		6511B20E2A0674AE00D00FA0 /* WithSwiftProductDependencies */ = {
+			isa = PBXGroup;
+			children = (
+				6511B20F2A0674AE00D00FA0 /* WithSwiftProductDependenciesApp.swift */,
+				6511B2112A0674AE00D00FA0 /* ContentView.swift */,
+				6511B2132A0674AF00D00FA0 /* Assets.xcassets */,
+				6511B2182A0674AF00D00FA0 /* WithSwiftProductDependencies.entitlements */,
+				6511B2152A0674AF00D00FA0 /* Preview Content */,
+			);
+			path = WithSwiftProductDependencies;
+			sourceTree = "<group>";
+		};
+		6511B2152A0674AF00D00FA0 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				6511B2162A0674AF00D00FA0 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		6511B1F82A06749600D00FA0 /* WithoutSwiftProductDependencies */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6511B2082A06749800D00FA0 /* Build configuration list for PBXNativeTarget "WithoutSwiftProductDependencies" */;
+			buildPhases = (
+				6511B1F52A06749600D00FA0 /* Sources */,
+				6511B1F62A06749600D00FA0 /* Frameworks */,
+				6511B1F72A06749600D00FA0 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = WithoutSwiftProductDependencies;
+			productName = WithoutSwiftProductDependencies;
+			productReference = 6511B1F92A06749600D00FA0 /* WithoutSwiftProductDependencies.app */;
+			productType = "com.apple.product-type.application";
+		};
+		6511B20C2A0674AE00D00FA0 /* WithSwiftProductDependencies */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6511B2192A0674AF00D00FA0 /* Build configuration list for PBXNativeTarget "WithSwiftProductDependencies" */;
+			buildPhases = (
+				6511B2092A0674AE00D00FA0 /* Sources */,
+				6511B20A2A0674AE00D00FA0 /* Frameworks */,
+				6511B20B2A0674AE00D00FA0 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = WithSwiftProductDependencies;
+			packageProductDependencies = (
+				6511B21D2A0675D500D00FA0 /* NIO */,
+				6511B2202A0675FB00D00FA0 /* ArgumentParser */,
+			);
+			productName = WithSwiftProductDependencies;
+			productReference = 6511B20D2A0674AE00D00FA0 /* WithSwiftProductDependencies.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		6511B1EF2A06740700D00FA0 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1420;
+				LastUpgradeCheck = 1420;
+				TargetAttributes = {
+					6511B1F82A06749600D00FA0 = {
+						CreatedOnToolsVersion = 14.2;
+					};
+					6511B20C2A0674AE00D00FA0 = {
+						CreatedOnToolsVersion = 14.2;
+					};
+				};
+			};
+			buildConfigurationList = 6511B1F22A06740700D00FA0 /* Build configuration list for PBXProject "SwiftPackageProductDependencies" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 6511B1EE2A06740700D00FA0;
+			packageReferences = (
+				6511B21C2A0675D500D00FA0 /* XCRemoteSwiftPackageReference "swift-nio" */,
+				6511B21F2A0675FB00D00FA0 /* XCRemoteSwiftPackageReference "swift-argument-parser" */,
+			);
+			productRefGroup = 6511B1FA2A06749600D00FA0 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				6511B1F82A06749600D00FA0 /* WithoutSwiftProductDependencies */,
+				6511B20C2A0674AE00D00FA0 /* WithSwiftProductDependencies */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		6511B1F72A06749600D00FA0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6511B2042A06749800D00FA0 /* Preview Assets.xcassets in Resources */,
+				6511B2012A06749800D00FA0 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6511B20B2A0674AE00D00FA0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6511B2172A0674AF00D00FA0 /* Preview Assets.xcassets in Resources */,
+				6511B2142A0674AF00D00FA0 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		6511B1F52A06749600D00FA0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6511B1FF2A06749600D00FA0 /* ContentView.swift in Sources */,
+				6511B1FD2A06749600D00FA0 /* WithoutSwiftProductDependenciesApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6511B2092A0674AE00D00FA0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6511B2122A0674AE00D00FA0 /* ContentView.swift in Sources */,
+				6511B2102A0674AE00D00FA0 /* WithSwiftProductDependenciesApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		6511B1F32A06740700D00FA0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		6511B1F42A06740700D00FA0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		6511B2062A06749800D00FA0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_ENTITLEMENTS = WithoutSwiftProductDependencies/WithoutSwiftProductDependencies.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_ASSET_PATHS = "\"WithoutSwiftProductDependencies/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 12.5;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.nokee.samples.xcode.WithoutSwiftProductDependencies;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		6511B2072A06749800D00FA0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_ENTITLEMENTS = WithoutSwiftProductDependencies/WithoutSwiftProductDependencies.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_ASSET_PATHS = "\"WithoutSwiftProductDependencies/Preview Content\"";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 12.5;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.nokee.samples.xcode.WithoutSwiftProductDependencies;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		6511B21A2A0674AF00D00FA0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_ENTITLEMENTS = WithSwiftProductDependencies/WithSwiftProductDependencies.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_ASSET_PATHS = "\"WithSwiftProductDependencies/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 12.5;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.nokee.samples.xcode.WithSwiftProductDependencies;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		6511B21B2A0674AF00D00FA0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_ENTITLEMENTS = WithSwiftProductDependencies/WithSwiftProductDependencies.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_ASSET_PATHS = "\"WithSwiftProductDependencies/Preview Content\"";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 12.5;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.nokee.samples.xcode.WithSwiftProductDependencies;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		6511B1F22A06740700D00FA0 /* Build configuration list for PBXProject "SwiftPackageProductDependencies" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6511B1F32A06740700D00FA0 /* Debug */,
+				6511B1F42A06740700D00FA0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6511B2082A06749800D00FA0 /* Build configuration list for PBXNativeTarget "WithoutSwiftProductDependencies" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6511B2062A06749800D00FA0 /* Debug */,
+				6511B2072A06749800D00FA0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6511B2192A0674AF00D00FA0 /* Build configuration list for PBXNativeTarget "WithSwiftProductDependencies" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6511B21A2A0674AF00D00FA0 /* Debug */,
+				6511B21B2A0674AF00D00FA0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		6511B21C2A0675D500D00FA0 /* XCRemoteSwiftPackageReference "swift-nio" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-nio.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
+			};
+		};
+		6511B21F2A0675FB00D00FA0 /* XCRemoteSwiftPackageReference "swift-argument-parser" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-argument-parser.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		6511B21D2A0675D500D00FA0 /* NIO */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6511B21C2A0675D500D00FA0 /* XCRemoteSwiftPackageReference "swift-nio" */;
+			productName = NIO;
+		};
+		6511B2202A0675FB00D00FA0 /* ArgumentParser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6511B21F2A0675FB00D00FA0 /* XCRemoteSwiftPackageReference "swift-argument-parser" */;
+			productName = ArgumentParser;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 6511B1EF2A06740700D00FA0 /* Project object */;
+}

--- a/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/SwiftPackageProductDependencies.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/SwiftPackageProductDependencies.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/SwiftPackageProductDependencies.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/SwiftPackageProductDependencies.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/SwiftPackageProductDependencies.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/SwiftPackageProductDependencies.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,41 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "fee6933f37fde9a5e12a1e4aeaa93fe60116ff2a",
+        "version" : "1.2.2"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "6c89474e62719ddcc1e9614989fff2f68208fe10",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
+        "version" : "1.0.4"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "546eaa261ec5028b9cc5c7fa883fba9dd5881a3b",
+        "version" : "2.52.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/WithSwiftProductDependencies/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/WithSwiftProductDependencies/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/WithSwiftProductDependencies/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/WithSwiftProductDependencies/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/WithSwiftProductDependencies/Assets.xcassets/Contents.json
+++ b/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/WithSwiftProductDependencies/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/WithSwiftProductDependencies/ContentView.swift
+++ b/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/WithSwiftProductDependencies/ContentView.swift
@@ -1,0 +1,26 @@
+//
+//  ContentView.swift
+//  WithSwiftProductDependencies
+//
+//  Created by Daniel Lacasse on 2023-05-06.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundColor(.accentColor)
+            Text("Hello, world!")
+        }
+        .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/WithSwiftProductDependencies/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/WithSwiftProductDependencies/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/WithSwiftProductDependencies/WithSwiftProductDependencies.entitlements
+++ b/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/WithSwiftProductDependencies/WithSwiftProductDependencies.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-only</key>
+    <true/>
+</dict>
+</plist>

--- a/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/WithSwiftProductDependencies/WithSwiftProductDependenciesApp.swift
+++ b/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/WithSwiftProductDependencies/WithSwiftProductDependenciesApp.swift
@@ -1,0 +1,17 @@
+//
+//  WithSwiftProductDependenciesApp.swift
+//  WithSwiftProductDependencies
+//
+//  Created by Daniel Lacasse on 2023-05-06.
+//
+
+import SwiftUI
+
+@main
+struct WithSwiftProductDependenciesApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/WithoutSwiftProductDependencies/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/WithoutSwiftProductDependencies/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/WithoutSwiftProductDependencies/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/WithoutSwiftProductDependencies/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/WithoutSwiftProductDependencies/Assets.xcassets/Contents.json
+++ b/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/WithoutSwiftProductDependencies/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/WithoutSwiftProductDependencies/ContentView.swift
+++ b/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/WithoutSwiftProductDependencies/ContentView.swift
@@ -1,0 +1,26 @@
+//
+//  ContentView.swift
+//  WithoutSwiftProductDependencies
+//
+//  Created by Daniel Lacasse on 2023-05-06.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundColor(.accentColor)
+            Text("Hello, world!")
+        }
+        .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/WithoutSwiftProductDependencies/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/WithoutSwiftProductDependencies/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/WithoutSwiftProductDependencies/WithoutSwiftProductDependencies.entitlements
+++ b/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/WithoutSwiftProductDependencies/WithoutSwiftProductDependencies.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-only</key>
+    <true/>
+</dict>
+</plist>

--- a/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/WithoutSwiftProductDependencies/WithoutSwiftProductDependenciesApp.swift
+++ b/subprojects/build-adapter-xcode/src/templates/swift-package-product-dependencies/WithoutSwiftProductDependencies/WithoutSwiftProductDependenciesApp.swift
@@ -1,0 +1,17 @@
+//
+//  WithoutSwiftProductDependenciesApp.swift
+//  WithoutSwiftProductDependencies
+//
+//  Created by Daniel Lacasse on 2023-05-06.
+//
+
+import SwiftUI
+
+@main
+struct WithoutSwiftProductDependenciesApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/targets/PBXNativeTarget.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/objects/targets/PBXNativeTarget.java
@@ -139,6 +139,11 @@ public interface PBXNativeTarget extends PBXTarget {
 			return this;
 		}
 
+		public Builder packageProductDependency(XCSwiftPackageProductDependency packageProductDependency) {
+			this.builder.add(CodeablePBXNativeTarget.CodingKeys.packageProductDependencies, packageProductDependency);
+			return this;
+		}
+
 		@Override
 		public PBXNativeTarget build() {
 			return new CodeablePBXNativeTarget(builder.build());

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/project/AbstractCodeable.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/project/AbstractCodeable.java
@@ -18,15 +18,20 @@ package dev.nokee.xcode.project;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import lombok.EqualsAndHashCode;
+import lombok.val;
 
 import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 @EqualsAndHashCode
-abstract class AbstractCodeable implements Codeable {
-	private final KeyedObject delegate;
+abstract class AbstractCodeable implements Codeable, Serializable {
+	private KeyedObject delegate;
 
 	protected AbstractCodeable(KeyedObject delegate) {
 		this.delegate = delegate;
@@ -101,5 +106,17 @@ abstract class AbstractCodeable implements Codeable {
 	@Override
 	public final void encode(EncodeContext context) {
 		delegate.encode(context);
+	}
+
+	private void writeObject(ObjectOutputStream outStream) throws IOException {
+		outStream.writeObject(getAsMap());
+	}
+
+	private void readObject(ObjectInputStream inStream) throws IOException, ClassNotFoundException {
+		val builder = DefaultKeyedObject.builder();
+		@SuppressWarnings("unchecked")
+		val codingKeyToValues = (Map<CodingKey, Object>) inStream.readObject();
+		codingKeyToValues.forEach(builder::put);
+		delegate = builder.build();
 	}
 }

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/project/AbstractCodeable.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/project/AbstractCodeable.java
@@ -109,7 +109,11 @@ abstract class AbstractCodeable implements Codeable, Serializable {
 	}
 
 	private void writeObject(ObjectOutputStream outStream) throws IOException {
-		outStream.writeObject(getAsMap());
+		val data = getAsMap().entrySet().stream()
+			// TODO: all coding key should be serializable and the filtering should be done during encoding
+			.filter(it -> it.getKey() instanceof Enum || it.getKey() instanceof SerializableCodingKey)
+			.collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+		outStream.writeObject(data);
 	}
 
 	private void readObject(ObjectInputStream inStream) throws IOException, ClassNotFoundException {

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/project/CodeableXCSwiftPackageProductDependency.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/project/CodeableXCSwiftPackageProductDependency.java
@@ -15,11 +15,14 @@
  */
 package dev.nokee.xcode.project;
 
+import com.google.common.collect.ImmutableMap;
 import dev.nokee.xcode.objects.swiftpackage.XCRemoteSwiftPackageReference;
 import dev.nokee.xcode.objects.swiftpackage.XCSwiftPackageProductDependency;
 
+import java.util.Map;
 import java.util.Objects;
 
+import static dev.nokee.util.internal.NotPredicate.not;
 import static dev.nokee.xcode.project.RecodeableKeyedObject.ofIsaAnd;
 
 public final class CodeableXCSwiftPackageProductDependency extends AbstractCodeable implements XCSwiftPackageProductDependency {
@@ -57,6 +60,13 @@ public final class CodeableXCSwiftPackageProductDependency extends AbstractCodea
 	@Override
 	public int stableHash() {
 		return Objects.hash(getProductName(), getPackageReference().getRepositoryUrl());
+	}
+
+	@Override
+	public Map<CodingKey, Object> getAsMap() {
+		// TODO: This leaks the coding out into the object... we should fix that.
+		//   What we really want is a way to decode the known keys and return any left over (not decoded) as ad-hoc keys
+		return super.getAsMap().entrySet().stream().filter(not(it -> it.getKey() instanceof SerializableCodingKey && it.getKey().getName().equals("package"))).collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
 	}
 
 	public static CodeableXCSwiftPackageProductDependency newInstance(KeyedObject delegate) {

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/project/DefaultKeyedObject.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/project/DefaultKeyedObject.java
@@ -188,7 +188,7 @@ public final class DefaultKeyedObject implements KeyedObject {
 
 		public void add(CodingKey codingKey, Object element) {
 			Objects.requireNonNull(element, () -> String.format("'%s' must not be null", codingKey.getName()));
-			Object value = builder.get(codingKey);
+			Object value = builder.getOrDefault(codingKey, (parent != null) ? parent.tryDecode(codingKey) : null);
 			if (value == null) {
 				builder.put(codingKey, ImmutableList.of(element));
 			} else if (value instanceof List) {

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/project/KeyedCoders.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/project/KeyedCoders.java
@@ -92,17 +92,7 @@ public final class KeyedCoders {
 	private static final ValueCoder<XCConfigurationList> objectRefOfConfigurationList = uncheckedCast("only interested in main type", objectRef(new XCConfigurationListDecoder<>()));
 	private static final ValueCoder<PBXTarget> objectRefOfTarget = uncheckedCast("only interested in main type", objectRef(new TargetDecoder<>()));
 
-	public static final CodingKey ISA = new CodingKey() {
-		@Override
-		public String getName() {
-			return "isa";
-		}
-
-		@Override
-		public String toString() {
-			return getName();
-		}
-	};
+	public static final CodingKey ISA = new SerializableCodingKey("isa");
 	public static final CodingKey VERSION_REQUIREMENT_KIND = new CodingKey() {
 		@Override
 		public String getName() {

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/project/PBXObjectReferenceKeyedObject.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/project/PBXObjectReferenceKeyedObject.java
@@ -74,7 +74,7 @@ public final class PBXObjectReferenceKeyedObject implements KeyedObject {
 
 					@Override
 					public Map<CodingKey, Object> getAsMap() {
-						return object.entrySet().stream().collect(Collectors.toMap(it -> (CodingKey) it::getKey, Map.Entry::getValue));
+						return object.entrySet().stream().collect(Collectors.toMap(it -> new SerializableCodingKey(it.getKey()), Map.Entry::getValue));
 					}
 
 					@Override
@@ -116,7 +116,7 @@ public final class PBXObjectReferenceKeyedObject implements KeyedObject {
 
 	@Override
 	public Map<CodingKey, Object> getAsMap() {
-		return reference.getFields().entrySet().stream().collect(Collectors.toMap(it -> it::getKey, Map.Entry::getValue));
+		return reference.getFields().entrySet().stream().collect(Collectors.toMap(it -> new SerializableCodingKey(it.getKey()), Map.Entry::getValue));
 	}
 
 	@Override

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/project/PBXObjectReferenceKeyedObject.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/project/PBXObjectReferenceKeyedObject.java
@@ -74,7 +74,7 @@ public final class PBXObjectReferenceKeyedObject implements KeyedObject {
 
 					@Override
 					public Map<CodingKey, Object> getAsMap() {
-						return object.entrySet().stream().collect(Collectors.toMap(it -> new SerializableCodingKey(it.getKey()), Map.Entry::getValue));
+						return object.entrySet().stream().collect(Collectors.toMap(it -> (CodingKey) it::getKey, Map.Entry::getValue));
 					}
 
 					@Override
@@ -116,7 +116,7 @@ public final class PBXObjectReferenceKeyedObject implements KeyedObject {
 
 	@Override
 	public Map<CodingKey, Object> getAsMap() {
-		return reference.getFields().entrySet().stream().collect(Collectors.toMap(it -> new SerializableCodingKey(it.getKey()), Map.Entry::getValue));
+		return reference.getFields().entrySet().stream().collect(Collectors.toMap(it -> (CodingKey) it::getKey, Map.Entry::getValue));
 	}
 
 	@Override

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/project/SerializableCodingKey.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/project/SerializableCodingKey.java
@@ -15,8 +15,11 @@
  */
 package dev.nokee.xcode.project;
 
+import lombok.EqualsAndHashCode;
+
 import java.io.Serializable;
 
+@EqualsAndHashCode
 public final class SerializableCodingKey implements CodingKey, Serializable {
 	private final String name;
 

--- a/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/project/SerializableCodingKey.java
+++ b/subprojects/xcode-ide-kit/src/main/java/dev/nokee/xcode/project/SerializableCodingKey.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.nokee.xcode.project;
+
+import java.io.Serializable;
+
+public final class SerializableCodingKey implements CodingKey, Serializable {
+	private final String name;
+
+	public SerializableCodingKey(String name) {
+		this.name = name;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public String toString() {
+		return getName();
+	}
+}

--- a/subprojects/xcode-ide-kit/src/test/java/dev/nokee/xcode/project/coders/MapKeyedObject.java
+++ b/subprojects/xcode-ide-kit/src/test/java/dev/nokee/xcode/project/coders/MapKeyedObject.java
@@ -17,6 +17,7 @@ package dev.nokee.xcode.project.coders;
 
 import dev.nokee.xcode.project.CodingKey;
 import dev.nokee.xcode.project.KeyedObject;
+import dev.nokee.xcode.project.SerializableCodingKey;
 import lombok.EqualsAndHashCode;
 
 import javax.annotation.Nullable;
@@ -45,7 +46,7 @@ public final class MapKeyedObject implements KeyedObject {
 
 	@Override
 	public Map<CodingKey, Object> getAsMap() {
-		return values.entrySet().stream().collect(Collectors.toMap(it -> (CodingKey) it::getKey, Map.Entry::getValue));
+		return values.entrySet().stream().collect(Collectors.toMap(it -> new SerializableCodingKey(it.getKey()), Map.Entry::getValue));
 	}
 
 	@Override

--- a/subprojects/xcode-ide-kit/src/test/java/dev/nokee/xcode/project/coders/MapKeyedObject.java
+++ b/subprojects/xcode-ide-kit/src/test/java/dev/nokee/xcode/project/coders/MapKeyedObject.java
@@ -17,7 +17,6 @@ package dev.nokee.xcode.project.coders;
 
 import dev.nokee.xcode.project.CodingKey;
 import dev.nokee.xcode.project.KeyedObject;
-import dev.nokee.xcode.project.SerializableCodingKey;
 import lombok.EqualsAndHashCode;
 
 import javax.annotation.Nullable;
@@ -46,7 +45,7 @@ public final class MapKeyedObject implements KeyedObject {
 
 	@Override
 	public Map<CodingKey, Object> getAsMap() {
-		return values.entrySet().stream().collect(Collectors.toMap(it -> new SerializableCodingKey(it.getKey()), Map.Entry::getValue));
+		return values.entrySet().stream().collect(Collectors.toMap(it -> (CodingKey) it::getKey, Map.Entry::getValue));
 	}
 
 	@Override


### PR DESCRIPTION
This PR brings the following change to the Swift PM dependencies isolation process:

- Support cross-project dependencies
- Ensure previous dependencies and references are kept
- Simplify the configuration and reuse PBX/XC models