### PR TITLE
Use ModelActionX instance

### DIFF
--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/ancestors/AncestryCapabilityPlugin.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/ancestors/AncestryCapabilityPlugin.java
@@ -17,7 +17,6 @@ package dev.nokee.model.internal.ancestors;
 
 import com.google.common.collect.ImmutableSet;
 import dev.nokee.model.internal.core.ModelActionWithInputs;
-import dev.nokee.model.internal.core.ModelComponentReference;
 import dev.nokee.model.internal.core.ModelNode;
 import dev.nokee.model.internal.core.ParentComponent;
 import dev.nokee.model.internal.core.ParentUtils;
@@ -29,10 +28,10 @@ import org.gradle.api.plugins.PluginAware;
 public abstract class AncestryCapabilityPlugin<T extends ExtensionAware & PluginAware> implements Plugin<T> {
 	@Override
 	public void apply(T target) {
-		target.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelComponentReference.of(ParentComponent.class), AncestryCapabilityPlugin::calculateAncestorsFromParent));
-	}
-
-	private static void calculateAncestorsFromParent(ModelNode entity, ParentComponent parent) {
-		entity.addComponent(new AncestorsComponent(new Ancestors(ParentUtils.stream(parent).map(AncestorRef::of).collect(ImmutableSet.toImmutableSet()))));
+		target.getExtensions().getByType(ModelConfigurer.class).configure(/*calculateAncestorsFromParent*/new ModelActionWithInputs.ModelAction1<ParentComponent>() {
+			protected void execute(ModelNode entity, ParentComponent parent) {
+				entity.addComponent(new AncestorsComponent(new Ancestors(ParentUtils.stream(parent).map(AncestorRef::of).collect(ImmutableSet.toImmutableSet()))));
+			}
+		});
 	}
 }

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/names/NamesCapabilityPlugin.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/names/NamesCapabilityPlugin.java
@@ -17,7 +17,6 @@ package dev.nokee.model.internal.names;
 
 import dev.nokee.model.internal.actions.ModelActionSystem;
 import dev.nokee.model.internal.core.ModelActionWithInputs;
-import dev.nokee.model.internal.core.ModelComponentReference;
 import dev.nokee.model.internal.core.ModelNode;
 import dev.nokee.model.internal.core.ParentComponent;
 import dev.nokee.model.internal.core.ParentUtils;
@@ -33,22 +32,22 @@ import static dev.nokee.model.internal.names.RelativeNames.toRelativeNames;
 public abstract class NamesCapabilityPlugin<T extends ExtensionAware & PluginAware> implements Plugin<T> {
 	@Override
 	public void apply(T target) {
-		target.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelComponentReference.of(ParentComponent.class), ModelComponentReference.of(ElementNameComponent.class), ModelComponentReference.of(ModelState.IsAtLeastCreated.class), NamesCapabilityPlugin::computeRelativelyQualifiedName));
-		target.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelComponentReference.of(ParentComponent.class), ModelComponentReference.of(ElementNameComponent.class), ModelComponentReference.of(ModelState.IsAtLeastCreated.class), NamesCapabilityPlugin::computeFullyQualifiedName));
+		target.getExtensions().getByType(ModelConfigurer.class).configure(/*computeRelativelyQualifiedName*/new ModelActionWithInputs.ModelAction3<ParentComponent, ElementNameComponent, ModelState.IsAtLeastCreated>() {
+			// ComponentFromEntity<MainComponentTag> read-only ancestors
+			// ComponentFromEntity<ElementNameComponent> read-only ancestors
+			protected void execute(ModelNode entity, ParentComponent parent, ElementNameComponent elementName, ModelState.IsAtLeastCreated ignored1) {
+				entity.addComponent(new RelativeNamesComponent(ParentUtils.stream(parent).collect(toRelativeNames(elementName.get()))));
+			}
+		});
+		target.getExtensions().getByType(ModelConfigurer.class).configure(/*computeFullyQualifiedName*/new ModelActionWithInputs.ModelAction3<ParentComponent, ElementNameComponent, ModelState.IsAtLeastCreated>() {
+			// ComponentFromEntity<MainComponentTag> read-only ancestors
+			// ComponentFromEntity<ElementNameComponent> read-only ancestors
+			protected void execute(ModelNode entity, ParentComponent parent, ElementNameComponent elementName, ModelState.IsAtLeastCreated ignored1) {
+				entity.addComponent(new FullyQualifiedNameComponent(ParentUtils.stream(parent).collect(toFullyQualifiedName(elementName.get()))));
+			}
+		});
 		target.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionSystem.updateSelectorForTag(RelativeNamesComponent.class));
 		target.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionSystem.updateSelectorForTag(FullyQualifiedNameComponent.class));
 		target.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionSystem.updateSelectorForTag(ElementNameComponent.class));
-	}
-
-	// ComponentFromEntity<MainComponentTag> read-only ancestors
-	// ComponentFromEntity<ElementNameComponent> read-only ancestors
-	private static void computeRelativelyQualifiedName(ModelNode entity, ParentComponent parent, ElementNameComponent elementName, ModelState.IsAtLeastCreated ignored1) {
-		entity.addComponent(new RelativeNamesComponent(ParentUtils.stream(parent).collect(toRelativeNames(elementName.get()))));
-	}
-
-	// ComponentFromEntity<MainComponentTag> read-only ancestors
-	// ComponentFromEntity<ElementNameComponent> read-only ancestors
-	private static void computeFullyQualifiedName(ModelNode entity, ParentComponent parent, ElementNameComponent elementName, ModelState.IsAtLeastCreated ignored1) {
-		entity.addComponent(new FullyQualifiedNameComponent(ParentUtils.stream(parent).collect(toFullyQualifiedName(elementName.get()))));
 	}
 }

--- a/subprojects/core-model/src/main/java/dev/nokee/model/internal/registry/DefaultModelRegistry.java
+++ b/subprojects/core-model/src/main/java/dev/nokee/model/internal/registry/DefaultModelRegistry.java
@@ -33,7 +33,6 @@ import dev.nokee.model.internal.core.HasInputs;
 import dev.nokee.model.internal.core.ModelAction;
 import dev.nokee.model.internal.core.ModelActionWithInputs;
 import dev.nokee.model.internal.core.ModelComponent;
-import dev.nokee.model.internal.core.ModelComponentReference;
 import dev.nokee.model.internal.core.ModelComponentType;
 import dev.nokee.model.internal.core.ModelElement;
 import dev.nokee.model.internal.core.ModelEntityId;
@@ -79,11 +78,10 @@ public final class DefaultModelRegistry implements ModelRegistry, ModelConfigure
 		this.instantiator = instantiator;
 		this.elementFactory = new ModelElementFactory(instantiator);
 		this.bindingService = new BindManagedProjectionService(instantiator);
-		configure(ModelActionWithInputs.of(ModelComponentReference.of(ModelPathComponent.class), ModelComponentReference.of(ModelState.class), new ModelActionWithInputs.A2<ModelPathComponent, ModelState>() {
+		configure(new ModelActionWithInputs.ModelAction2<ModelPathComponent, ModelState>() {
 			private final Set<ModelEntityId> alreadyExecuted = new HashSet<>();
 
-			@Override
-			public void execute(ModelNode node, ModelPathComponent path, ModelState state) {
+			protected void execute(ModelNode node, ModelPathComponent path, ModelState state) {
 				if (state.isAtLeast(ModelState.Created) && alreadyExecuted.add(node.getId())) {
 					if (!path.get().equals(ModelPath.root()) && (!path.get().getParent().isPresent() || !nodes.containsKey(path.get().getParent().get()))) {
 						throw new IllegalArgumentException(String.format("Model %s has to be direct descendant", path.get()));
@@ -102,18 +100,17 @@ public final class DefaultModelRegistry implements ModelRegistry, ModelConfigure
 					});
 				}
 			}
-		}));
-		configure(ModelActionWithInputs.of(ModelComponentReference.of(ModelPathComponent.class), ModelComponentReference.of(ModelState.class), new ModelActionWithInputs.A2<ModelPathComponent, ModelState>() {
-			public final Set<ModelEntityId> alreadyExecuted = new HashSet<>();
+		});
+		configure(new ModelActionWithInputs.ModelAction2<ModelPathComponent, ModelState>() {
+			private final Set<ModelEntityId> alreadyExecuted = new HashSet<>();
 
-			@Override
-			public void execute(ModelNode node, ModelPathComponent path, ModelState state) {
+			protected void execute(ModelNode node, ModelPathComponent path, ModelState state) {
 				if (state.isAtLeast(ModelState.Registered) && alreadyExecuted.add(node.getId())) {
 					assert !nodes.values().contains(node) : "duplicated registered notification";
 					nodes.put(path.get(), node);
 				}
 			}
-		}));
+		});
 		rootNode = ModelStates.register(createRootNode());
 	}
 

--- a/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/registry/DefaultModelRegistryTest.java
+++ b/subprojects/core-model/src/test/groovy/dev/nokee/model/internal/registry/DefaultModelRegistryTest.java
@@ -20,7 +20,6 @@ import dev.nokee.internal.testing.util.ProjectTestUtils;
 import dev.nokee.model.internal.core.DescendantNodes;
 import dev.nokee.model.internal.core.ModelAction;
 import dev.nokee.model.internal.core.ModelActionWithInputs;
-import dev.nokee.model.internal.core.ModelComponentReference;
 import dev.nokee.model.internal.core.ModelNode;
 import dev.nokee.model.internal.core.ModelNodeUtils;
 import dev.nokee.model.internal.core.ModelPath;
@@ -118,11 +117,13 @@ public class DefaultModelRegistryTest {
 				assertThrows(IllegalArgumentException.class, () -> modelLookup.get(path("foo")));
 				return null;
 			}).when(action).execute(any());
-			subject.configure(ModelActionWithInputs.of(ModelComponentReference.of(ModelState.class), (node, state) -> {
-				if (state.equals(ModelState.Initialized)) {
-					action.execute(node);
+			subject.configure(new ModelActionWithInputs.ModelAction1<ModelState>() {
+				protected void execute(ModelNode node, ModelState state) {
+					if (state.equals(ModelState.Initialized)) {
+						action.execute(node);
+					}
 				}
-			}));
+			});
 			register("foo");
 			verify(action, times(1)).execute(any());
 		}
@@ -135,11 +136,13 @@ public class DefaultModelRegistryTest {
 				assertDoesNotThrow(() -> modelLookup.get(path("bar")));
 				return null;
 			}).when(action).execute(any());
-			subject.configure(ModelActionWithInputs.of(ModelComponentReference.of(ModelPathComponent.class), ModelComponentReference.of(ModelState.class), (node, path, state) -> {
-				if (state.equals(ModelState.Registered) && path.get().equals(path("bar"))) {
-					action.execute(node);
+			subject.configure(new ModelActionWithInputs.ModelAction2<ModelPathComponent, ModelState>() {
+				protected void execute(ModelNode node, ModelPathComponent path, ModelState state) {
+					if (state.equals(ModelState.Registered) && path.get().equals(path("bar"))) {
+						action.execute(node);
+					}
 				}
-			}));
+			});
 			register("bar");
 			verify(action, times(1)).execute(any());
 		}

--- a/subprojects/ide-visual-studio/src/main/java/dev/nokee/ide/visualstudio/internal/plugins/VisualStudioIdePlugin.java
+++ b/subprojects/ide-visual-studio/src/main/java/dev/nokee/ide/visualstudio/internal/plugins/VisualStudioIdePlugin.java
@@ -19,9 +19,9 @@ import dev.nokee.ide.visualstudio.VisualStudioIdeProjectExtension;
 import dev.nokee.ide.visualstudio.internal.rules.CreateNativeComponentVisualStudioIdeProject;
 import dev.nokee.model.internal.ModelElementFactory;
 import dev.nokee.model.internal.core.ModelActionWithInputs;
-import dev.nokee.model.internal.core.ModelComponentReference;
+import dev.nokee.model.internal.core.ModelNode;
 import dev.nokee.model.internal.registry.ModelConfigurer;
-import dev.nokee.model.internal.tags.ModelTags;
+import dev.nokee.model.internal.tags.ModelComponentTag;
 import dev.nokee.platform.base.internal.IsComponent;
 import dev.nokee.platform.base.internal.plugins.ComponentModelBasePlugin;
 import dev.nokee.platform.base.internal.plugins.OnDiscover;
@@ -44,9 +44,11 @@ public abstract class VisualStudioIdePlugin implements Plugin<Project> {
 			public void execute(ComponentModelBasePlugin appliedPlugin) {
 				val modelConfigurer = project.getExtensions().getByType(ModelConfigurer.class);
 				val action = new CreateNativeComponentVisualStudioIdeProject(extension, project.getLayout(), project.getObjects(), project.getProviders());
-				modelConfigurer.configure(new OnDiscover(ModelActionWithInputs.of(ModelTags.referenceOf(IsComponent.class), ModelComponentReference.of(ModelElementFactory.class), (entity, tag, factory) -> {
-					action.execute(factory.createElement(entity));
-				})));
+				modelConfigurer.configure(new OnDiscover(new ModelActionWithInputs.ModelAction2<ModelComponentTag<IsComponent>, ModelElementFactory>() {
+					protected void execute(ModelNode entity, ModelComponentTag<IsComponent> tag, ModelElementFactory factory) {
+						action.execute(factory.createElement(entity));
+					}
+				}));
 			}
 		};
 	}

--- a/subprojects/ide-xcode/src/main/java/dev/nokee/ide/xcode/internal/plugins/XcodeIdePlugin.java
+++ b/subprojects/ide-xcode/src/main/java/dev/nokee/ide/xcode/internal/plugins/XcodeIdePlugin.java
@@ -23,10 +23,10 @@ import dev.nokee.ide.xcode.internal.tasks.SyncXcodeIdeProduct;
 import dev.nokee.model.internal.ModelElementFactory;
 import dev.nokee.model.internal.ProjectIdentifier;
 import dev.nokee.model.internal.core.ModelActionWithInputs;
-import dev.nokee.model.internal.core.ModelComponentReference;
+import dev.nokee.model.internal.core.ModelNode;
 import dev.nokee.model.internal.registry.ModelConfigurer;
 import dev.nokee.model.internal.registry.ModelLookup;
-import dev.nokee.model.internal.tags.ModelTags;
+import dev.nokee.model.internal.tags.ModelComponentTag;
 import dev.nokee.platform.base.internal.IsComponent;
 import dev.nokee.platform.base.internal.plugins.ComponentModelBasePlugin;
 import dev.nokee.platform.base.internal.plugins.OnDiscover;
@@ -121,9 +121,11 @@ public abstract class XcodeIdePlugin implements Plugin<Project> {
 			public void execute(ComponentModelBasePlugin appliedPlugin) {
 				val modelConfigurer = project.getExtensions().getByType(ModelConfigurer.class);
 				val action = new CreateNativeComponentXcodeIdeProject(extension, project.getProviders(), project.getObjects(), project.getLayout(), project.getTasks(), ProjectIdentifier.of(project), project.getExtensions().getByType(ModelLookup.class));
-				modelConfigurer.configure(new OnDiscover(ModelActionWithInputs.of(ModelTags.referenceOf(IsComponent.class), ModelComponentReference.of(ModelElementFactory.class), (entity, tag, factory) -> {
-					action.execute(factory.createElement(entity));
-				})));
+				modelConfigurer.configure(new OnDiscover(new ModelActionWithInputs.ModelAction2<ModelComponentTag<IsComponent>, ModelElementFactory>() {
+					protected void execute(ModelNode entity, ModelComponentTag<IsComponent> tag, ModelElementFactory factory) {
+						action.execute(factory.createElement(entity));
+					}
+				}));
 			}
 		};
 	}

--- a/subprojects/language-base/src/main/java/dev/nokee/language/base/internal/plugins/LanguageBasePlugin.java
+++ b/subprojects/language-base/src/main/java/dev/nokee/language/base/internal/plugins/LanguageBasePlugin.java
@@ -37,7 +37,6 @@ import dev.nokee.model.internal.registry.ModelConfigurer;
 import dev.nokee.model.internal.registry.ModelRegistry;
 import dev.nokee.model.internal.state.ModelState;
 import dev.nokee.model.internal.tags.ModelComponentTag;
-import dev.nokee.model.internal.tags.ModelTags;
 import dev.nokee.model.internal.type.ModelType;
 import dev.nokee.model.internal.type.TypeOf;
 import dev.nokee.platform.base.ComponentSources;
@@ -81,11 +80,13 @@ public class LanguageBasePlugin implements Plugin<Project> {
 			}
 		});
 
-		// ComponentFromEntity<ParentComponent> read-only self
-		project.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelTags.referenceOf(IsLanguageSourceSet.class), ModelComponentReference.of(ModelPathComponent.class), ModelComponentReference.of(DisplayNameComponent.class), ModelComponentReference.of(ElementNameComponent.class), ModelComponentReference.of(ModelState.IsAtLeastCreated.class), (entity, ignored1, path, displayName, elementName, ignored2) -> {
-			val parentIdentifier = entity.find(ParentComponent.class).map(parent -> parent.get().get(IdentifierComponent.class).get()).orElse(null);
-			entity.addComponent(new IdentifierComponent(new DefaultDomainObjectIdentifier(elementName.get(), parentIdentifier, displayName.get(), path.get())));
-		}));
+		project.getExtensions().getByType(ModelConfigurer.class).configure(new ModelActionWithInputs.ModelAction5<ModelComponentTag<IsLanguageSourceSet>, ModelPathComponent, DisplayNameComponent, ElementNameComponent, ModelState.IsAtLeastCreated>() {
+			// ComponentFromEntity<ParentComponent> read-only self
+			protected void execute(ModelNode entity, ModelComponentTag<IsLanguageSourceSet> ignored1, ModelPathComponent path, DisplayNameComponent displayName, ElementNameComponent elementName, ModelState.IsAtLeastCreated ignored2) {
+				val parentIdentifier = entity.find(ParentComponent.class).map(parent -> parent.get().get(IdentifierComponent.class).get()).orElse(null);
+				entity.addComponent(new IdentifierComponent(new DefaultDomainObjectIdentifier(elementName.get(), parentIdentifier, displayName.get(), path.get())));
+			}
+		});
 		project.getExtensions().getByType(ModelConfigurer.class).configure(new OnDiscover(ModelActionWithInputs.of(ModelComponentReference.ofProjection(ModelType.of(new TypeOf<ModelBackedSourceAwareComponentMixIn<? extends ComponentSources, ? extends ComponentSources>>() {})), ModelComponentReference.of(IdentifierComponent.class), (entity, projection, identifier) -> {
 			val registry = project.getExtensions().getByType(ModelRegistry.class);
 			Class<ComponentSources> type = (Class<ComponentSources>) sourcesType((ModelType<SourceAwareComponent<? extends ComponentSources>>)projection.getType());

--- a/subprojects/language-base/src/main/java/dev/nokee/language/base/internal/plugins/LanguageBasePlugin.java
+++ b/subprojects/language-base/src/main/java/dev/nokee/language/base/internal/plugins/LanguageBasePlugin.java
@@ -25,6 +25,7 @@ import dev.nokee.model.internal.core.DisplayNameComponent;
 import dev.nokee.model.internal.core.IdentifierComponent;
 import dev.nokee.model.internal.core.ModelActionWithInputs;
 import dev.nokee.model.internal.core.ModelComponentReference;
+import dev.nokee.model.internal.core.ModelNode;
 import dev.nokee.model.internal.core.ModelNodeContext;
 import dev.nokee.model.internal.core.ModelNodeUtils;
 import dev.nokee.model.internal.core.ModelPathComponent;
@@ -35,6 +36,7 @@ import dev.nokee.model.internal.plugins.ModelBasePlugin;
 import dev.nokee.model.internal.registry.ModelConfigurer;
 import dev.nokee.model.internal.registry.ModelRegistry;
 import dev.nokee.model.internal.state.ModelState;
+import dev.nokee.model.internal.tags.ModelComponentTag;
 import dev.nokee.model.internal.tags.ModelTags;
 import dev.nokee.model.internal.type.ModelType;
 import dev.nokee.model.internal.type.TypeOf;
@@ -70,12 +72,14 @@ public class LanguageBasePlugin implements Plugin<Project> {
 
 		val elementsPropertyFactory = new ComponentElementsPropertyRegistrationFactory();
 
-		// ComponentFromEntity<DisplayNameComponent> read-only self
-		project.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelTags.referenceOf(IsLanguageSourceSet.class), ModelComponentReference.of(ModelState.IsAtLeastCreated.class), (entity, ignored1, ignored2) -> {
-			if (!entity.has(DisplayNameComponent.class)) {
-				entity.addComponent(new DisplayNameComponent("sources"));
+		project.getExtensions().getByType(ModelConfigurer.class).configure(new ModelActionWithInputs.ModelAction2<ModelComponentTag<IsLanguageSourceSet>, ModelState.IsAtLeastCreated>() {
+			// ComponentFromEntity<DisplayNameComponent> read-only self
+			protected void execute(ModelNode entity, ModelComponentTag<IsLanguageSourceSet> ignored1, ModelState.IsAtLeastCreated ignored2) {
+				if (!entity.has(DisplayNameComponent.class)) {
+					entity.addComponent(new DisplayNameComponent("sources"));
+				}
 			}
-		}));
+		});
 
 		// ComponentFromEntity<ParentComponent> read-only self
 		project.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelTags.referenceOf(IsLanguageSourceSet.class), ModelComponentReference.of(ModelPathComponent.class), ModelComponentReference.of(DisplayNameComponent.class), ModelComponentReference.of(ElementNameComponent.class), ModelComponentReference.of(ModelState.IsAtLeastCreated.class), (entity, ignored1, path, displayName, elementName, ignored2) -> {

--- a/subprojects/language-cpp/src/main/java/dev/nokee/language/cpp/internal/plugins/CppLanguageBasePlugin.java
+++ b/subprojects/language-cpp/src/main/java/dev/nokee/language/cpp/internal/plugins/CppLanguageBasePlugin.java
@@ -33,7 +33,6 @@ import dev.nokee.language.nativebase.internal.toolchains.NokeeStandardToolChains
 import dev.nokee.model.internal.core.GradlePropertyComponent;
 import dev.nokee.model.internal.core.IdentifierComponent;
 import dev.nokee.model.internal.core.ModelActionWithInputs;
-import dev.nokee.model.internal.core.ModelComponentReference;
 import dev.nokee.model.internal.core.ModelNode;
 import dev.nokee.model.internal.core.ModelNodes;
 import dev.nokee.model.internal.core.ModelPropertyRegistrationFactory;
@@ -47,7 +46,6 @@ import dev.nokee.model.internal.registry.ModelRegistry;
 import dev.nokee.model.internal.state.ModelState;
 import dev.nokee.model.internal.state.ModelStates;
 import dev.nokee.model.internal.tags.ModelComponentTag;
-import dev.nokee.model.internal.tags.ModelTags;
 import dev.nokee.platform.base.internal.DomainObjectEntities;
 import dev.nokee.platform.base.internal.extensionaware.ExtensionAwareComponent;
 import dev.nokee.platform.base.internal.plugins.OnDiscover;
@@ -84,12 +82,14 @@ public class CppLanguageBasePlugin implements Plugin<Project> {
 				entity.addComponent(new NativeCompileTypeComponent(CppCompileTask.class));
 			}
 		});
-		project.getExtensions().getByType(ModelConfigurer.class).configure(new OnDiscover(ModelActionWithInputs.of(ModelComponentReference.of(IdentifierComponent.class), ModelTags.referenceOf(NativeLanguageSourceSetAwareTag.class), ModelComponentReference.of(ParentComponent.class), (entity, identifier, tag, parent) -> {
-			ParentUtils.stream(parent).filter(it -> it.hasComponent(typeOf(SupportCppSourceSetTag.class))).findFirst().ifPresent(ignored -> {
-				val sourceSet = project.getExtensions().getByType(ModelRegistry.class).register(project.getExtensions().getByType(DefaultCppSourceSetRegistrationFactory.class).create(entity));
-				entity.addComponent(new CppSourceSetComponent(ModelNodes.of(sourceSet)));
-			});
-		})));
+		project.getExtensions().getByType(ModelConfigurer.class).configure(new OnDiscover(new ModelActionWithInputs.ModelAction3<IdentifierComponent, ModelComponentTag<NativeLanguageSourceSetAwareTag>, ParentComponent>() {
+			protected void execute(ModelNode entity, IdentifierComponent identifier, ModelComponentTag<NativeLanguageSourceSetAwareTag> tag, ParentComponent parent) {
+				ParentUtils.stream(parent).filter(it -> it.hasComponent(typeOf(SupportCppSourceSetTag.class))).findFirst().ifPresent(ignored -> {
+					val sourceSet = project.getExtensions().getByType(ModelRegistry.class).register(project.getExtensions().getByType(DefaultCppSourceSetRegistrationFactory.class).create(entity));
+					entity.addComponent(new CppSourceSetComponent(ModelNodes.of(sourceSet)));
+				});
+			}
+		}));
 
 		project.getExtensions().getByType(ModelConfigurer.class).configure(new ModelActionWithInputs.ModelAction2<CppSourcesPropertyComponent, FullyQualifiedNameComponent>() {
 			// ComponentFromEntity<GradlePropertyComponent> read-write on CppSourcesPropertyComponent
@@ -116,14 +116,16 @@ public class CppLanguageBasePlugin implements Plugin<Project> {
 				entity.addComponent(new CppSourcesPropertyComponent(property));
 			}
 		}));
-		// ComponentFromEntity<GradlePropertyComponent> read-write on SourcePropertyComponent
-		project.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelTags.referenceOf(CppSourceSetTag.class), ModelComponentReference.of(SourcePropertyComponent.class), ModelComponentReference.of(ParentComponent.class), (entity, ignored1, source, parent) -> {
-			((ConfigurableFileCollection) source.get().get(GradlePropertyComponent.class).get()).from((Callable<?>) () -> {
-				ModelStates.finalize(parent.get());
-				return ParentUtils.stream(parent).flatMap(it -> stream(it.find(CppSourcesComponent.class))).findFirst()
-					.map(it -> (Object) it.get()).orElse(Collections.emptyList());
-			});
-		}));
+		project.getExtensions().getByType(ModelConfigurer.class).configure(new ModelActionWithInputs.ModelAction3<ModelComponentTag<CppSourceSetTag>, SourcePropertyComponent, ParentComponent>() {
+			// ComponentFromEntity<GradlePropertyComponent> read-write on SourcePropertyComponent
+			protected void execute(ModelNode entity, ModelComponentTag<CppSourceSetTag> ignored1, SourcePropertyComponent source, ParentComponent parent) {
+				((ConfigurableFileCollection) source.get().get(GradlePropertyComponent.class).get()).from((Callable<?>) () -> {
+					ModelStates.finalize(parent.get());
+					return ParentUtils.stream(parent).flatMap(it -> stream(it.find(CppSourcesComponent.class))).findFirst()
+						.map(it -> (Object) it.get()).orElse(Collections.emptyList());
+				});
+			}
+		});
 		project.getExtensions().getByType(ModelConfigurer.class).configure(new ModelActionWithInputs.ModelAction2<CppSourcesPropertyComponent, ModelState.IsAtLeastFinalized>() {
 			// ComponentFromEntity<GradlePropertyComponent> read-write on CppSourcesPropertyComponent
 			protected void execute(ModelNode entity, CppSourcesPropertyComponent cppSources, ModelState.IsAtLeastFinalized ignored1) {

--- a/subprojects/language-native/src/main/java/dev/nokee/language/nativebase/internal/NativeHeaderLanguageBasePlugin.java
+++ b/subprojects/language-native/src/main/java/dev/nokee/language/nativebase/internal/NativeHeaderLanguageBasePlugin.java
@@ -19,7 +19,6 @@ import dev.nokee.language.base.internal.SourceSetFactory;
 import dev.nokee.language.base.internal.plugins.LanguageBasePlugin;
 import dev.nokee.model.internal.core.GradlePropertyComponent;
 import dev.nokee.model.internal.core.ModelActionWithInputs;
-import dev.nokee.model.internal.core.ModelComponentReference;
 import dev.nokee.model.internal.core.ModelNode;
 import dev.nokee.model.internal.core.ModelPropertyRegistrationFactory;
 import dev.nokee.model.internal.core.ModelRegistration;
@@ -32,7 +31,6 @@ import dev.nokee.model.internal.registry.ModelRegistry;
 import dev.nokee.model.internal.state.ModelState;
 import dev.nokee.model.internal.state.ModelStates;
 import dev.nokee.model.internal.tags.ModelComponentTag;
-import dev.nokee.model.internal.tags.ModelTags;
 import dev.nokee.platform.base.internal.extensionaware.ExtensionAwareComponent;
 import dev.nokee.platform.base.internal.plugins.OnDiscover;
 import lombok.val;
@@ -81,14 +79,16 @@ public class NativeHeaderLanguageBasePlugin implements Plugin<Project> {
 				entity.addComponent(new PrivateHeadersPropertyComponent(property));
 			}
 		}));
-		// ComponentFromEntity<GradlePropertyComponent> read-write on HasConfigurableHeadersPropertyComponent
-		project.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelTags.referenceOf(NativeHeaderSetTag.class), ModelComponentReference.of(HasConfigurableHeadersPropertyComponent.class), ModelComponentReference.of(ParentComponent.class), (entity, ignored1, headers, parent) -> {
-			((ConfigurableFileCollection) headers.get().get(GradlePropertyComponent.class).get()).from((Callable<?>) () -> {
-				ModelStates.finalize(parent.get());
-				return ParentUtils.stream(parent).flatMap(it -> stream(it.find(PrivateHeadersComponent.class))).findFirst()
-					.map(it -> (Object) it.get()).orElse(Collections.emptyList());
-			});
-		}));
+		project.getExtensions().getByType(ModelConfigurer.class).configure(new ModelActionWithInputs.ModelAction3<ModelComponentTag<NativeHeaderSetTag>, HasConfigurableHeadersPropertyComponent, ParentComponent>() {
+			// ComponentFromEntity<GradlePropertyComponent> read-write on HasConfigurableHeadersPropertyComponent
+			protected void execute(ModelNode entity, ModelComponentTag<NativeHeaderSetTag> ignored1, HasConfigurableHeadersPropertyComponent headers, ParentComponent parent) {
+				((ConfigurableFileCollection) headers.get().get(GradlePropertyComponent.class).get()).from((Callable<?>) () -> {
+					ModelStates.finalize(parent.get());
+					return ParentUtils.stream(parent).flatMap(it -> stream(it.find(PrivateHeadersComponent.class))).findFirst()
+						.map(it -> (Object) it.get()).orElse(Collections.emptyList());
+				});
+			}
+		});
 		project.getExtensions().getByType(ModelConfigurer.class).configure(new ModelActionWithInputs.ModelAction2<PrivateHeadersPropertyComponent, ModelState.IsAtLeastFinalized>() {
 			// ComponentFromEntity<GradlePropertyComponent> read-write on PrivateHeadersPropertyComponent
 			protected void execute(ModelNode entity, PrivateHeadersPropertyComponent privateHeaders, ModelState.IsAtLeastFinalized ignored1) {
@@ -130,14 +130,16 @@ public class NativeHeaderLanguageBasePlugin implements Plugin<Project> {
 				entity.addComponent(new PublicHeadersPropertyComponent(property));
 			}
 		}));
-		// ComponentFromEntity<GradlePropertyComponent> read-write on HasConfigurableHeadersPropertyComponent
-		project.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelTags.referenceOf(NativeHeaderSetTag.class), ModelComponentReference.of(HasConfigurableHeadersPropertyComponent.class), ModelComponentReference.of(ParentComponent.class), (entity, ignored1, headers, parent) -> {
-			((ConfigurableFileCollection) headers.get().get(GradlePropertyComponent.class).get()).from((Callable<?>) () -> {
-				ModelStates.finalize(parent.get());
-				return ParentUtils.stream(parent).flatMap(it -> stream(it.find(PublicHeadersComponent.class))).findFirst()
-					.map(it -> (Object) it.get()).orElse(Collections.emptyList());
-			});
-		}));
+		project.getExtensions().getByType(ModelConfigurer.class).configure(new ModelActionWithInputs.ModelAction3<ModelComponentTag<NativeHeaderSetTag>, HasConfigurableHeadersPropertyComponent, ParentComponent>() {
+			// ComponentFromEntity<GradlePropertyComponent> read-write on HasConfigurableHeadersPropertyComponent
+			protected void execute(ModelNode entity, ModelComponentTag<NativeHeaderSetTag> ignored1, HasConfigurableHeadersPropertyComponent headers, ParentComponent parent) {
+				((ConfigurableFileCollection) headers.get().get(GradlePropertyComponent.class).get()).from((Callable<?>) () -> {
+					ModelStates.finalize(parent.get());
+					return ParentUtils.stream(parent).flatMap(it -> stream(it.find(PublicHeadersComponent.class))).findFirst()
+						.map(it -> (Object) it.get()).orElse(Collections.emptyList());
+				});
+			}
+		});
 		project.getExtensions().getByType(ModelConfigurer.class).configure(new ModelActionWithInputs.ModelAction2<PublicHeadersPropertyComponent, ModelState.IsAtLeastFinalized>() {
 			// ComponentFromEntity<GradlePropertyComponent> read-write on PublicHeadersPropertyComponent
 			protected void execute(ModelNode entity, PublicHeadersPropertyComponent publicHeaders, ModelState.IsAtLeastFinalized ignored1) {

--- a/subprojects/language-objective-c/src/main/java/dev/nokee/language/objectivec/internal/plugins/ObjectiveCLanguageBasePlugin.java
+++ b/subprojects/language-objective-c/src/main/java/dev/nokee/language/objectivec/internal/plugins/ObjectiveCLanguageBasePlugin.java
@@ -33,7 +33,6 @@ import dev.nokee.language.objectivec.internal.tasks.ObjectiveCCompileTask;
 import dev.nokee.model.internal.core.GradlePropertyComponent;
 import dev.nokee.model.internal.core.IdentifierComponent;
 import dev.nokee.model.internal.core.ModelActionWithInputs;
-import dev.nokee.model.internal.core.ModelComponentReference;
 import dev.nokee.model.internal.core.ModelNode;
 import dev.nokee.model.internal.core.ModelNodes;
 import dev.nokee.model.internal.core.ModelPropertyRegistrationFactory;
@@ -47,7 +46,6 @@ import dev.nokee.model.internal.registry.ModelRegistry;
 import dev.nokee.model.internal.state.ModelState;
 import dev.nokee.model.internal.state.ModelStates;
 import dev.nokee.model.internal.tags.ModelComponentTag;
-import dev.nokee.model.internal.tags.ModelTags;
 import dev.nokee.platform.base.internal.DomainObjectEntities;
 import dev.nokee.platform.base.internal.extensionaware.ExtensionAwareComponent;
 import dev.nokee.platform.base.internal.plugins.OnDiscover;
@@ -85,12 +83,14 @@ public class ObjectiveCLanguageBasePlugin implements Plugin<Project> {
 				entity.addComponent(new NativeCompileTypeComponent(ObjectiveCCompileTask.class));
 			}
 		});
-		project.getExtensions().getByType(ModelConfigurer.class).configure(new OnDiscover(ModelActionWithInputs.of(ModelComponentReference.of(IdentifierComponent.class), ModelTags.referenceOf(NativeLanguageSourceSetAwareTag.class), ModelComponentReference.of(ParentComponent.class), (entity, identifier, tag, parent) -> {
-			ParentUtils.stream(parent).filter(it -> it.hasComponent(typeOf(SupportObjectiveCSourceSetTag.class))).findFirst().ifPresent(ignored -> {
-				val sourceSet = project.getExtensions().getByType(ModelRegistry.class).register(registrationFactory.create(entity));
-				entity.addComponent(new ObjectiveCSourceSetComponent(ModelNodes.of(sourceSet)));
-			});
-		})));
+		project.getExtensions().getByType(ModelConfigurer.class).configure(new OnDiscover(new ModelActionWithInputs.ModelAction3<IdentifierComponent, ModelComponentTag<NativeLanguageSourceSetAwareTag>, ParentComponent>() {
+			protected void execute(ModelNode entity, IdentifierComponent identifier, ModelComponentTag<NativeLanguageSourceSetAwareTag> tag, ParentComponent parent) {
+				ParentUtils.stream(parent).filter(it -> it.hasComponent(typeOf(SupportObjectiveCSourceSetTag.class))).findFirst().ifPresent(ignored -> {
+					val sourceSet = project.getExtensions().getByType(ModelRegistry.class).register(registrationFactory.create(entity));
+					entity.addComponent(new ObjectiveCSourceSetComponent(ModelNodes.of(sourceSet)));
+				});
+			}
+		}));
 
 		project.getExtensions().getByType(ModelConfigurer.class).configure(new ModelActionWithInputs.ModelAction2<ObjectiveCSourcesPropertyComponent, FullyQualifiedNameComponent>() {
 			// ComponentFromEntity<GradlePropertyComponent> read-write on ObjectiveCSourcesPropertyComponent
@@ -117,14 +117,16 @@ public class ObjectiveCLanguageBasePlugin implements Plugin<Project> {
 				entity.addComponent(new ObjectiveCSourcesPropertyComponent(property));
 			}
 		}));
-		// ComponentFromEntity<GradlePropertyComponent> read-write on SourcePropertyComponent
-		project.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelTags.referenceOf(ObjectiveCSourceSetTag.class), ModelComponentReference.of(SourcePropertyComponent.class), ModelComponentReference.of(ParentComponent.class), (entity, ignored1, source, parent) -> {
-			((ConfigurableFileCollection) source.get().get(GradlePropertyComponent.class).get()).from((Callable<?>) () -> {
-				ModelStates.finalize(parent.get());
-				return ParentUtils.stream(parent).flatMap(it -> stream(it.find(ObjectiveCSourcesComponent.class))).findFirst()
-					.map(it -> (Object) it.get()).orElse(Collections.emptyList());
-			});
-		}));
+		project.getExtensions().getByType(ModelConfigurer.class).configure(new ModelActionWithInputs.ModelAction3<ModelComponentTag<ObjectiveCSourceSetTag>, SourcePropertyComponent, ParentComponent>() {
+			// ComponentFromEntity<GradlePropertyComponent> read-write on SourcePropertyComponent
+			protected void execute(ModelNode entity, ModelComponentTag<ObjectiveCSourceSetTag> ignored1, SourcePropertyComponent source, ParentComponent parent) {
+				((ConfigurableFileCollection) source.get().get(GradlePropertyComponent.class).get()).from((Callable<?>) () -> {
+					ModelStates.finalize(parent.get());
+					return ParentUtils.stream(parent).flatMap(it -> stream(it.find(ObjectiveCSourcesComponent.class))).findFirst()
+						.map(it -> (Object) it.get()).orElse(Collections.emptyList());
+				});
+			}
+		});
 		project.getExtensions().getByType(ModelConfigurer.class).configure(new ModelActionWithInputs.ModelAction2<ObjectiveCSourcesPropertyComponent, ModelState.IsAtLeastFinalized>() {
 			// ComponentFromEntity<GradlePropertyComponent> read-write on ObjectiveCSourcesPropertyComponent
 			protected void execute(ModelNode entity, ObjectiveCSourcesPropertyComponent objcSources, ModelState.IsAtLeastFinalized ignored1) {

--- a/subprojects/language-swift/src/main/java/dev/nokee/language/swift/internal/plugins/SwiftLanguageBasePlugin.java
+++ b/subprojects/language-swift/src/main/java/dev/nokee/language/swift/internal/plugins/SwiftLanguageBasePlugin.java
@@ -27,7 +27,6 @@ import dev.nokee.language.swift.tasks.internal.SwiftCompileTask;
 import dev.nokee.model.internal.core.GradlePropertyComponent;
 import dev.nokee.model.internal.core.IdentifierComponent;
 import dev.nokee.model.internal.core.ModelActionWithInputs;
-import dev.nokee.model.internal.core.ModelComponentReference;
 import dev.nokee.model.internal.core.ModelNode;
 import dev.nokee.model.internal.core.ModelNodes;
 import dev.nokee.model.internal.core.ModelPropertyRegistrationFactory;
@@ -41,7 +40,6 @@ import dev.nokee.model.internal.registry.ModelRegistry;
 import dev.nokee.model.internal.state.ModelState;
 import dev.nokee.model.internal.state.ModelStates;
 import dev.nokee.model.internal.tags.ModelComponentTag;
-import dev.nokee.model.internal.tags.ModelTags;
 import dev.nokee.platform.base.internal.DomainObjectEntities;
 import dev.nokee.platform.base.internal.extensionaware.ExtensionAwareComponent;
 import dev.nokee.platform.base.internal.plugins.OnDiscover;
@@ -82,12 +80,14 @@ public class SwiftLanguageBasePlugin implements Plugin<Project> {
 				entity.addComponent(new NativeCompileTypeComponent(SwiftCompileTask.class));
 			}
 		});
-		project.getExtensions().getByType(ModelConfigurer.class).configure(new OnDiscover(ModelActionWithInputs.of(ModelComponentReference.of(IdentifierComponent.class), ModelTags.referenceOf(NativeLanguageSourceSetAwareTag.class), ModelComponentReference.of(ParentComponent.class), (entity, identifier, tag, parent) -> {
-			ParentUtils.stream(parent).filter(it -> it.hasComponent(typeOf(SupportSwiftSourceSetTag.class))).findFirst().ifPresent(ignored -> {
-				val sourceSet = project.getExtensions().getByType(ModelRegistry.class).register(project.getExtensions().getByType(DefaultSwiftSourceSetRegistrationFactory.class).create(entity));
-				entity.addComponent(new SwiftSourceSetComponent(ModelNodes.of(sourceSet)));
-			});
-		})));
+		project.getExtensions().getByType(ModelConfigurer.class).configure(new OnDiscover(new ModelActionWithInputs.ModelAction3<IdentifierComponent, ModelComponentTag<NativeLanguageSourceSetAwareTag>, ParentComponent>() {
+			protected void execute(ModelNode entity, IdentifierComponent identifier, ModelComponentTag<NativeLanguageSourceSetAwareTag> tag, ParentComponent parent) {
+				ParentUtils.stream(parent).filter(it -> it.hasComponent(typeOf(SupportSwiftSourceSetTag.class))).findFirst().ifPresent(ignored -> {
+					val sourceSet = project.getExtensions().getByType(ModelRegistry.class).register(project.getExtensions().getByType(DefaultSwiftSourceSetRegistrationFactory.class).create(entity));
+					entity.addComponent(new SwiftSourceSetComponent(ModelNodes.of(sourceSet)));
+				});
+			}
+		}));
 
 		project.getExtensions().getByType(ModelConfigurer.class).configure(new ModelActionWithInputs.ModelAction2<SwiftSourcesPropertyComponent, FullyQualifiedNameComponent>() {
 			// ComponentFromEntity<GradlePropertyComponent> read-write on SwiftSourcesPropertyComponent
@@ -114,14 +114,16 @@ public class SwiftLanguageBasePlugin implements Plugin<Project> {
 				entity.addComponent(new SwiftSourcesPropertyComponent(property));
 			}
 		}));
-		// ComponentFromEntity<GradlePropertyComponent> read-write on SourcePropertyComponent
-		project.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelTags.referenceOf(SwiftSourceSetTag.class), ModelComponentReference.of(SourcePropertyComponent.class), ModelComponentReference.of(ParentComponent.class), (entity, ignored1, source, parent) -> {
-			((ConfigurableFileCollection) source.get().get(GradlePropertyComponent.class).get()).from((Callable<?>) () -> {
-				ModelStates.finalize(parent.get());
-				return ParentUtils.stream(parent).flatMap(it -> stream(it.find(SwiftSourcesComponent.class))).findFirst()
-					.map(it -> (Object) it.get()).orElse(Collections.emptyList());
-			});
-		}));
+		project.getExtensions().getByType(ModelConfigurer.class).configure(new ModelActionWithInputs.ModelAction3<ModelComponentTag<SwiftSourceSetTag>, SourcePropertyComponent, ParentComponent>() {
+			// ComponentFromEntity<GradlePropertyComponent> read-write on SourcePropertyComponent
+			protected void execute(ModelNode entity, ModelComponentTag<SwiftSourceSetTag> ignored1, SourcePropertyComponent source, ParentComponent parent) {
+				((ConfigurableFileCollection) source.get().get(GradlePropertyComponent.class).get()).from((Callable<?>) () -> {
+					ModelStates.finalize(parent.get());
+					return ParentUtils.stream(parent).flatMap(it -> stream(it.find(SwiftSourcesComponent.class))).findFirst()
+						.map(it -> (Object) it.get()).orElse(Collections.emptyList());
+				});
+			}
+		});
 		project.getExtensions().getByType(ModelConfigurer.class).configure(new ModelActionWithInputs.ModelAction2<SwiftSourcesPropertyComponent, ModelState.IsAtLeastFinalized>() {
 			// ComponentFromEntity<GradlePropertyComponent> read-write on SwiftSourcesPropertyComponent
 			protected void execute(ModelNode entity, SwiftSourcesPropertyComponent swiftSources, ModelState.IsAtLeastFinalized ignored1) {

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/DependencyBucketCapabilityPlugin.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/DependencyBucketCapabilityPlugin.java
@@ -23,7 +23,6 @@ import dev.nokee.model.internal.core.DisplayNameComponent;
 import dev.nokee.model.internal.core.GradlePropertyComponent;
 import dev.nokee.model.internal.core.IdentifierComponent;
 import dev.nokee.model.internal.core.ModelActionWithInputs;
-import dev.nokee.model.internal.core.ModelComponentReference;
 import dev.nokee.model.internal.core.ModelElementProviderSourceComponent;
 import dev.nokee.model.internal.core.ModelNode;
 import dev.nokee.model.internal.core.ModelNodes;
@@ -109,11 +108,13 @@ public abstract class DependencyBucketCapabilityPlugin<T extends ExtensionAware 
 
 		target.getExtensions().getByType(ModelConfigurer.class).configure(new SyncBucketDependenciesToConfigurationProjectionRule());
 
-		// ComponentFromEntity<ParentComponent> read-only self
-		target.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelTags.referenceOf(IsDependencyBucket.class), ModelComponentReference.of(ModelPathComponent.class), ModelComponentReference.of(DisplayNameComponent.class), ModelComponentReference.of(ElementNameComponent.class), (entity, ignored1, path, displayName, elementName) -> {
-			val parentIdentifier = entity.find(ParentComponent.class).flatMap(parent -> parent.get().find(IdentifierComponent.class)).map(IdentifierComponent::get).orElse(null);
-			entity.addComponent(new IdentifierComponent(new DefaultDomainObjectIdentifier(elementName.get(), parentIdentifier, displayName.get(), path.get())));
-		}));
+		target.getExtensions().getByType(ModelConfigurer.class).configure(new ModelActionWithInputs.ModelAction4<ModelComponentTag<IsDependencyBucket>, ModelPathComponent, DisplayNameComponent, ElementNameComponent>() {
+			// ComponentFromEntity<ParentComponent> read-only self
+			protected void execute(ModelNode entity, ModelComponentTag<IsDependencyBucket> ignored1, ModelPathComponent path, DisplayNameComponent displayName, ElementNameComponent elementName) {
+				val parentIdentifier = entity.find(ParentComponent.class).flatMap(parent -> parent.get().find(IdentifierComponent.class)).map(IdentifierComponent::get).orElse(null);
+				entity.addComponent(new IdentifierComponent(new DefaultDomainObjectIdentifier(elementName.get(), parentIdentifier, displayName.get(), path.get())));
+			}
+		});
 
 		target.getExtensions().getByType(ModelConfigurer.class).configure(new DescriptionRule());
 

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/DependencyBucketCapabilityPlugin.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/dependencies/DependencyBucketCapabilityPlugin.java
@@ -101,9 +101,11 @@ public abstract class DependencyBucketCapabilityPlugin<T extends ExtensionAware 
 
 		target.getExtensions().getByType(ModelConfigurer.class).configure(new DisplayNameRule());
 
-		target.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelTags.referenceOf(IsDependencyBucket.class), ModelComponentReference.of(ConfigurationComponent.class), ModelComponentReference.of(ModelState.IsAtLeastFinalized.class), (entity, ignored1, configuration, ignored2) -> {
-			configuration.get().get().getExtendsFrom().forEach(it -> ((ConfigurationInternal) it).preventFromFurtherMutation());
-		}));
+		target.getExtensions().getByType(ModelConfigurer.class).configure(new ModelActionWithInputs.ModelAction3<ModelComponentTag<IsDependencyBucket>, ConfigurationComponent, ModelState.IsAtLeastFinalized>() {
+			protected void execute(ModelNode entity, ModelComponentTag<IsDependencyBucket> ignored1, ConfigurationComponent configuration, ModelState.IsAtLeastFinalized ignored2) {
+				configuration.get().get().getExtendsFrom().forEach(it -> ((ConfigurationInternal) it).preventFromFurtherMutation());
+			}
+		});
 
 		target.getExtensions().getByType(ModelConfigurer.class).configure(new SyncBucketDependenciesToConfigurationProjectionRule());
 

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/elements/ComponentElementsCapabilityPlugin.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/elements/ComponentElementsCapabilityPlugin.java
@@ -21,6 +21,7 @@ import dev.nokee.model.internal.core.GradlePropertyComponent;
 import dev.nokee.model.internal.core.ModelActionWithInputs;
 import dev.nokee.model.internal.core.ModelComponentReference;
 import dev.nokee.model.internal.core.ModelElementProviderSourceComponent;
+import dev.nokee.model.internal.core.ModelNode;
 import dev.nokee.model.internal.core.ModelNodeUtils;
 import dev.nokee.model.internal.core.ParentComponent;
 import dev.nokee.model.internal.names.RelativeName;
@@ -28,6 +29,7 @@ import dev.nokee.model.internal.names.RelativeNamesComponent;
 import dev.nokee.model.internal.registry.ModelConfigurer;
 import dev.nokee.model.internal.registry.ModelLookup;
 import dev.nokee.model.internal.state.ModelStates;
+import dev.nokee.model.internal.tags.ModelComponentTag;
 import dev.nokee.model.internal.tags.ModelTags;
 import dev.nokee.platform.base.internal.ModelNodeBackedViewStrategy;
 import dev.nokee.platform.base.internal.ViewAdapter;
@@ -59,9 +61,11 @@ public abstract class ComponentElementsCapabilityPlugin<T extends ExtensionAware
 	@Override
 	@SuppressWarnings("unchecked")
 	public void apply(T target) {
-		target.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelTags.referenceOf(ComponentElementsTag.class), ModelComponentReference.of(ComponentElementTypeComponent.class), ModelComponentReference.of(ParentComponent.class), (entity, tag, elementType, parent) -> {
-			entity.addComponent(createdUsing(of(ViewAdapter.class), () -> new ViewAdapter<>(elementType.get().getConcreteType(), new ModelNodeBackedViewStrategy(providers, () -> ModelStates.finalize(parent.get())))));
-		}));
+		target.getExtensions().getByType(ModelConfigurer.class).configure(new ModelActionWithInputs.ModelAction3<ModelComponentTag<ComponentElementsTag>, ComponentElementTypeComponent, ParentComponent>() {
+			protected void execute(ModelNode entity, ModelComponentTag<ComponentElementsTag> tag, ComponentElementTypeComponent elementType, ParentComponent parent) {
+				entity.addComponent(createdUsing(of(ViewAdapter.class), () -> new ViewAdapter<>(elementType.get().getConcreteType(), new ModelNodeBackedViewStrategy(providers, () -> ModelStates.finalize(parent.get())))));
+			}
+		});
 		target.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelTags.referenceOf(ComponentElementsTag.class), ModelComponentReference.of(ViewConfigurationBaseComponent.class), ModelComponentReference.of(ComponentElementTypeComponent.class), ModelComponentReference.of(GradlePropertyComponent.class), (entity, tag, base, elementType, property) -> {
 			((MapProperty<String, Object>) property.get()).set(providers.provider(() -> {
 				@SuppressWarnings("unchecked")

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/extensionaware/ExtensionAwareCapability.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/extensionaware/ExtensionAwareCapability.java
@@ -16,8 +16,9 @@
 package dev.nokee.platform.base.internal.extensionaware;
 
 import dev.nokee.model.internal.core.ModelActionWithInputs;
+import dev.nokee.model.internal.core.ModelNode;
 import dev.nokee.model.internal.registry.ModelConfigurer;
-import dev.nokee.model.internal.tags.ModelTags;
+import dev.nokee.model.internal.tags.ModelComponentTag;
 import org.gradle.api.Plugin;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.ExtensionAware;
@@ -35,9 +36,11 @@ public class ExtensionAwareCapability<T extends ExtensionAware & PluginAware> im
 
 	@Override
 	public void apply(T target) {
-		target.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelTags.referenceOf(ExtensionAwareMixIn.Tag.class), (entity, ignored1) -> {
-			entity.addComponent(new ExtensionAwareComponent(objects.newInstance(ExtensionContainerProvider.class).getExtensions()));
-		}));
+		target.getExtensions().getByType(ModelConfigurer.class).configure(new ModelActionWithInputs.ModelAction1<ModelComponentTag<ExtensionAwareMixIn.Tag>>() {
+			protected void execute(ModelNode entity, ModelComponentTag<ExtensionAwareMixIn.Tag> ignored1) {
+				entity.addComponent(new ExtensionAwareComponent(objects.newInstance(ExtensionContainerProvider.class).getExtensions()));
+			}
+		});
 	}
 
 	public interface ExtensionContainerProvider extends ExtensionAware {}

--- a/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/plugins/ComponentModelBasePlugin.java
+++ b/subprojects/platform-base/src/main/java/dev/nokee/platform/base/internal/plugins/ComponentModelBasePlugin.java
@@ -42,7 +42,7 @@ import dev.nokee.model.internal.registry.ModelLookup;
 import dev.nokee.model.internal.registry.ModelRegistry;
 import dev.nokee.model.internal.state.ModelState;
 import dev.nokee.model.internal.state.ModelStates;
-import dev.nokee.model.internal.tags.ModelTags;
+import dev.nokee.model.internal.tags.ModelComponentTag;
 import dev.nokee.model.internal.type.ModelType;
 import dev.nokee.model.internal.type.TypeOf;
 import dev.nokee.platform.base.Binary;
@@ -192,13 +192,15 @@ public class ComponentModelBasePlugin implements Plugin<Project> {
 				.build());
 		})));
 
-		// ComponentFromEntity<ParentComponent> read-only self
-		project.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelTags.referenceOf(IsTask.class), ModelComponentReference.of(ModelPathComponent.class), ModelComponentReference.of(DisplayNameComponent.class), ModelComponentReference.of(ElementNameComponent.class), ModelComponentReference.of(ModelState.IsAtLeastCreated.class), (entity, ignored1, path, displayName, elementName, ignored2) -> {
-			if (!entity.has(IdentifierComponent.class)) {
-				val parentIdentifier = entity.find(ParentComponent.class).map(parent -> parent.get().get(IdentifierComponent.class).get()).orElse(null);
-				entity.addComponent(new IdentifierComponent(new DefaultDomainObjectIdentifier(elementName.get(), parentIdentifier, displayName.get(), path.get())));
+		project.getExtensions().getByType(ModelConfigurer.class).configure(new ModelActionWithInputs.ModelAction5<ModelComponentTag<IsTask>, ModelPathComponent, DisplayNameComponent, ElementNameComponent, ModelState.IsAtLeastCreated>() {
+			// ComponentFromEntity<ParentComponent> read-only self
+			protected void execute(ModelNode entity, ModelComponentTag<IsTask> ignored1, ModelPathComponent path, DisplayNameComponent displayName, ElementNameComponent elementName, ModelState.IsAtLeastCreated ignored2) {
+				if (!entity.has(IdentifierComponent.class)) {
+					val parentIdentifier = entity.find(ParentComponent.class).map(parent -> parent.get().get(IdentifierComponent.class).get()).orElse(null);
+					entity.addComponent(new IdentifierComponent(new DefaultDomainObjectIdentifier(elementName.get(), parentIdentifier, displayName.get(), path.get())));
+				}
 			}
-		}));
+		});
 
 		project.getPluginManager().apply(ComponentElementsCapabilityPlugin.class);
 

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/IosComponentBasePlugin.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/IosComponentBasePlugin.java
@@ -21,7 +21,6 @@ import dev.nokee.model.internal.actions.ConfigurableTag;
 import dev.nokee.model.internal.core.GradlePropertyComponent;
 import dev.nokee.model.internal.core.IdentifierComponent;
 import dev.nokee.model.internal.core.ModelActionWithInputs;
-import dev.nokee.model.internal.core.ModelComponentReference;
 import dev.nokee.model.internal.core.ModelComponentType;
 import dev.nokee.model.internal.core.ModelNode;
 import dev.nokee.model.internal.core.ModelNodeUtils;
@@ -34,7 +33,6 @@ import dev.nokee.model.internal.registry.ModelConfigurer;
 import dev.nokee.model.internal.registry.ModelRegistry;
 import dev.nokee.model.internal.state.ModelStates;
 import dev.nokee.model.internal.tags.ModelComponentTag;
-import dev.nokee.model.internal.tags.ModelTags;
 import dev.nokee.platform.base.Binary;
 import dev.nokee.platform.base.internal.BuildVariantComponent;
 import dev.nokee.platform.base.internal.BuildVariantInternal;
@@ -98,47 +96,51 @@ public class IosComponentBasePlugin implements Plugin<Project> {
 	public void apply(Project project) {
 		project.getPluginManager().apply(NativeComponentBasePlugin.class);
 
-		project.getExtensions().getByType(ModelConfigurer.class).configure(new OnDiscover(ModelActionWithInputs.of(ModelComponentReference.of(IdentifierComponent.class), ModelTags.referenceOf(IosApplicationComponentTag.class), ModelComponentReference.of(FullyQualifiedNameComponent.class), (entity, identifier, tag, fullyQualifiedName) -> {
-			val registry = project.getExtensions().getByType(ModelRegistry.class);
+		project.getExtensions().getByType(ModelConfigurer.class).configure(new OnDiscover(new ModelActionWithInputs.ModelAction3<IdentifierComponent, ModelComponentTag<IosApplicationComponentTag>, FullyQualifiedNameComponent>() {
+			protected void execute(ModelNode entity, IdentifierComponent identifier, ModelComponentTag<IosApplicationComponentTag> tag, FullyQualifiedNameComponent fullyQualifiedName) {
+				val registry = project.getExtensions().getByType(ModelRegistry.class);
 
-			registry.register(newEntity("resources", IosResourceSetSpec.class, it -> it.ownedBy(entity))).configure(IosResourceSet.class, sourceSet -> sourceSet.from("src/" + fullyQualifiedName.get() + "/resources"));
+				registry.register(newEntity("resources", IosResourceSetSpec.class, it -> it.ownedBy(entity))).configure(IosResourceSet.class, sourceSet -> sourceSet.from("src/" + fullyQualifiedName.get() + "/resources"));
 
-			val implementation = registry.register(newEntity("implementation", DeclarableDependencyBucketSpec.class, it -> it.ownedBy(entity).withTag(FrameworkAwareDependencyBucketTag.class)));
-			val compileOnly = registry.register(newEntity("compileOnly", DeclarableDependencyBucketSpec.class, it -> it.ownedBy(entity).withTag(FrameworkAwareDependencyBucketTag.class)));
-			val linkOnly = registry.register(newEntity("linkOnly", DeclarableDependencyBucketSpec.class, it -> it.ownedBy(entity).withTag(FrameworkAwareDependencyBucketTag.class)));
-			val runtimeOnly = registry.register(newEntity("runtimeOnly", DeclarableDependencyBucketSpec.class, it -> it.ownedBy(entity).withTag(FrameworkAwareDependencyBucketTag.class)));
+				val implementation = registry.register(newEntity("implementation", DeclarableDependencyBucketSpec.class, it -> it.ownedBy(entity).withTag(FrameworkAwareDependencyBucketTag.class)));
+				val compileOnly = registry.register(newEntity("compileOnly", DeclarableDependencyBucketSpec.class, it -> it.ownedBy(entity).withTag(FrameworkAwareDependencyBucketTag.class)));
+				val linkOnly = registry.register(newEntity("linkOnly", DeclarableDependencyBucketSpec.class, it -> it.ownedBy(entity).withTag(FrameworkAwareDependencyBucketTag.class)));
+				val runtimeOnly = registry.register(newEntity("runtimeOnly", DeclarableDependencyBucketSpec.class, it -> it.ownedBy(entity).withTag(FrameworkAwareDependencyBucketTag.class)));
 
-			entity.addComponent(new ImplementationConfigurationComponent(ModelNodes.of(implementation)));
-			entity.addComponent(new CompileOnlyConfigurationComponent(ModelNodes.of(compileOnly)));
-			entity.addComponent(new LinkOnlyConfigurationComponent(ModelNodes.of(linkOnly)));
-			entity.addComponent(new RuntimeOnlyConfigurationComponent(ModelNodes.of(runtimeOnly)));
-		})));
-		project.getExtensions().getByType(ModelConfigurer.class).configure(new OnDiscover(ModelActionWithInputs.of(ModelComponentReference.of(IdentifierComponent.class), ModelTags.referenceOf(NativeVariantTag.class), ModelComponentReference.of(ParentComponent.class), (entity, identifier, tag, parent) -> {
-			if (!parent.get().hasComponent(typeOf(IosApplicationComponentTag.class))) {
-				return;
+				entity.addComponent(new ImplementationConfigurationComponent(ModelNodes.of(implementation)));
+				entity.addComponent(new CompileOnlyConfigurationComponent(ModelNodes.of(compileOnly)));
+				entity.addComponent(new LinkOnlyConfigurationComponent(ModelNodes.of(linkOnly)));
+				entity.addComponent(new RuntimeOnlyConfigurationComponent(ModelNodes.of(runtimeOnly)));
 			}
+		}));
+		project.getExtensions().getByType(ModelConfigurer.class).configure(new OnDiscover(new ModelActionWithInputs.ModelAction3<IdentifierComponent, ModelComponentTag<NativeVariantTag>, ParentComponent>() {
+			protected void execute(ModelNode entity, IdentifierComponent identifier, ModelComponentTag<NativeVariantTag> tag, ParentComponent parent) {
+				if (!parent.get().hasComponent(typeOf(IosApplicationComponentTag.class))) {
+					return;
+				}
 
-			val registry = project.getExtensions().getByType(ModelRegistry.class);
+				val registry = project.getExtensions().getByType(ModelRegistry.class);
 
-			val implementation = registry.register(newEntity("implementation", DeclarableDependencyBucketSpec.class, it -> it.ownedBy(entity).withTag(FrameworkAwareDependencyBucketTag.class)));
-			val compileOnly = registry.register(newEntity("compileOnly", DeclarableDependencyBucketSpec.class, it -> it.ownedBy(entity).withTag(FrameworkAwareDependencyBucketTag.class)));
-			val linkOnly = registry.register(newEntity("linkOnly", DeclarableDependencyBucketSpec.class, it -> it.ownedBy(entity).withTag(FrameworkAwareDependencyBucketTag.class)));
-			val runtimeOnly = registry.register(newEntity("runtimeOnly", DeclarableDependencyBucketSpec.class, it -> it.ownedBy(entity).withTag(FrameworkAwareDependencyBucketTag.class)));
+				val implementation = registry.register(newEntity("implementation", DeclarableDependencyBucketSpec.class, it -> it.ownedBy(entity).withTag(FrameworkAwareDependencyBucketTag.class)));
+				val compileOnly = registry.register(newEntity("compileOnly", DeclarableDependencyBucketSpec.class, it -> it.ownedBy(entity).withTag(FrameworkAwareDependencyBucketTag.class)));
+				val linkOnly = registry.register(newEntity("linkOnly", DeclarableDependencyBucketSpec.class, it -> it.ownedBy(entity).withTag(FrameworkAwareDependencyBucketTag.class)));
+				val runtimeOnly = registry.register(newEntity("runtimeOnly", DeclarableDependencyBucketSpec.class, it -> it.ownedBy(entity).withTag(FrameworkAwareDependencyBucketTag.class)));
 
-			entity.addComponent(new ImplementationConfigurationComponent(ModelNodes.of(implementation)));
-			entity.addComponent(new CompileOnlyConfigurationComponent(ModelNodes.of(compileOnly)));
-			entity.addComponent(new LinkOnlyConfigurationComponent(ModelNodes.of(linkOnly)));
-			entity.addComponent(new RuntimeOnlyConfigurationComponent(ModelNodes.of(runtimeOnly)));
+				entity.addComponent(new ImplementationConfigurationComponent(ModelNodes.of(implementation)));
+				entity.addComponent(new CompileOnlyConfigurationComponent(ModelNodes.of(compileOnly)));
+				entity.addComponent(new LinkOnlyConfigurationComponent(ModelNodes.of(linkOnly)));
+				entity.addComponent(new RuntimeOnlyConfigurationComponent(ModelNodes.of(runtimeOnly)));
 
-			val runtimeElements = registry.register(newEntity("runtimeElements", ConsumableDependencyBucketSpec.class, it -> it.ownedBy(entity)));
-			runtimeElements.configure(Configuration.class, configureExtendsFrom(implementation.as(Configuration.class), runtimeOnly.as(Configuration.class))
-				.andThen(configureAttributes(it -> it.usage(project.getObjects().named(Usage.class, Usage.NATIVE_RUNTIME))))
-				.andThen(ConfigurationUtilsEx.configureOutgoingAttributes((BuildVariantInternal) ((VariantIdentifier) identifier.get()).getBuildVariant(), project.getObjects())));
-			val outgoing = entity.addComponent(new NativeOutgoingDependenciesComponent(new IosApplicationOutgoingDependencies(ModelNodeUtils.get(ModelNodes.of(runtimeElements), Configuration.class), project.getObjects())));
-			entity.addComponent(new VariantComponentDependencies<NativeComponentDependencies>(ModelProperties.getProperty(entity, "dependencies").as(NativeComponentDependencies.class)::get, outgoing.get()));
+				val runtimeElements = registry.register(newEntity("runtimeElements", ConsumableDependencyBucketSpec.class, it -> it.ownedBy(entity)));
+				runtimeElements.configure(Configuration.class, configureExtendsFrom(implementation.as(Configuration.class), runtimeOnly.as(Configuration.class))
+					.andThen(configureAttributes(it -> it.usage(project.getObjects().named(Usage.class, Usage.NATIVE_RUNTIME))))
+					.andThen(ConfigurationUtilsEx.configureOutgoingAttributes((BuildVariantInternal) ((VariantIdentifier) identifier.get()).getBuildVariant(), project.getObjects())));
+				val outgoing = entity.addComponent(new NativeOutgoingDependenciesComponent(new IosApplicationOutgoingDependencies(ModelNodeUtils.get(ModelNodes.of(runtimeElements), Configuration.class), project.getObjects())));
+				entity.addComponent(new VariantComponentDependencies<NativeComponentDependencies>(ModelProperties.getProperty(entity, "dependencies").as(NativeComponentDependencies.class)::get, outgoing.get()));
 
-			registry.instantiate(configureMatching(ownedBy(entity.getId()).and(subtypeOf(of(Configuration.class))), new ExtendsFromParentConfigurationAction()));
-		})));
+				registry.instantiate(configureMatching(ownedBy(entity.getId()).and(subtypeOf(of(Configuration.class))), new ExtendsFromParentConfigurationAction()));
+			}
+		}));
 		project.getExtensions().getByType(ModelConfigurer.class).configure(new ModelActionWithInputs.ModelAction2<ModelComponentTag<IosApplicationComponentTag>, LinkedVariantsComponent>() {
 			protected void execute(ModelNode entity, ModelComponentTag<IosApplicationComponentTag> tag, LinkedVariantsComponent variants) {
 				val component = ModelNodeUtils.get(entity, DefaultIosApplicationComponent.class);

--- a/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/IosComponentBasePlugin.java
+++ b/subprojects/platform-ios/src/main/java/dev/nokee/platform/ios/internal/plugins/IosComponentBasePlugin.java
@@ -33,6 +33,7 @@ import dev.nokee.model.internal.names.FullyQualifiedNameComponent;
 import dev.nokee.model.internal.registry.ModelConfigurer;
 import dev.nokee.model.internal.registry.ModelRegistry;
 import dev.nokee.model.internal.state.ModelStates;
+import dev.nokee.model.internal.tags.ModelComponentTag;
 import dev.nokee.model.internal.tags.ModelTags;
 import dev.nokee.platform.base.Binary;
 import dev.nokee.platform.base.internal.BuildVariantComponent;
@@ -138,32 +139,40 @@ public class IosComponentBasePlugin implements Plugin<Project> {
 
 			registry.instantiate(configureMatching(ownedBy(entity.getId()).and(subtypeOf(of(Configuration.class))), new ExtendsFromParentConfigurationAction()));
 		})));
-		project.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelTags.referenceOf(IosApplicationComponentTag.class), ModelComponentReference.of(LinkedVariantsComponent.class), (entity, tag, variants) -> {
-			val component = ModelNodeUtils.get(entity, DefaultIosApplicationComponent.class);
+		project.getExtensions().getByType(ModelConfigurer.class).configure(new ModelActionWithInputs.ModelAction2<ModelComponentTag<IosApplicationComponentTag>, LinkedVariantsComponent>() {
+			protected void execute(ModelNode entity, ModelComponentTag<IosApplicationComponentTag> tag, LinkedVariantsComponent variants) {
+				val component = ModelNodeUtils.get(entity, DefaultIosApplicationComponent.class);
 
-			Streams.zip(component.getBuildVariants().get().stream(), Streams.stream(variants), (buildVariant, variant) -> {
-				val variantIdentifier = VariantIdentifier.builder().withBuildVariant((BuildVariantInternal) buildVariant).withComponentIdentifier(component.getIdentifier()).build();
+				Streams.zip(component.getBuildVariants().get().stream(), Streams.stream(variants), (buildVariant, variant) -> {
+					val variantIdentifier = VariantIdentifier.builder().withBuildVariant((BuildVariantInternal) buildVariant).withComponentIdentifier(component.getIdentifier()).build();
 
-				iosApplicationVariant(variantIdentifier, component, project).getComponents().forEach(variant::addComponent);
-				variant.addComponent(new BuildVariantComponent(buildVariant));
-				ModelStates.register(variant);
+					iosApplicationVariant(variantIdentifier, component, project).getComponents().forEach(variant::addComponent);
+					variant.addComponent(new BuildVariantComponent(buildVariant));
+					ModelStates.register(variant);
 
-				onEachVariantDependencies(variant, variant.getComponent(ModelComponentType.componentOf(VariantComponentDependencies.class)), project.getProviders());
-				return null;
-			}).forEach(it -> {});
+					onEachVariantDependencies(variant, variant.getComponent(ModelComponentType.componentOf(VariantComponentDependencies.class)), project.getProviders());
+					return null;
+				}).forEach(it -> {});
 
-			component.finalizeValue();
-		}));
+				component.finalizeValue();
+			}
+		});
 
-		project.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelTags.referenceOf(IosApplicationComponentTag.class), ModelComponentReference.of(TargetMachinesPropertyComponent.class), (entity, tag, targetMachines) -> {
-			((SetProperty<TargetMachine>) targetMachines.get().get(GradlePropertyComponent.class).get()).convention(Collections.singletonList(NativeRuntimeBasePlugin.TARGET_MACHINE_FACTORY.os("ios").getX86_64()));
-		}));
-		project.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelTags.referenceOf(IosApplicationComponentTag.class), ModelComponentReference.of(TargetLinkagesPropertyComponent.class), (entity, tag, targetLinkages) -> {
-			((SetProperty<TargetLinkage>) targetLinkages.get().get(GradlePropertyComponent.class).get()).convention(Collections.singletonList(TargetLinkages.EXECUTABLE));
-		}));
-		project.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelTags.referenceOf(IosApplicationComponentTag.class), ModelComponentReference.of(TargetBuildTypesPropertyComponent.class), (entity, tag, targetBuildTypes) -> {
-			((SetProperty<TargetBuildType>) targetBuildTypes.get().get(GradlePropertyComponent.class).get()).convention(Collections.singletonList(TargetBuildTypes.named("Default")));
-		}));
+		project.getExtensions().getByType(ModelConfigurer.class).configure(new ModelActionWithInputs.ModelAction2<ModelComponentTag<IosApplicationComponentTag>, TargetMachinesPropertyComponent>() {
+			protected void execute(ModelNode entity, ModelComponentTag<IosApplicationComponentTag> tag, TargetMachinesPropertyComponent targetMachines) {
+				((SetProperty<TargetMachine>) targetMachines.get().get(GradlePropertyComponent.class).get()).convention(Collections.singletonList(NativeRuntimeBasePlugin.TARGET_MACHINE_FACTORY.os("ios").getX86_64()));
+			}
+		});
+		project.getExtensions().getByType(ModelConfigurer.class).configure(new ModelActionWithInputs.ModelAction2<ModelComponentTag<IosApplicationComponentTag>, TargetLinkagesPropertyComponent>() {
+			protected void execute(ModelNode entity, ModelComponentTag<IosApplicationComponentTag> tag, TargetLinkagesPropertyComponent targetLinkages) {
+				((SetProperty<TargetLinkage>) targetLinkages.get().get(GradlePropertyComponent.class).get()).convention(Collections.singletonList(TargetLinkages.EXECUTABLE));
+			}
+		});
+		project.getExtensions().getByType(ModelConfigurer.class).configure(new ModelActionWithInputs.ModelAction2<ModelComponentTag<IosApplicationComponentTag>, TargetBuildTypesPropertyComponent>() {
+			protected void execute(ModelNode entity, ModelComponentTag<IosApplicationComponentTag> tag, TargetBuildTypesPropertyComponent targetBuildTypes) {
+				((SetProperty<TargetBuildType>) targetBuildTypes.get().get(GradlePropertyComponent.class).get()).convention(Collections.singletonList(TargetBuildTypes.named("Default")));
+			}
+		});
 	}
 
 	@SuppressWarnings("unchecked")

--- a/subprojects/platform-jni/src/main/java/dev/nokee/language/jvm/internal/plugins/JvmLanguageBasePlugin.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/language/jvm/internal/plugins/JvmLanguageBasePlugin.java
@@ -83,13 +83,15 @@ public class JvmLanguageBasePlugin implements Plugin<Project> {
 					entity.addComponent(new CompileTaskComponent(ModelNodes.of(compileTask)));
 				}
 			}));
-			project.getExtensions().getByType(ModelConfigurer.class).configure(new OnDiscover(ModelActionWithInputs.of(ModelTags.referenceOf(KotlinSourceSetSpec.Tag.class), ModelComponentReference.of(IdentifierComponent.class), ModelComponentReference.of(ParentComponent.class), ModelComponentReference.of(SourceSetComponent.class), (entity, projection, identifier, parent, sourceSet) -> {
-				val sourceSetProvider = sourceSet.get();
-				@SuppressWarnings("unchecked")
-				val KotlinCompile  = (Class<Task>) ModelTypeUtils.toUndecoratedType(sourceSetProvider.flatMap(it -> project.getTasks().named(it.getCompileTaskName("kotlin"))).get().getClass());
-				val compileTask = registry.register(newEntity("compile", KotlinCompile, it -> it.ownedBy(entity)));
-				entity.addComponent(new CompileTaskComponent(ModelNodes.of(compileTask)));
-			})));
+			project.getExtensions().getByType(ModelConfigurer.class).configure(new OnDiscover(new ModelActionWithInputs.ModelAction4<ModelComponentTag<KotlinSourceSetSpec.Tag>, IdentifierComponent, ParentComponent, SourceSetComponent>() {
+				protected void execute(ModelNode entity, ModelComponentTag<KotlinSourceSetSpec.Tag> projection, IdentifierComponent identifier, ParentComponent parent, SourceSetComponent sourceSet) {
+					val sourceSetProvider = sourceSet.get();
+					@SuppressWarnings("unchecked")
+					val KotlinCompile  = (Class<Task>) ModelTypeUtils.toUndecoratedType(sourceSetProvider.flatMap(it -> project.getTasks().named(it.getCompileTaskName("kotlin"))).get().getClass());
+					val compileTask = registry.register(newEntity("compile", KotlinCompile, it -> it.ownedBy(entity)));
+					entity.addComponent(new CompileTaskComponent(ModelNodes.of(compileTask)));
+				}
+			}));
 
 			// ComponentFromEntity<FullyQualifiedNameComponent> read-only (on parent only)
 			project.getExtensions().getByType(ModelConfigurer.class).configure(new AttachGroovySourcesToGroovySourceSet());

--- a/subprojects/platform-jni/src/main/java/dev/nokee/language/jvm/internal/plugins/JvmLanguageBasePlugin.java
+++ b/subprojects/platform-jni/src/main/java/dev/nokee/language/jvm/internal/plugins/JvmLanguageBasePlugin.java
@@ -62,21 +62,27 @@ public class JvmLanguageBasePlugin implements Plugin<Project> {
 
 		project.getPlugins().withType(JavaBasePlugin.class, ignored -> {
 			// ComponentFromEntity<FullyQualifiedNameComponent> read-only (on parent only)
-			project.getExtensions().getByType(ModelConfigurer.class).configure(new OnDiscover(ModelActionWithInputs.of(ModelTags.referenceOf(JvmSourceSetTag.class), ModelComponentReference.of(ParentComponent.class), (entity, projection, parent) -> {
-				val sourceSetRegistry = NamedDomainObjectRegistry.of(project.getExtensions().getByType(SourceSetContainer.class));
-				val sourceSetProvider = sourceSetRegistry.registerIfAbsent(parent.get().get(FullyQualifiedNameComponent.class).get().toString());
-				entity.addComponent(new SourceSetComponent(sourceSetProvider));
-			})));
+			project.getExtensions().getByType(ModelConfigurer.class).configure(new OnDiscover(new ModelActionWithInputs.ModelAction2<ModelComponentTag<JvmSourceSetTag>, ParentComponent>() {
+				protected void execute(ModelNode entity, ModelComponentTag<JvmSourceSetTag> projection, ParentComponent parent) {
+					val sourceSetRegistry = NamedDomainObjectRegistry.of(project.getExtensions().getByType(SourceSetContainer.class));
+					val sourceSetProvider = sourceSetRegistry.registerIfAbsent(parent.get().get(FullyQualifiedNameComponent.class).get().toString());
+					entity.addComponent(new SourceSetComponent(sourceSetProvider));
+				}
+			}));
 
 			val registry = project.getExtensions().getByType(ModelRegistry.class);
-			project.getExtensions().getByType(ModelConfigurer.class).configure(new OnDiscover(ModelActionWithInputs.of(ModelTags.referenceOf(JavaSourceSetSpec.Tag.class), ModelComponentReference.of(IdentifierComponent.class), (entity, tag, identifier) -> {
-				val compileTask = registry.register(newEntity("compile", JavaCompile.class, it -> it.ownedBy(entity)));
-				entity.addComponent(new CompileTaskComponent(ModelNodes.of(compileTask)));
-			})));
-			project.getExtensions().getByType(ModelConfigurer.class).configure(new OnDiscover(ModelActionWithInputs.of(ModelTags.referenceOf(GroovySourceSetSpec.Tag.class), ModelComponentReference.of(IdentifierComponent.class), (entity, projection, identifier) -> {
-				val compileTask = registry.register(newEntity("compile", GroovyCompile.class, it -> it.ownedBy(entity)));
-				entity.addComponent(new CompileTaskComponent(ModelNodes.of(compileTask)));
-			})));
+			project.getExtensions().getByType(ModelConfigurer.class).configure(new OnDiscover(new ModelActionWithInputs.ModelAction2<ModelComponentTag<JavaSourceSetSpec.Tag>, IdentifierComponent>() {
+				protected void execute(ModelNode entity, ModelComponentTag<JavaSourceSetSpec.Tag> tag, IdentifierComponent identifier) {
+					val compileTask = registry.register(newEntity("compile", JavaCompile.class, it -> it.ownedBy(entity)));
+					entity.addComponent(new CompileTaskComponent(ModelNodes.of(compileTask)));
+				}
+			}));
+			project.getExtensions().getByType(ModelConfigurer.class).configure(new OnDiscover(new ModelActionWithInputs.ModelAction2<ModelComponentTag<GroovySourceSetSpec.Tag>, IdentifierComponent>() {
+				protected void execute(ModelNode entity, ModelComponentTag<GroovySourceSetSpec.Tag> projection, IdentifierComponent identifier) {
+					val compileTask = registry.register(newEntity("compile", GroovyCompile.class, it -> it.ownedBy(entity)));
+					entity.addComponent(new CompileTaskComponent(ModelNodes.of(compileTask)));
+				}
+			}));
 			project.getExtensions().getByType(ModelConfigurer.class).configure(new OnDiscover(ModelActionWithInputs.of(ModelTags.referenceOf(KotlinSourceSetSpec.Tag.class), ModelComponentReference.of(IdentifierComponent.class), ModelComponentReference.of(ParentComponent.class), ModelComponentReference.of(SourceSetComponent.class), (entity, projection, identifier, parent, sourceSet) -> {
 				val sourceSetProvider = sourceSet.get();
 				@SuppressWarnings("unchecked")

--- a/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeComponentBasePlugin.java
+++ b/subprojects/platform-native/src/main/java/dev/nokee/platform/nativebase/internal/plugins/NativeComponentBasePlugin.java
@@ -253,82 +253,84 @@ public class NativeComponentBasePlugin implements Plugin<Project> {
 			}
 		});
 
-		project.getExtensions().getByType(ModelConfigurer.class).configure(new OnDiscover(ModelActionWithInputs.of(ModelTags.referenceOf(NativeVariantTag.class), ModelComponentReference.of(BuildVariantComponent.class), ModelComponentReference.of(IdentifierComponent.class), ModelComponentReference.of(ParentComponent.class), (entity, ignored1, buildVariantComponent, identifier, parent) -> {
-			val registry = project.getExtensions().getByType(ModelRegistry.class);
-			val buildVariant = (BuildVariantInternal) buildVariantComponent.get();
+		project.getExtensions().getByType(ModelConfigurer.class).configure(new OnDiscover(new ModelActionWithInputs.ModelAction4<ModelComponentTag<NativeVariantTag>, BuildVariantComponent, IdentifierComponent, ParentComponent>() {
+			protected void execute(ModelNode entity, ModelComponentTag<NativeVariantTag> ignored1, BuildVariantComponent buildVariantComponent, IdentifierComponent identifier, ParentComponent parent) {
+				val registry = project.getExtensions().getByType(ModelRegistry.class);
+				val buildVariant = (BuildVariantInternal) buildVariantComponent.get();
 
-			if (buildVariant.hasAxisValue(BinaryLinkage.BINARY_LINKAGE_COORDINATE_AXIS)) {
-				registry.instantiate(configureEach(descendantOf(entity.getId()), CSourceSetSpec.class, sourceSet -> {
-					sourceSet.getCompileTask().configure(task -> NativePlatformFactory.create(buildVariant).ifPresent(task.getTargetPlatform()::set));
-					ModelNodes.of(sourceSet).addComponent(new BuildVariantComponent(buildVariant));
-				}));
-				registry.instantiate(configureEach(descendantOf(entity.getId()), CppSourceSetSpec.class, sourceSet -> {
-					sourceSet.getCompileTask().configure(task -> NativePlatformFactory.create(buildVariant).ifPresent(task.getTargetPlatform()::set));
-					ModelNodes.of(sourceSet).addComponent(new BuildVariantComponent(buildVariant));
-				}));
-				registry.instantiate(configureEach(descendantOf(entity.getId()), ObjectiveCSourceSetSpec.class, sourceSet -> {
-					sourceSet.getCompileTask().configure(task -> NativePlatformFactory.create(buildVariant).ifPresent(task.getTargetPlatform()::set));
-					ModelNodes.of(sourceSet).addComponent(new BuildVariantComponent(buildVariant));
-				}));
-				registry.instantiate(configureEach(descendantOf(entity.getId()), ObjectiveCppSourceSetSpec.class, sourceSet -> {
-					sourceSet.getCompileTask().configure(task -> NativePlatformFactory.create(buildVariant).ifPresent(task.getTargetPlatform()::set));
-					ModelNodes.of(sourceSet).addComponent(new BuildVariantComponent(buildVariant));
-				}));
-				registry.instantiate(configureEach(descendantOf(entity.getId()), SwiftSourceSetSpec.class, sourceSet -> {
-					sourceSet.getCompileTask().configure(task -> NativePlatformFactory.create(buildVariant).ifPresent(task.getTargetPlatform()::set));
-					sourceSet.getCompileTask().configure(task -> task.getModuleName().set(project.getProviders().provider(() -> TextCaseUtils.toCamelCase(ModelStates.finalize(ModelNodes.of(sourceSet).get(ParentComponent.class).get()).get(BaseNameComponent.class).get()))));
-					ModelNodes.of(sourceSet).addComponent(new BuildVariantComponent(buildVariant));
-				}));
+				if (buildVariant.hasAxisValue(BinaryLinkage.BINARY_LINKAGE_COORDINATE_AXIS)) {
+					registry.instantiate(configureEach(descendantOf(entity.getId()), CSourceSetSpec.class, sourceSet -> {
+						sourceSet.getCompileTask().configure(task -> NativePlatformFactory.create(buildVariant).ifPresent(task.getTargetPlatform()::set));
+						ModelNodes.of(sourceSet).addComponent(new BuildVariantComponent(buildVariant));
+					}));
+					registry.instantiate(configureEach(descendantOf(entity.getId()), CppSourceSetSpec.class, sourceSet -> {
+						sourceSet.getCompileTask().configure(task -> NativePlatformFactory.create(buildVariant).ifPresent(task.getTargetPlatform()::set));
+						ModelNodes.of(sourceSet).addComponent(new BuildVariantComponent(buildVariant));
+					}));
+					registry.instantiate(configureEach(descendantOf(entity.getId()), ObjectiveCSourceSetSpec.class, sourceSet -> {
+						sourceSet.getCompileTask().configure(task -> NativePlatformFactory.create(buildVariant).ifPresent(task.getTargetPlatform()::set));
+						ModelNodes.of(sourceSet).addComponent(new BuildVariantComponent(buildVariant));
+					}));
+					registry.instantiate(configureEach(descendantOf(entity.getId()), ObjectiveCppSourceSetSpec.class, sourceSet -> {
+						sourceSet.getCompileTask().configure(task -> NativePlatformFactory.create(buildVariant).ifPresent(task.getTargetPlatform()::set));
+						ModelNodes.of(sourceSet).addComponent(new BuildVariantComponent(buildVariant));
+					}));
+					registry.instantiate(configureEach(descendantOf(entity.getId()), SwiftSourceSetSpec.class, sourceSet -> {
+						sourceSet.getCompileTask().configure(task -> NativePlatformFactory.create(buildVariant).ifPresent(task.getTargetPlatform()::set));
+						sourceSet.getCompileTask().configure(task -> task.getModuleName().set(project.getProviders().provider(() -> TextCaseUtils.toCamelCase(ModelStates.finalize(ModelNodes.of(sourceSet).get(ParentComponent.class).get()).get(BaseNameComponent.class).get()))));
+						ModelNodes.of(sourceSet).addComponent(new BuildVariantComponent(buildVariant));
+					}));
 
-				val linkage = buildVariant.getAxisValue(BinaryLinkage.BINARY_LINKAGE_COORDINATE_AXIS);
-				if (linkage.isExecutable()) {
-					val binaryIdentifier = BinaryIdentifier.of(identifier.get(), BinaryIdentity.ofMain("executable", "executable binary"));
+					val linkage = buildVariant.getAxisValue(BinaryLinkage.BINARY_LINKAGE_COORDINATE_AXIS);
+					if (linkage.isExecutable()) {
+						val binaryIdentifier = BinaryIdentifier.of(identifier.get(), BinaryIdentity.ofMain("executable", "executable binary"));
 
-					val executableBinary = registry.register(newEntity("executable", ExecutableBinaryInternal.class, it -> it.ownedBy(entity)
-						.displayName("executable binary")
-						.withComponent(new IdentifierComponent(binaryIdentifier))
-						.withComponent(new BuildVariantComponent(buildVariant))
-						.withTag(ExcludeFromQualifyingNameTag.class)
-					));
-					entity.addComponent(new NativeExecutableBinaryComponent(ModelNodes.of(executableBinary)));
-				} else if (linkage.isShared()) {
-					val binaryIdentifier = BinaryIdentifier.of(identifier.get(), BinaryIdentity.ofMain("sharedLibrary", "shared library binary"));
+						val executableBinary = registry.register(newEntity("executable", ExecutableBinaryInternal.class, it -> it.ownedBy(entity)
+							.displayName("executable binary")
+							.withComponent(new IdentifierComponent(binaryIdentifier))
+							.withComponent(new BuildVariantComponent(buildVariant))
+							.withTag(ExcludeFromQualifyingNameTag.class)
+						));
+						entity.addComponent(new NativeExecutableBinaryComponent(ModelNodes.of(executableBinary)));
+					} else if (linkage.isShared()) {
+						val binaryIdentifier = BinaryIdentifier.of(identifier.get(), BinaryIdentity.ofMain("sharedLibrary", "shared library binary"));
 
-					val sharedLibraryBinary = registry.register(newEntity("sharedLibrary", SharedLibraryBinaryInternal.class, it -> it.ownedBy(entity)
-						.displayName("shared library binary")
-						.withComponent(new IdentifierComponent(binaryIdentifier))
-						.withComponent(new BuildVariantComponent(buildVariant))
-						.withTag(ExcludeFromQualifyingNameTag.class)
-					));
-					entity.addComponent(new NativeSharedLibraryBinaryComponent(ModelNodes.of(sharedLibraryBinary)));
-				} else if (linkage.isBundle()) {
-					val binaryIdentifier = BinaryIdentifier.of(identifier.get(), BinaryIdentity.ofMain("bundle", "bundle binary"));
+						val sharedLibraryBinary = registry.register(newEntity("sharedLibrary", SharedLibraryBinaryInternal.class, it -> it.ownedBy(entity)
+							.displayName("shared library binary")
+							.withComponent(new IdentifierComponent(binaryIdentifier))
+							.withComponent(new BuildVariantComponent(buildVariant))
+							.withTag(ExcludeFromQualifyingNameTag.class)
+						));
+						entity.addComponent(new NativeSharedLibraryBinaryComponent(ModelNodes.of(sharedLibraryBinary)));
+					} else if (linkage.isBundle()) {
+						val binaryIdentifier = BinaryIdentifier.of(identifier.get(), BinaryIdentity.ofMain("bundle", "bundle binary"));
 
-					registry.register(newEntity("bundle", BundleBinaryInternal.class, it -> it.ownedBy(entity)
-						.displayName("bundle binary")
-						.withComponent(new IdentifierComponent(binaryIdentifier))
-						.withComponent(new BuildVariantComponent(buildVariant))
-						.withTag(ExcludeFromQualifyingNameTag.class)
-					));
-				} else if (linkage.isStatic()) {
-					val binaryIdentifier = BinaryIdentifier.of(identifier.get(), BinaryIdentity.ofMain("staticLibrary", "static library binary"));
+						registry.register(newEntity("bundle", BundleBinaryInternal.class, it -> it.ownedBy(entity)
+							.displayName("bundle binary")
+							.withComponent(new IdentifierComponent(binaryIdentifier))
+							.withComponent(new BuildVariantComponent(buildVariant))
+							.withTag(ExcludeFromQualifyingNameTag.class)
+						));
+					} else if (linkage.isStatic()) {
+						val binaryIdentifier = BinaryIdentifier.of(identifier.get(), BinaryIdentity.ofMain("staticLibrary", "static library binary"));
 
-					val staticLibraryBinary = registry.register(newEntity("staticLibrary", StaticLibraryBinaryInternal.class, it -> it.ownedBy(entity)
+						val staticLibraryBinary = registry.register(newEntity("staticLibrary", StaticLibraryBinaryInternal.class, it -> it.ownedBy(entity)
 							.displayName("static library binary")
 							.withComponent(new IdentifierComponent(binaryIdentifier))
 							.withComponent(new BuildVariantComponent(buildVariant))
 							.withTag(ExcludeFromQualifyingNameTag.class)
 						));
-					entity.addComponent(new NativeStaticLibraryBinaryComponent(ModelNodes.of(staticLibraryBinary)));
-				}
+						entity.addComponent(new NativeStaticLibraryBinaryComponent(ModelNodes.of(staticLibraryBinary)));
+					}
 
-				if (linkage.isShared() || linkage.isStatic()) {
-					registry.instantiate(configureEach(descendantOf(entity.getId()), SwiftCompileTask.class, task -> {
-						task.getCompilerArgs().add("-parse-as-library");
-					}));
+					if (linkage.isShared() || linkage.isStatic()) {
+						registry.instantiate(configureEach(descendantOf(entity.getId()), SwiftCompileTask.class, task -> {
+							task.getCompilerArgs().add("-parse-as-library");
+						}));
+					}
 				}
 			}
-		})));
+		}));
 
 		project.getExtensions().getByType(ModelConfigurer.class).configure(new OnDiscover(new RuntimeLibrariesConfigurationRegistrationRule(project.getExtensions().getByType(ModelRegistry.class), project.getObjects())));
 		project.getExtensions().getByType(ModelConfigurer.class).configure(new AttachAttributesToConfigurationRule<>(RuntimeLibrariesConfiguration.class, project.getExtensions().getByType(ModelRegistry.class), project.getObjects()));
@@ -506,33 +508,39 @@ public class NativeComponentBasePlugin implements Plugin<Project> {
 		});
 
 		// TODO: Should be part of native-application-base plugin
-		project.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelTags.referenceOf(NativeVariantTag.class), ModelComponentReference.of(BuildVariantComponent.class), ModelComponentReference.of(ParentComponent.class), ModelComponentReference.of(NativeExecutableBinaryComponent.class), (entity, ignored1, buildVariant, parent, binary) -> {
-			if (parent.get().hasComponent(ModelTags.typeOf(NativeApplicationTag.class))) {
-				val lifecycleTask = project.getExtensions().getByType(ModelRegistry.class).register(newEntity("executable", Task.class, it -> it.ownedBy(entity)));
-				lifecycleTask.configure(Task.class, configureBuildGroup());
-				lifecycleTask.configure(Task.class, configureDescription("Assembles a executable binary containing the objects files of %s.", binary.get().get(IdentifierComponent.class).get()));
-				lifecycleTask.configure(Task.class, configureDependsOn((Callable<?>) () -> ModelNodeUtils.get(ModelStates.finalize(binary.get()), ExecutableBinary.class)));
+		project.getExtensions().getByType(ModelConfigurer.class).configure(new ModelActionWithInputs.ModelAction4<ModelComponentTag<NativeVariantTag>, BuildVariantComponent, ParentComponent, NativeExecutableBinaryComponent>() {
+			protected void execute(ModelNode entity, ModelComponentTag<NativeVariantTag> ignored1, BuildVariantComponent buildVariant, ParentComponent parent, NativeExecutableBinaryComponent binary) {
+				if (parent.get().hasComponent(ModelTags.typeOf(NativeApplicationTag.class))) {
+					val lifecycleTask = project.getExtensions().getByType(ModelRegistry.class).register(newEntity("executable", Task.class, it -> it.ownedBy(entity)));
+					lifecycleTask.configure(Task.class, configureBuildGroup());
+					lifecycleTask.configure(Task.class, configureDescription("Assembles a executable binary containing the objects files of %s.", binary.get().get(IdentifierComponent.class).get()));
+					lifecycleTask.configure(Task.class, configureDependsOn((Callable<?>) () -> ModelNodeUtils.get(ModelStates.finalize(binary.get()), ExecutableBinary.class)));
+				}
 			}
-		}));
+		});
 
 		// TODO: Should be part of native-library-base plugin
-		project.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelTags.referenceOf(NativeVariantTag.class), ModelComponentReference.of(BuildVariantComponent.class), ModelComponentReference.of(ParentComponent.class), ModelComponentReference.of(NativeSharedLibraryBinaryComponent.class), (entity, ignored1, buildVariant, parent, binary) -> {
-			if (parent.get().hasComponent(ModelTags.typeOf(NativeLibraryTag.class))) {
-				val lifecycleTask = project.getExtensions().getByType(ModelRegistry.class).register(newEntity("sharedLibrary", Task.class, it -> it.ownedBy(entity)));
-				lifecycleTask.configure(Task.class, configureBuildGroup());
-				lifecycleTask.configure(Task.class, configureDescription("Assembles a shared library binary containing the objects files of %s.", binary.get().get(IdentifierComponent.class).get()));
-				lifecycleTask.configure(Task.class, configureDependsOn((Callable<?>) () -> ModelNodeUtils.get(ModelStates.finalize(binary.get()), SharedLibraryBinary.class)));
+		project.getExtensions().getByType(ModelConfigurer.class).configure(new ModelActionWithInputs.ModelAction4<ModelComponentTag<NativeVariantTag>, BuildVariantComponent, ParentComponent, NativeSharedLibraryBinaryComponent>() {
+			protected void execute(ModelNode entity, ModelComponentTag<NativeVariantTag> ignored1, BuildVariantComponent buildVariant, ParentComponent parent, NativeSharedLibraryBinaryComponent binary) {
+				if (parent.get().hasComponent(ModelTags.typeOf(NativeLibraryTag.class))) {
+					val lifecycleTask = project.getExtensions().getByType(ModelRegistry.class).register(newEntity("sharedLibrary", Task.class, it -> it.ownedBy(entity)));
+					lifecycleTask.configure(Task.class, configureBuildGroup());
+					lifecycleTask.configure(Task.class, configureDescription("Assembles a shared library binary containing the objects files of %s.", binary.get().get(IdentifierComponent.class).get()));
+					lifecycleTask.configure(Task.class, configureDependsOn((Callable<?>) () -> ModelNodeUtils.get(ModelStates.finalize(binary.get()), SharedLibraryBinary.class)));
+				}
 			}
-		}));
+		});
 		// TODO: Should be part of native-library-base plugin
-		project.getExtensions().getByType(ModelConfigurer.class).configure(ModelActionWithInputs.of(ModelTags.referenceOf(NativeVariantTag.class), ModelComponentReference.of(BuildVariantComponent.class), ModelComponentReference.of(ParentComponent.class), ModelComponentReference.of(NativeStaticLibraryBinaryComponent.class), (entity, ignored1, buildVariant, parent, binary) -> {
-			if (parent.get().hasComponent(ModelTags.typeOf(NativeLibraryTag.class))) {
-				val lifecycleTask = project.getExtensions().getByType(ModelRegistry.class).register(newEntity("staticLibrary", Task.class, it -> it.ownedBy(entity)));
-				lifecycleTask.configure(Task.class, configureBuildGroup());
-				lifecycleTask.configure(Task.class, configureDescription("Assembles a static library binary containing the objects files of %s.", binary.get().get(IdentifierComponent.class).get()));
-				lifecycleTask.configure(Task.class, configureDependsOn((Callable<?>) () -> ModelNodeUtils.get(ModelStates.finalize(binary.get()), StaticLibraryBinary.class)));
+		project.getExtensions().getByType(ModelConfigurer.class).configure(new ModelActionWithInputs.ModelAction4<ModelComponentTag<NativeVariantTag>, BuildVariantComponent, ParentComponent, NativeStaticLibraryBinaryComponent>() {
+			protected void execute(ModelNode entity, ModelComponentTag<NativeVariantTag> ignored1, BuildVariantComponent buildVariant, ParentComponent parent, NativeStaticLibraryBinaryComponent binary) {
+				if (parent.get().hasComponent(ModelTags.typeOf(NativeLibraryTag.class))) {
+					val lifecycleTask = project.getExtensions().getByType(ModelRegistry.class).register(newEntity("staticLibrary", Task.class, it -> it.ownedBy(entity)));
+					lifecycleTask.configure(Task.class, configureBuildGroup());
+					lifecycleTask.configure(Task.class, configureDescription("Assembles a static library binary containing the objects files of %s.", binary.get().get(IdentifierComponent.class).get()));
+					lifecycleTask.configure(Task.class, configureDependsOn((Callable<?>) () -> ModelNodeUtils.get(ModelStates.finalize(binary.get()), StaticLibraryBinary.class)));
+				}
 			}
-		}));
+		});
 
 		project.getExtensions().getByType(ModelConfigurer.class).configure(new ModelActionWithInputs.ModelAction2<DevelopmentVariantPropertyComponent, ModelComponentTag<NativeApplicationTag>>() {
 			// ComponentFromEntity<GradlePropertyComponent> read-write on DevelopmentVariantPropertyComponent


### PR DESCRIPTION
To shift toward a more declarable action/job/system execution, we are moving toward isolation and descriptor based. It will allow us to move toward more parallelism as the constraint will follow the action/job/system model. Although the `ModelActionX` instances are more verbose, they fit nicely with our future work. It also allows us to abstract away how the jobs declare their constraints.

A quick note on the action/job/system model. Given the internal is closely related to an ECS design, we need to express the System better. At the moment, this aspect is non-existent. The system allows a certain ordering in the rule executions. The Job is what can be scheduled in parallel. It contains the constrain on required components and is executed for each matching entity. Finally, the action is what the developer writes. We are considering making things easier by declaring mutability and some unpacking strategy so we don't always have to deal directly with components/component references.